### PR TITLE
docs: fix Codex marketplace install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Invoke: `/evo:discover`, `/evo:optimize`.
 **Codex** (requires 0.121.0-alpha.2 or newer -- `npm install -g @openai/codex@alpha` if you're on 0.120.0 stable)
 
 ```bash
-codex marketplace add evo-hq/evo
+codex plugin marketplace add evo-hq/evo
 ```
 
 Then `/plugins` → `evo` → install. Invoke: `$evo discover`, `$evo optimize`.


### PR DESCRIPTION
## Summary
- update the Codex install command in the README to use the current `codex plugin marketplace add` path
- keep the rest of the install flow unchanged

## Verification
- verified the current Codex CLI command path with `codex plugin marketplace --help`
- confirmed `codex marketplace add` is not recognized on `codex-cli 0.123.0-alpha.8`
