### PR TITLE
Add Codex plugin manifest 

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "evo",
+  "version": "0.1.0",
+  "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
+  "author": {
+    "name": "evo-hq",
+    "url": "https://github.com/evo-hq"
+  },
+  "homepage": "https://github.com/evo-hq/evo",
+  "repository": "https://github.com/evo-hq/evo",
+  "license": "Apache-2.0",
+  "keywords": [
+    "optimization",
+    "experiments",
+    "benchmarks",
+    "agents"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "evo",
+    "shortDescription": "Experiment-driven code optimizer",
+    "longDescription": "Runs benchmark-guided optimization loops with tree search and parallel subagents.",
+    "developerName": "evo-hq",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/evo-hq/evo",
+    "privacyPolicyURL": "https://github.com/evo-hq/evo/blob/main/README.md",
+    "termsOfServiceURL": "https://github.com/evo-hq/evo/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Use evo to discover a benchmark for this repository.",
+      "Run evo optimize with subagents=5 budget=5 stall=5.",
+      "Show the best evo experiment diff and score."
+    ],
+    "brandColor": "#111827"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Invoke them as:
 - Claude Code: `/evo:discover`, `/evo:optimize`
 - Codex: `$evo:discover`, `$evo:optimize`
 
+The same `evo:discover` and `evo:optimize` skills are shared between Claude Code and Codex; only invocation syntax differs.
+
 `evo:optimize` accepts optional parameters:
 
 | Parameter | Default | Description |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # evo
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that optimizes code through experiments. You give it a codebase. It discovers metrics to optimize, sets up the evaluation, and starts running experiments in a loop -- trying things, keeping what improves the score, throwing away what doesn't.
+A plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://developers.openai.com/codex/plugins) that optimizes code through experiments. You give it a codebase. It discovers metrics to optimize, sets up the evaluation, and starts running experiments in a loop -- trying things, keeping what improves the score, throwing away what doesn't.
 
 Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) -- where an LLM runs training experiments autonomously to beat its own best score. Autoresearch is a pure hill climb: try something, keep or revert, repeat on a single branch. Evo adds structure on top of that idea:
 
@@ -13,9 +13,11 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) 
 - **Shared state.** Failure traces, annotations, and discarded hypotheses are accessible to every agent before it decides what to try next.
 - **Gating.** Regression tests or safety checks can be wired up as a gate. Experiments that don't pass get discarded.
 - **Observability.** A dashboard to monitor your experiments.
-- **Benchmark discovery.** `/discover` explores the repo, figures out what to measure, and instruments the evaluation.
+- **Benchmark discovery.** `evo:discover` explores the repo, figures out what to measure, and instruments the evaluation.
 
 ## Install
+
+### Claude Code
 
 Inside Claude Code:
 
@@ -26,16 +28,58 @@ Inside Claude Code:
 
 Then reload Claude Code. The `/evo:discover` and `/evo:optimize` slash commands become available in any repo.
 
