### PR TITLE
docs: restructure install, cover OpenClaw and Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # evo
 
-A plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://developers.openai.com/codex) that optimizes code through experiments. You give it a codebase. It discovers metrics to optimize, sets up the evaluation, and starts running experiments in a loop -- trying things, keeping what improves the score, throwing away what doesn't.
+A plugin for your agentic framework that optimizes code through experiments. Currently supported on [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://developers.openai.com/codex), [OpenClaw](https://github.com/openclaw/openclaw), and [Hermes](https://github.com/NousResearch/hermes-agent).
+
+You give it a codebase. It discovers metrics to optimize, sets up the evaluation, and starts running experiments in a loop -- trying things, keeping what improves the score, throwing away what doesn't.
 
 Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) -- where an LLM runs training experiments autonomously to beat its own best score. Autoresearch is a pure hill climb: try something, keep or revert, repeat on a single branch. Evo adds structure on top of that idea:
 
@@ -13,54 +15,68 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) 
 - **Shared state.** Failure traces, annotations, and discarded hypotheses are accessible to every agent before it decides what to try next.
 - **Gating.** Regression tests or safety checks can be wired up as a gate. Experiments that don't pass get discarded.
 - **Observability.** A dashboard to monitor your experiments.
-- **Benchmark discovery.** `evo:discover` explores the repo, figures out what to measure, and instruments the evaluation.
+- **Benchmark discovery.** The `discover` skill explores the repo, figures out what to measure, and instruments the evaluation.
 
 ## Install
 
