### PR TITLE
0.2.1: fix evo get hiding inherited gates + version-drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Assert CLI and plugin manifest versions match
+        run: python3 scripts/check_versions.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,14 @@
 name: publish
 
 # Triggered by pushing a tag matching v*.
-# - v0.1.0       -> publishes both SDKs at 0.1.0
+# - v0.1.0       -> publishes both SDKs AND the CLI at 0.1.0
 # - py-v0.1.0    -> publishes only the Python SDK
 # - node-v0.1.0  -> publishes only the Node SDK
+# - cli-v0.1.0   -> publishes only the CLI (evo-hq-cli)
 #
-# The tag version must match the version in the SDK's package manifest.
+# The tag version must match the version in the corresponding package
+# manifest (sdk/python/pyproject.toml, sdk/node/package.json, or
+# plugins/evo/pyproject.toml).
 
 on:
   push:
@@ -13,21 +16,22 @@ on:
       - "v*"
       - "py-v*"
       - "node-v*"
+      - "cli-v*"
   workflow_dispatch:
     inputs:
       target:
-        description: Which SDK to publish
+        description: What to publish
         required: true
         type: choice
-        options: [both, python, node]
-        default: both
+        options: [all, python, node, cli]
+        default: all
 
 jobs:
   publish-python:
     if: |
       startsWith(github.ref, 'refs/tags/v') ||
       startsWith(github.ref, 'refs/tags/py-v') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'python'))
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'python'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,7 +73,7 @@ jobs:
     if: |
       startsWith(github.ref, 'refs/tags/v') ||
       startsWith(github.ref, 'refs/tags/node-v') ||