-Requirements: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Python 3.12+, git, [uv](https://docs.astral.sh/uv/).
+### Codex (local marketplace)
+
+Codex plugins are installed from marketplaces. For a personal install:
+
+```bash
+mkdir -p ~/.codex/plugins
+cp -R /absolute/path/to/evo ~/.codex/plugins/evo
+
+mkdir -p ~/.agents/plugins
+cat > ~/.agents/plugins/marketplace.json <<'JSON'
+{
+  "name": "evo-local",
+  "interface": {
+    "displayName": "Evo Local"
+  },
+  "plugins": [
+    {
+      "name": "evo",
+      "source": {
+        "source": "local",
+        "path": "./.codex/plugins/evo"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+JSON
+```
+
+If `~/.agents/plugins/marketplace.json` already exists, merge the `evo` plugin entry into your existing `plugins` array instead of replacing the file.
+
+Restart Codex, open the plugin directory, pick the `Evo Local` marketplace, and install `evo`.
+
+Requirements: Claude Code or Codex, Python 3.12+, git, [uv](https://docs.astral.sh/uv/).
 
 ## Usage
 
-Two slash commands:
+Two skill entry points:
 
-- **`/evo:discover`** -- explores the repo, instruments the benchmark, runs baseline
-- **`/evo:optimize`** -- runs the optimization loop with parallel subagents until interrupted
+- **`evo:discover`** -- explores the repo, instruments the benchmark, runs baseline
+- **`evo:optimize`** -- runs the optimization loop with parallel subagents until interrupted
 
-`/evo:optimize` accepts optional parameters:
+Invoke them as:
+
+- Claude Code: `/evo:discover`, `/evo:optimize`
+- Codex: `$evo:discover`, `$evo:optimize`
+
+`evo:optimize` accepts optional parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -43,15 +87,15 @@ Two slash commands:
 | `budget` | 5 | Max iterations each subagent can run within its branch |
 | `stall` | 5 | Consecutive rounds with no improvement before auto-stopping |
 
-Example: `/evo:optimize subagents=3 budget=10 stall=3`
+Example: `evo:optimize subagents=3 budget=10 stall=3`
 
 Typical flow:
 
 ```
-you: /evo:discover
+you: evo:discover
 evo: explores repo, instruments benchmark, runs baseline
 
-you: /evo:optimize
+you: evo:optimize
 evo: spawns 5 subagents in parallel, each exploring a different direction
      each subagent can run up to 5 iterations within its branch
      orchestrator collects results, prunes dead branches, adjusts strategy
@@ -80,7 +124,7 @@ Orchestrator (main agent)
 
 ## Dashboard
 
-The dashboard starts automatically when you run `/evo:discover` (or `evo init`). When it comes up, Claude surfaces the URL in the chat:
+The dashboard starts automatically when you run `evo:discover` (or `evo init`). When it comes up, the agent surfaces the URL in the chat:
 
 ```
 Dashboard live: http://127.0.0.1:8080 (pid 12345)

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -31,7 +31,7 @@ Prefer wrapping an existing benchmark rather than mutating it in place.
 
 ### 3a. Ask the user which instrumentation mode to use
 
-Before writing any instrumentation code, **ask the user once** (use `AskUserQuestion`):
+Before writing any instrumentation code, **ask the user once** using your host's user-input flow:
 
 > "I can wire up the benchmark in one of two ways:
 >
@@ -91,10 +91,10 @@ The SDK auto-reads `$EVO_TRACES_DIR` and `$EVO_EXPERIMENT_ID`. Traces are flushe
 
 ### 3c. Inline mode (no SDK dependency)
 
-Copy the helper from the bundled reference file directly into the user's benchmark script:
+Copy the helper from this skill's bundled reference file directly into the user's benchmark script (resolve paths relative to this `SKILL.md`):
 
-- Python: `${CLAUDE_SKILL_DIR}/references/inline_instrumentation.py`
-- Node: `${CLAUDE_SKILL_DIR}/references/inline_instrumentation.js`
+- Python: `references/inline_instrumentation.py`
+- Node: `references/inline_instrumentation.js`
 
 Both expose two functions:
 
@@ -116,7 +116,7 @@ Before running the full baseline, validate the toolchain with the cheapest possi
 Run the benchmark command directly (outside `evo`) with `EVO_TRACES_DIR` set to a temp directory. **Pipe stdout through the validation script** to enforce the JSON contract:
 
 ```bash
-EVO_TRACES_DIR=/tmp/evo_validate <benchmark_command> 2>/tmp/evo_validate_stderr.log | python ${CLAUDE_SKILL_DIR}/scripts/validate_stdout.py
+EVO_TRACES_DIR=/tmp/evo_validate <benchmark_command> 2>/tmp/evo_validate_stderr.log | python <skill_dir>/scripts/validate_stdout.py
 ```
 
 The validator checks:

--- a/skills/discover/SKILL.md
+++ b/skills/discover/SKILL.md
@@ -113,10 +113,12 @@ Create a gate script if appropriate.
 
 Before running the full baseline, validate the toolchain with the cheapest possible end-to-end execution (single task, smallest split, dry-run flag, mock mode -- whatever is fastest):
 
-Run the benchmark command directly (outside `evo`) with `EVO_TRACES_DIR` set to a temp directory. **Pipe stdout through the validation script** to enforce the JSON contract:
+Run the benchmark command directly (outside `evo`) with `EVO_TRACES_DIR` set to a temp directory. **Pipe stdout through the validation script** to enforce the JSON contract.
+Set `SKILL_DIR` to the absolute path of this skill directory (the folder containing this `SKILL.md`):
 
 ```bash
-EVO_TRACES_DIR=/tmp/evo_validate <benchmark_command> 2>/tmp/evo_validate_stderr.log | python <skill_dir>/scripts/validate_stdout.py
+SKILL_DIR=/absolute/path/to/evo/skills/discover
+EVO_TRACES_DIR=/tmp/evo_validate <benchmark_command> 2>/tmp/evo_validate_stderr.log | python "$SKILL_DIR/scripts/validate_stdout.py"
 ```
 
 The validator checks:

--- a/skills/optimize/SKILL.md
+++ b/skills/optimize/SKILL.md
@@ -83,9 +83,9 @@ Formulate N directions (one per subagent). Each direction should include:
 
 ### 3. Spawn parallel subagents
 
-Spawn all subagents in a **single message** using the Agent tool. **All subagents must run in the background** (`run_in_background: true`) so they execute in parallel.
+Spawn all subagents in a **single batch** using your host's multi-agent tool (`spawn_agent` in Codex, Agent tool in Claude Code). **All subagents must run in the background** so they execute in parallel.
 
-Use `model: "sonnet"` for straightforward hypotheses, `model: "opus"` for harder ones requiring deeper reasoning.
+Prefer a faster model for straightforward hypotheses and a stronger model for harder ones requiring deeper reasoning.
 
 Each subagent prompt must include:
 - An instruction to read `skills/subagent/SKILL.md` and follow its protocol


### PR DESCRIPTION
## What does the pr do? 
> This PR adds Codex plugin support to evo without changing existing Claude plugin behavior. It includes a new Codex plugin manifest, README updates for Codex setup and usage, and host-agnostic skill docs that no longer rely on Claude-specific paths or tool names.

## Changes
- New `.codex-plugin/plugin.json` manifest so evo shows up in the Codex plugin directory
- README install and usage docs updated for both Claude Code and Codex
- Skill instructions made host-agnostic — no more hardcoded `$CLAUDE_SKILL_DIR` paths or Claude-specific tool names
- Validator path is now resolved relative to the skill directory via `$SKILL_DIR`