-Common requirements: Python 3.12+, git, [uv](https://docs.astral.sh/uv/).
+Common: `git`, [uv](https://docs.astral.sh/uv/), Python 3.10+.
 
-### Claude Code
+### 1. Install the evo CLI (non-Claude Code hosts)
+
+Claude Code bundles its own copy. Every other host calls `evo` as an external binary:
+
+```bash
+uv tool install evo-hq-cli   # or: pipx install evo-hq-cli
+evo --version                # evo-hq-cli 0.2.2
+```
+
+### 2. Add the plugin
+
+**Claude Code**
 
 ```
 /plugin marketplace add evo-hq/evo
 /plugin install evo@evo-hq-evo
 ```
 
-Reload Claude Code. `/evo:discover` and `/evo:optimize` become available in any repo.
+Invoke: `/evo:discover`, `/evo:optimize`.
 
-### Codex
-
-Codex needs the `evo` CLI installed globally. Install once, outside Codex:
-
-```bash
-uv tool install evo-hq-cli
-# or: pipx install evo-hq-cli
-evo --version   # should print: evo-hq-cli x.x.x
-```
-
-Then add the plugin (requires Codex **0.121.0-alpha.2 or newer** for the `marketplace add` command -- `npm install -g @openai/codex@alpha` if you're still on 0.120.0 stable):
+**Codex** (requires 0.121.0-alpha.2 or newer -- `npm install -g @openai/codex@alpha` if you're on 0.120.0 stable)
 
 ```bash
 codex marketplace add evo-hq/evo
 ```
 
-Open Codex, run `/plugins`, find `evo`, install. Skills become available as `$evo discover` and `$evo optimize`.
+Then `/plugins` → `evo` → install. Invoke: `$evo discover`, `$evo optimize`.
 
+**OpenClaw**
 
+```bash
+openclaw plugins install evo --marketplace https://github.com/evo-hq/evo
+```
+
+Invoke: `/discover`, `/optimize`.
+
+**Hermes** (per-skill install, no bundle support)
+
+```bash
+hermes skills install evo-hq/evo/plugins/evo/skills/discover --force
+hermes skills install evo-hq/evo/plugins/evo/skills/optimize
+hermes skills install evo-hq/evo/plugins/evo/skills/subagent
+```
+
+`--force` on `discover` bypasses the SKILL.md scanner (it flags evo's own install examples). Invoke: `/discover`, `/optimize`.
 
 ## Usage
 
 Two skills:
 
-- **`evo:discover`** -- explores the repo, instruments the benchmark, runs baseline
-- **`evo:optimize`** -- runs the optimization loop with parallel subagents until interrupted
+- **`discover`** -- explores the repo, instruments the benchmark, runs baseline
+- **`optimize`** -- runs the optimization loop with parallel subagents until interrupted
 
-Invocation syntax differs by host:
+Invocation syntax depends on the host -- see the Install section above.
 
-- Claude Code: `/evo:discover`, `/evo:optimize`
-- Codex: `$evo discover`, `$evo optimize`
-
-`evo:optimize` accepts optional parameters:
+`optimize` accepts optional parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -68,7 +84,7 @@ Invocation syntax differs by host:
 | `budget` | 5 | Max iterations each subagent can run within its branch |
 | `stall` | 5 | Consecutive rounds with no improvement before auto-stopping |
 
-Example: `/evo:optimize subagents=3 budget=10 stall=3` (or `$evo optimize subagents=3 budget=10 stall=3` on Codex).
+Example (Claude Code): `/evo:optimize subagents=3 budget=10 stall=3`. Other hosts use their own invocation prefix.
 
 Typical flow:
 
@@ -114,7 +130,7 @@ Dashboard live: http://127.0.0.1:8080 (pid 12345)
 If `8080` is busy, evo auto-increments (`8081`, `8082`, ...) and prints the actual port. You can also start it manually:
 
 ```bash
-uv run --project /path/to/evo evo dashboard --port 8080
+uv run --project /path/to/evo/plugins/evo evo dashboard --port 8080
 ```
 
 The chosen port is persisted to `.evo/dashboard.port` so repeat runs re-use it.
@@ -125,10 +141,16 @@ For working on evo itself (not just using it):
 
 ```bash
 git clone https://github.com/evo-hq/evo
-uv run --project /path/to/evo evo status
+cd evo
+uv run --project plugins/evo evo --version   # evo-hq-cli 0.2.2
 ```
 
 `uv run` resolves dependencies on first use -- no `pip install` step.
+
+The SDKs live in separate packages:
+
+- `sdk/python/` -- `evo-hq-agent`, Python 3.10+, zero deps. Tests: `cd sdk/python && uv run --with pytest pytest test/`.
+- `sdk/node/` -- `@evo-hq/evo-agent`, Node 18+, zero deps. Tests: `cd sdk/node && npm test`.
 
 ## TODO
 


### PR DESCRIPTION
## Summary

Install section was four sibling subsections that repeated `uv tool install evo-hq-cli` three times, and the intro still listed only Claude Code and Codex. Restructured into two numbered steps: CLI install once (for non-Claude Code hosts), then per-host plugin install with invocation syntax inline.

Adds OpenClaw and Hermes. OpenClaw pulls the plugin directly from GitHub via `openclaw plugins install evo --marketplace https://github.com/evo-hq/evo` and registers it as a Codex-format bundle (no manifest changes needed). Hermes has no bundle install — three `hermes skills install evo-hq/evo/plugins/evo/skills/<name>` commands, with `--force` on `discover` because its SDK-install and gate-command examples trip the SKILL.md security scanner.

Bug fixes that got picked up along the way:

- Dashboard and Dev install showed `uv run --project /path/to/evo ...`, but there is no `pyproject.toml` at the repo root. uv walks upward and falls through to the system `evo` on PATH, so "dev install" was silently exercising the wrong binary. Corrected to `/path/to/evo/plugins/evo`.
- Dev smoke test was `evo status`, which errors outside an initialized workspace. Replaced with `evo --version`.
- Python prereq was `3.12+`; dropped to `3.10+` to match `plugins/evo/pyproject.toml`.
- Feature bullet used `evo:discover` backtick syntax (Claude Code only) — now "the `discover` skill".

Intro reworded to "A plugin for your agentic framework that optimizes code through experiments", with the four currently supported hosts on the following line.

## Test plan

- [x] `uv run --project plugins/evo evo --version` prints `evo-hq-cli 0.2.2`
- [x] `cd sdk/python && uv run --with pytest pytest test/` → 6 passed
- [x] `cd sdk/node && npm test` → 2 passed
- [x] `openclaw plugins install evo --marketplace https://github.com/evo-hq/evo` on a clean state → `plugins inspect evo` shows `Status: loaded`, `skills list` shows discover/optimize/subagent as ready
- [x] `hermes skills install evo-hq/evo/plugins/evo/skills/discover --force` → installs; without `--force` → blocked with 10 findings (scanner working as designed). optimize and subagent auto-allow.