-      (github.event_name == 'workflow_dispatch' && (inputs.target == 'both' || inputs.target == 'node'))
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'node'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,3 +105,47 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish
+
+  publish-cli:
+    if: |
+      startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(github.ref, 'refs/tags/cli-v') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'cli'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Assert CLI and plugin manifest versions match
+        run: python3 scripts/check_versions.py
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+      - name: Build sdist + wheel
+        working-directory: plugins/evo
+        run: python -m build
+      - name: Verify tag matches package version
+        working-directory: plugins/evo
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          VERSION=$(python -c "import tomllib,sys; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          case "$TAG" in
+            v*)     EXPECTED="v${VERSION}" ;;
+            cli-v*) EXPECTED="cli-v${VERSION}" ;;
+            *)      EXPECTED="" ;;
+          esac
+          if [ -n "$EXPECTED" ] && [ "$TAG" != "$EXPECTED" ]; then
+            echo "Tag $TAG does not match pyproject version $VERSION (expected $EXPECTED)"
+            exit 1
+          fi
+      - name: Check distribution metadata
+        working-directory: plugins/evo
+        run: twine check dist/*
+      - name: Publish to PyPI
+        working-directory: plugins/evo
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --non-interactive dist/*

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/bin/evo-version-check
+++ b/plugins/evo/bin/evo-version-check
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# bin/evo-version-check -- assert the installed evo-hq-cli version matches
+# the plugin manifest this wrapper lives in. Hosts (Claude Code, Codex)
+# refetch the plugin based on the manifest version, but they do not
+# reinstall the globally-installed CLI. If the two drift, the skills
+# will be instructing the CLI to do things it cannot do.
+#
+# Exit 0 on match, 1 on mismatch (with diagnostic on stderr), 2 on
+# environment error (manifest missing, CLI missing, parse failure).
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MANIFEST=""
+for candidate in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.codex-plugin/plugin.json"; do
+    if [ -f "$candidate" ]; then
+        MANIFEST="$candidate"
+        break
+    fi
+done
+
+if [ -z "$MANIFEST" ]; then
+    echo "evo-version-check: no plugin manifest found under $PLUGIN_ROOT" >&2
+    exit 2
+fi
+
+# Parse "version": "X.Y.Z" without requiring jq (may be absent on the host).
+PLUGIN_VERSION=$(
+    grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$MANIFEST" \
+    | head -1 \
+    | sed 's/.*"\([^"]*\)"[[:space:]]*$/\1/'
+)
+if [ -z "$PLUGIN_VERSION" ]; then
+    echo "evo-version-check: could not parse version from $MANIFEST" >&2
+    exit 2
+fi
+
+if ! command -v evo >/dev/null 2>&1; then
+    echo "evo-version-check: evo CLI not on PATH" >&2
+    exit 2
+fi
+
+CLI_OUTPUT=$(evo --version 2>/dev/null || true)
+CLI_VERSION=$(
+    printf '%s\n' "$CLI_OUTPUT" \
+    | grep -oE 'evo-hq-cli[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' \
+    | awk '{print $2}' \
+    | head -1
+)
+if [ -z "$CLI_VERSION" ]; then
+    echo "evo-version-check: could not parse evo-hq-cli version from 'evo --version' output: ${CLI_OUTPUT}" >&2
+    exit 2
+fi
+
+if [ "$CLI_VERSION" != "$PLUGIN_VERSION" ]; then
+    cat >&2 <<EOF
+evo-version-check: plugin manifest and installed CLI disagree.
+
+  plugin manifest : $PLUGIN_VERSION   ($MANIFEST)
+  installed CLI   : $CLI_VERSION   (evo --version)
+
+The host has refetched a newer/older plugin than the CLI on PATH. Update the CLI to match:
+
+  uv tool install --force evo-hq-cli==$PLUGIN_VERSION
+    or
+  pipx install --force evo-hq-cli==$PLUGIN_VERSION
+
+Then re-invoke the skill.
+EOF
+    exit 1
+fi
+
+echo "evo-version-check: OK (plugin=$PLUGIN_VERSION, cli=$CLI_VERSION)"

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.12,<3.14"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -16,21 +16,23 @@ This skill runs on any host that implements the Agent Skills spec. When the body
 - **File paths like `references/...`** -- relative to this `SKILL.md`; resolve from the skill directory.
 - **Slash commands shown in user-facing copy** (e.g. `/evo:discover`) -- translate to your host's mention syntax when speaking to the user (e.g. `$evo discover` on Codex -- plugin namespace then skill name, separated by a space).
 
-## 0. Verify the evo CLI is available
+## 0. Verify the evo CLI is available and in sync with the plugin
 
 Before anything else, run:
 
 ```bash
-evo --version
+evo-version-check
 ```
 
-Three outcomes to handle:
+This wraps `evo --version` and additionally asserts the installed CLI matches the plugin manifest version (hosts refetch the plugin on version bumps, but do not reinstall the globally-installed CLI -- drift between the two breaks skills silently).
 
-1. **Output contains `evo-hq-cli`** (e.g. `evo-hq-cli 0.2.0`) -- the CLI is our binary. Continue to step 1.
-2. **Command not found** -- the host can't find `evo` on PATH. Stop and tell the user:
+Four outcomes to handle:
+
+1. **Exit 0, `evo-version-check: OK (plugin=X, cli=X)`** -- continue to step 1.
+2. **Exit 1, "plugin manifest and installed CLI disagree"** -- stop and show the user the script's stderr verbatim; it tells them the `uv tool install --force evo-hq-cli==<version>` command to run. Then re-invoke this skill.
+3. **Exit 2, "evo CLI not on PATH"** -- stop and tell the user:
    > `evo-hq-cli` isn't on your PATH. Install it once: `uv tool install evo-hq-cli` (or `pipx install evo-hq-cli`). Then re-invoke this skill.
-3. **Output is something else** (commonly `evo 1.x` or similar -- that's the unrelated SLAM package on PyPI) -- stop and tell the user:
-   > Found `evo` on PATH but it's a different package (not evo-hq-cli). Either `uv tool uninstall evo` (or the equivalent for your installer) and install `evo-hq-cli` in its place, or ensure `evo-hq-cli`'s install location is earlier on PATH. Then re-invoke.
+4. **`evo-version-check: command not found`** -- the host's plugin install is incomplete (missing the `bin/` wrapper). Fall back to running `evo --version` directly and check for `evo-hq-cli` in the output; if it's a different package (commonly `evo 1.x` -- the unrelated SLAM tool), tell the user to uninstall it and install `evo-hq-cli` in its place.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -638,7 +638,13 @@ def cmd_get(args: argparse.Namespace) -> int:
         path = experiments_dir_for(root, args.exp_id) / args.filename
         print(path.read_text(encoding="utf-8"))
         return 0
-    print(json.dumps(_read_node(root, args.exp_id), indent=2))
+    graph = load_graph(root)
+    if args.exp_id not in graph["nodes"]:
+        raise RuntimeError(f"unknown experiment: {args.exp_id}")
+    node = dict(graph["nodes"][args.exp_id])
+    node["own_gates"] = node.get("gates", [])
+    node["gates"] = collect_gates_from_path(graph, args.exp_id)
+    print(json.dumps(node, indent=2))
     return 0
 
 

--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Assert evo-hq-cli, claude-plugin, and codex-plugin versions all match.
+
+Runs in CI (and locally) to prevent a release where the CLI was bumped
+but the plugin manifests were not (or vice versa). Claude Code and
+Codex use the plugin manifest version to decide whether to refetch the
+plugin -- if only pyproject.toml bumps, installed hosts never see the
+new CLI.
+
+Exit 0 on match, non-zero with a diagnostic on mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SOURCES = [
+    ("plugins/evo/pyproject.toml", "pyproject.toml (evo-hq-cli)"),
+    ("plugins/evo/src/evo/__init__.py", "__version__ (read by `evo --version`)"),
+    ("plugins/evo/.claude-plugin/plugin.json", "Claude Code plugin manifest"),
+    ("plugins/evo/.codex-plugin/plugin.json", "Codex plugin manifest"),
+]
+
+
+def read_pyproject_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    # Top-level [project] version. Use a regex to avoid a tomllib dep so
+    # the script runs on any Python 3.8+.
+    match = re.search(
+        r'^\[project\].*?^version\s*=\s*"([^"]+)"',
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        raise RuntimeError(f"no [project] version in {path}")
+    return match.group(1)
+
+
+def read_json_version(path: Path) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "version" not in data:
+        raise RuntimeError(f"no version field in {path}")
+    return data["version"]
+
+
+def read_python_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', text, flags=re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"no __version__ assignment in {path}")
+    return match.group(1)
+
+
+def main() -> int:
+    versions: list[tuple[str, str, str]] = []  # (relpath, label, version)
+    for relpath, label in SOURCES:
+        path = REPO_ROOT / relpath
+        if not path.exists():
+            print(f"ERROR: missing {relpath}", file=sys.stderr)
+            return 2
+        if path.suffix == ".toml":
+            version = read_pyproject_version(path)
+        elif path.suffix == ".json":
+            version = read_json_version(path)
+        elif path.suffix == ".py":
+            version = read_python_version(path)
+        else:
+            raise RuntimeError(f"unknown file type for {path}")
+        versions.append((relpath, label, version))
+
+    distinct = {v for _, _, v in versions}
+    if len(distinct) == 1:
+        (only,) = distinct
+        print(f"OK: all {len(versions)} sources report version {only}")
+        return 0
+
+    print("ERROR: version mismatch between plugin and CLI:", file=sys.stderr)
+    width = max(len(rp) for rp, _, _ in versions)
+    for relpath, label, version in versions:
+        print(f"  {relpath:<{width}}  {version}  ({label})", file=sys.stderr)
+    print(
+        "\nBump all three together. Claude Code / Codex key off the plugin "
+        "manifest version to decide whether to refetch the plugin -- bumping "
+        "pyproject alone leaves installed hosts stuck on the old CLI.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -21,9 +21,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 SOURCES = [
     ("plugins/evo/pyproject.toml", "pyproject.toml (evo-hq-cli)"),
-    ("plugins/evo/src/evo/__init__.py", "__version__ (read by `evo --version`)"),
+    ("plugins/evo/src/evo/__init__.py", "evo/__init__.__version__ (read by `evo --version`)"),
     ("plugins/evo/.claude-plugin/plugin.json", "Claude Code plugin manifest"),
     ("plugins/evo/.codex-plugin/plugin.json", "Codex plugin manifest"),
+    ("sdk/python/pyproject.toml", "pyproject.toml (evo-hq-agent)"),
+    ("sdk/python/src/evo_agent/__init__.py", "evo_agent/__init__.__version__"),
+    ("sdk/node/package.json", "package.json (@evo-hq/evo-agent)"),
 ]
 
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -84,7 +84,7 @@ def main() -> int:
     for relpath, label, version in versions:
         print(f"  {relpath:<{width}}  {version}  ({label})", file=sys.stderr)
     print(
-        "\nBump all three together. Claude Code / Codex key off the plugin "
+        f"\nBump all {len(versions)} together. Claude Code / Codex key off the plugin "
         "manifest version to decide whether to refetch the plugin -- bumping "
         "pyproject alone leaves installed hosts stuck on the old CLI.",
         file=sys.stderr,

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/sdk/python/test/test_run.py
+++ b/sdk/python/test/test_run.py
@@ -1,0 +1,151 @@
+"""Python SDK tests. Mirrors sdk/node/test/run.test.js.
+
+Run: `python3 sdk/python/test/test_run.py`
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "sdk" / "python" / "src"))
+
+from evo_agent import Gate, Run  # noqa: E402
+
+
+@contextmanager
+def tmp_traces_dir():
+    with tempfile.TemporaryDirectory(prefix="evo-agent-test-") as d:
+        prev_traces = os.environ.get("EVO_TRACES_DIR")
+        prev_exp = os.environ.get("EVO_EXPERIMENT_ID")
+        os.environ["EVO_TRACES_DIR"] = d
+        os.environ["EVO_EXPERIMENT_ID"] = "exp-123"
+        try:
+            yield Path(d)
+        finally:
+            if prev_traces is None:
+                os.environ.pop("EVO_TRACES_DIR", None)
+            else:
+                os.environ["EVO_TRACES_DIR"] = prev_traces
+            if prev_exp is None:
+                os.environ.pop("EVO_EXPERIMENT_ID", None)
+            else:
+                os.environ["EVO_EXPERIMENT_ID"] = prev_exp
+
+
+@contextmanager
+def capture_stdout():
+    buf = io.StringIO()
+    original = sys.stdout
+    sys.stdout = buf
+    try:
+        yield buf
+    finally:
+        sys.stdout = original
+
+
+def test_run_writes_trace_files_and_emits_score_json() -> None:
+    with tmp_traces_dir() as traces_dir, capture_stdout() as buf:
+        # LocalBackend captures sys.stdout at Run() construction, so the
+        # stdout redirect must wrap the whole lifecycle.
+        run = Run()
+        run.log("0", "starting")
+        run.log("0", {"role": "user", "content": "hi"})
+        run.report("0", score=1.0, summary="ok")
+        run.report("1", score=0.0, failure_reason="bad")
+        result = run.finish()
+        emitted = json.loads(buf.getvalue())
+
+        assert result["score"] == 0.5, result
+        assert result["tasks"] == {"0": 1.0, "1": 0.0}, result["tasks"]
+        assert emitted["score"] == 0.5, emitted
+
+        files = sorted(p.name for p in traces_dir.iterdir())
+        assert files == ["task_0.json", "task_1.json"], files
+
+        t0 = json.loads((traces_dir / "task_0.json").read_text())
+        assert t0["experiment_id"] == "exp-123"
+        assert t0["status"] == "passed"
+        assert t0["score"] == 1.0
+        assert t0["log"] == ["starting", {"role": "user", "content": "hi"}]
+
+        t1 = json.loads((traces_dir / "task_1.json").read_text())
+        assert t1["status"] == "failed"
+        assert t1["failure_reason"] == "bad"
+
+
+def test_run_mean_score_when_finish_not_given_explicit_score() -> None:
+    with tmp_traces_dir(), capture_stdout():
+        run = Run()
+        run.report("a", score=0.8)
+        run.report("b", score=0.2)
+        result = run.finish()
+        assert result["score"] == 0.5, result
+
+
+def test_run_respects_explicit_finish_score() -> None:
+    with tmp_traces_dir(), capture_stdout():
+        run = Run()
+        run.report("a", score=1.0)
+        result = run.finish(score=0.42)
+        assert result["score"] == 0.42, result
+
+
+def test_run_finish_idempotent() -> None:
+    with tmp_traces_dir(), capture_stdout():
+        run = Run()
+        run.report("a", score=1.0)
+        run.finish()
+        second = run.finish()
+        # Second call is a no-op and returns an empty dict.
+        assert second == {}, second
+
+
+def test_gate_check_accepts_score_or_explicit_passed() -> None:
+    g = Gate()
+    g.check("a", score=0.8)
+    g.check("b", score=0.3)
+    g.check("c", passed=True, detail="manual")
+    assert len(g._checks) == 3
+    assert g._checks[0]["passed"] is True
+    assert g._checks[1]["passed"] is False
+    assert g._checks[2]["passed"] is True
+    assert g._checks[2]["detail"] == "manual"
+
+
+def test_gate_check_requires_score_or_passed() -> None:
+    g = Gate()
+    try:
+        g.check("a")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError when neither score nor passed given")
+
+
+TESTS = [fn for name, fn in globals().items() if name.startswith("test_") and callable(fn)]
+
+
+def main() -> int:
+    failed = 0
+    for fn in TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL  {fn.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(TESTS) - failed}/{len(TESTS)} passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -314,6 +314,18 @@ sys.exit(1 if "BREAK_CANCEL" in content else 0)
     names = {g["name"] for g in gate_list}
     assert names == {"refund_flow", "cancel_flow"}
 
+    # `evo get` returns effective gates (own + inherited) and exposes
+    # own-only gates under `own_gates`. exp_0000 inherits refund_flow
+    # from root and owns cancel_flow.
+    got = json.loads(evo(["get", "exp_0000"], cwd=root).stdout)
+    assert {g["name"] for g in got["gates"]} == {"refund_flow", "cancel_flow"}
+    assert {g["name"] for g in got["own_gates"]} == {"cancel_flow"}
+
+    # For root, effective and own are identical.
+    got_root = json.loads(evo(["get", "root"], cwd=root).stdout)
+    assert {g["name"] for g in got_root["gates"]} == {"refund_flow"}
+    assert {g["name"] for g in got_root["own_gates"]} == {"refund_flow"}
+
     # Experiment that improves score but breaks the refund gate
     evo(["new", "--parent", "exp_0000", "-m", "break refund"], cwd=root)
     write(root / ".evo" / "run_0000" / "worktrees" / "exp_0001" / "agent.py", 'STATE = "GOOD BREAK_REFUND"\n')

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,0 +1,115 @@
+"""Unit tests for pure functions in evo.core.
+
+Fast (millisecond) tests for logic that does not touch git, subprocess, or
+the filesystem. Complements the slower tests/e2e.py flow tests.
+
+Run: `python3 tests/unit/test_core.py`
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.core import collect_gates_from_path, path_to_node  # noqa: E402
+
+
+def _graph(*nodes: dict) -> dict:
+    return {"nodes": {n["id"]: n for n in nodes}}
+
+
+def _node(id_: str, parent: str | None, gates: list[dict] | None = None, **extra) -> dict:
+    return {"id": id_, "parent": parent, "gates": gates or [], **extra}
+
+
+def _gate(name: str, command: str = "cmd") -> dict:
+    return {"name": name, "command": command, "added_at": "2026-04-15T00:00:00Z"}
+
+
+def test_path_to_node_returns_root_to_leaf_chain() -> None:
+    graph = _graph(
+        _node("root", None),
+        _node("exp_0000", "root"),
+        _node("exp_0001", "exp_0000"),
+    )
+    chain = [n["id"] for n in path_to_node(graph, "exp_0001")]
+    assert chain == ["root", "exp_0000", "exp_0001"], chain
+
+
+def test_collect_gates_empty_when_no_gates_anywhere() -> None:
+    graph = _graph(_node("root", None), _node("exp_0000", "root"))
+    assert collect_gates_from_path(graph, "exp_0000") == []
+
+
+def test_collect_gates_inherits_root_gate() -> None:
+    graph = _graph(
+        _node("root", None, gates=[_gate("core_tests", "pytest -x")]),
+        _node("exp_0000", "root"),
+    )
+    gates = collect_gates_from_path(graph, "exp_0000")
+    assert [g["name"] for g in gates] == ["core_tests"]
+    assert gates[0]["command"] == "pytest -x"
+
+
+def test_collect_gates_unions_root_and_own_gates_in_root_to_leaf_order() -> None:
+    graph = _graph(
+        _node("root", None, gates=[_gate("root_gate")]),
+        _node("exp_0000", "root", gates=[_gate("own_gate")]),
+    )
+    gates = collect_gates_from_path(graph, "exp_0000")
+    assert [g["name"] for g in gates] == ["root_gate", "own_gate"]
+
+
+def test_collect_gates_dedupes_by_name_keeping_ancestor_wins() -> None:
+    # Same gate name declared on an ancestor and a descendant: the ancestor
+    # one is kept (ancestors are walked first), the descendant redeclaration
+    # is ignored. Verifies we do not surface the gate twice.
+    graph = _graph(
+        _node("root", None, gates=[_gate("flaky", "pytest ancestor")]),
+        _node("exp_0000", "root", gates=[_gate("flaky", "pytest descendant")]),
+    )
+    gates = collect_gates_from_path(graph, "exp_0000")
+    assert len(gates) == 1
+    assert gates[0]["command"] == "pytest ancestor"
+
+
+def test_collect_gates_scoped_to_ancestry_not_siblings() -> None:
+    graph = _graph(
+        _node("root", None, gates=[_gate("root_gate")]),
+        _node("exp_0000", "root", gates=[_gate("sibling_gate")]),
+        _node("exp_0001", "root"),
+    )
+    gates = collect_gates_from_path(graph, "exp_0001")
+    assert [g["name"] for g in gates] == ["root_gate"]
+
+
+def test_collect_gates_on_root_returns_own_only() -> None:
+    graph = _graph(_node("root", None, gates=[_gate("core_tests")]))
+    gates = collect_gates_from_path(graph, "root")
+    assert [g["name"] for g in gates] == ["core_tests"]
+
+
+TESTS = [fn for name, fn in globals().items() if name.startswith("test_") and callable(fn)]
+
+
+def main() -> int:
+    failed = 0
+    for fn in TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL  {fn.__name__}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(TESTS) - failed}/{len(TESTS)} passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #2, where `evo get <id>` returned the node's raw `gates` array from `graph.json` (own gates only), while `evo run` and `evo gate list` walk ancestry. Inspection output and actual enforcement disagreed: an agent could read `evo get`, see `"gates": []`, and conclude nothing was enforced while gates inherited from root were firing.

`cmd_get` now resolves gates via `collect_gates_from_path`, same as `cmd_run`. `gates` is the effective set; `own_gates` holds the raw per-node array.

## Tests

`tests/` previously contained only `e2e.py`, a hand-rolled script spawning subprocesses per test. Added:

- `tests/unit/test_core.py` -- unit tests for `collect_gates_from_path` (inheritance, dedup on name collision, sibling isolation).
- `sdk/python/test/test_run.py` -- Python SDK tests mirroring `sdk/node/test/run.test.js`. The Python SDK previously had no tests.

## Lockstep versioning

All three published packages (`evo-hq-cli`, `evo-hq-agent`, `@evo-hq/evo-agent`) now share one version. Tag `v<N>` publishes all three; independent versions create foot-guns. SDK bumps without code changes are acceptable cost for the simpler mental model.

Seven version strings asserted equal on every PR by `scripts/check_versions.py`:

- `plugins/evo/pyproject.toml` (evo-hq-cli)
- `plugins/evo/src/evo/__init__.py` (`__version__`, what `evo --version` prints)
- `plugins/evo/.claude-plugin/plugin.json`
- `plugins/evo/.codex-plugin/plugin.json`
- `sdk/python/pyproject.toml` (evo-hq-agent)
- `sdk/python/src/evo_agent/__init__.py`
- `sdk/node/package.json` (@evo-hq/evo-agent)

All bump to 0.2.1.

## Runtime check for host/CLI drift

`bin/evo-version-check` compares installed CLI version against the plugin manifest. Discover skill's step 0 runs it instead of a bare `evo --version`. Catches hosts that have refetched a new plugin while the globally-installed CLI is old.

## CI

New `.github/workflows/ci.yml` runs `scripts/check_versions.py` on every PR and push.

## CLI publish automation

`publish.yml` previously only handled the two SDKs; `evo-hq-cli` was published manually for 0.2.0. New `publish-cli` job mirrors `publish-python` against `plugins/evo/`: runs `check_versions.py`, builds, asserts tag matches pyproject version, `twine check`, `twine upload`. Reuses `PYPI_API_TOKEN`.

Tag conventions:
- `v*` -> all three (both SDKs + CLI)
- `cli-v*` -> CLI only (new)
- `py-v*` / `node-v*` -> unchanged; emergency-republish paths under lockstep

Build tested locally with `uv build` + `twine check` on `plugins/evo/` -- both sdist and wheel pass metadata validation.

## Tested

- `python3 tests/e2e.py` -- 5 flows green. `test_gate_flow` now also asserts `evo get` output.
- `python3 tests/unit/test_core.py` -- 7/7.
- `python3 sdk/python/test/test_run.py` -- 6/6.
- `scripts/check_versions.py` -- all 7 sources match.
- `bin/evo-version-check` against a real mismatch -- exits 1 with the right `uv tool install --force` command.
- `uv build && twine check dist/*` on `plugins/evo/` -- both artifacts pass.