### PR TITLE
skills/optimize: port RLM cross-cutting-scan + add rlm_eval harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ sdk/python/uv.lock
 
 # Node
 node_modules/
+
+# Claude Code local project settings
+.claude/

--- a/scripts/rlm_eval/README.md
+++ b/scripts/rlm_eval/README.md
@@ -1,0 +1,148 @@
+# rlm_eval
+
+Harness for measuring whether evo's `optimize` skill actually helps an
+orchestrator find cross-cutting patterns in an experiment tree. Named after
+the Recursive Language Model idea (Zhang/Kraska/Khattab, arXiv:2512.24601)
+that seeded it -- the skill's hard rule is to fan out across experiments via
+parallel sub-agents rather than read every trace inline.
+
+It runs paired trials under `claude -p`:
+- **V** (vanilla): the pre-RLM `SKILL.md`, snapshotted as `baseline_SKILL.md`.
+- **R** (current): whatever is live at `plugins/evo/skills/optimize/SKILL.md`.
+
+Each trial gets a synthetic `.evo/` tree with six planted patterns
+(A/B/C/D/E/S) and is scored both strictly (planted-only) and by an LLM judge
+that credits legitimate grounded observations beyond the planted set.
+
+## Files
+
+- `rlm_eval.py` -- CLI: `check`, `setup`, `trial`, `matrix`, `score`, `clean`.
+- `generate_fixture.py` -- case-spec + one batched LLM call per case; writes
+  `.evo/run_0001/experiments/<id>/...` and `ground_truth.json`.
+- `score.py` -- strict scorer. Credits only planted patterns.
+- `score_llm.py` -- `claude -p` judge with 0/1/2 rubric + `planted_recall`.
+- `baseline_SKILL.md` -- frozen V skill. Do not edit; replace only when
+  intentionally re-baselining.
+- `fixtures/` -- generated, gitignored.
+
+Trial outputs default to `trials/` at repo root, also gitignored.
+
+## Dependencies
+
+- `claude` CLI on PATH.
+- Python 3.10+.
+- macOS or Linux for sandboxed Bash isolation (Seatbelt / bubblewrap). On
+  native Windows the harness falls back to permission deny rules only, which
+  blocks Claude's `Read`/`Edit`/`Grep` but not arbitrary Bash subprocesses --
+  use WSL2 for full isolation.
+
+Run `python scripts/rlm_eval/rlm_eval.py check` to verify.
+
+## Typical run
+
+```bash
+cd scripts/rlm_eval
+
+# One-time: generate small/medium/large fixtures.
+python rlm_eval.py setup --seed 1
+
+# Single trial against R (default), large fixture.
+python rlm_eval.py trial \
+  --fixture fixtures/large \
+  --out ../../trials/smoke
+
+# V vs R across 5 seeds on the large fixture. Writes matrix.csv.
+python rlm_eval.py matrix \
+  --size large \
+  --seeds 5 \
+  --out ../../trials/matrix_vr
+```
+
+`matrix.csv` columns include `variant`, `strict_recall`, `llm_quality`,
+`planted_found`, `missed_planted`, `agent_tool_calls`, `bash_claude_spawns`,
+`num_turns`, `wall_seconds`, `cost_usd`.
+
+## Planted patterns
+
+The fixture plants six patterns so the scorer knows what ground truth looks
+like. See `generate_fixture.py:CASES` for the exact counts and IDs.
+
+- **A** -- shared gate failure (e.g. `refund_flow_guard` timeout across ~18 exps).
+- **B** -- shared zero-score task coupling (`t7` and `t12` co-zero).
+- **C** -- intersection of A and B (compound failure).
+- **D** -- semantic root cause buried in trace prose (varied wording for one
+  underlying cause like refund-amount parsing); D forces `t5=0.0` so the
+  structural pass surfaces D experiments as a candidate cluster.
+- **E** -- wall-of-regression hypothesis (same `swap_parser_v2` hypothesis
+  repeatedly regresses).
+- **S** -- committed improvers (candidate parent nodes for next round).
+
+An orchestrator that only skims `outcome.json` gets A, B, E, S. Getting C, D
+requires actually reading traces -- which is exactly what R's fan-out rule
+forces.
+
+## Results (5 seeds, large fixture)
+
+| seed | V recall | R recall | V missed  | R missed | V cost | R cost |
+|-----:|---------:|---------:|:----------|:---------|-------:|-------:|
+| 1    | 0.67     | 0.83     | C         | -        | $0.92  | $2.65  |
+| 2    | 0.50     | 1.00     | C         | -        | $0.94  | $2.62  |
+| 3    | 0.67     | 1.00     | C         | -        | $0.72  | $2.88  |
+| 4    | 0.50     | 1.00     | C, D      | -        | $0.73  | $2.69  |
+| 5    | 0.33     | 1.00     | C         | -        | $1.13  | $3.02  |
+| mean | 0.53     | 0.97     |           |          | $0.89  | $2.77  |
+
+V misses the compound pattern C every time. R catches it on all 5 seeds,
+at ~3x the cost.
+
+## Isolation
+
+Each trial stages only the fixture's `.evo/` subtree plus the skill under
+test (renamed to `skill.md`) into a scratch dir, then runs `claude -p` there
+with:
+- permission `deny` covering `ground_truth.json`, `generate_fixture.py`,
+  `score*.py`, and every other prior trial under `trials/`;
+- `Edit`/`Write` denied entirely (trials are read-only);
+- on macOS/Linux, a `sandbox` block with `denyRead` on the same paths so
+  Bash subprocesses can't `cat` the ground truth either.
+
+`_scan_leaks` walks the stream transcript after the fact and flags any tool
+call that touched a denied path. `matrix.csv` surfaces a `leaks` count per
+trial.
+
+## Scoring
+
+Two scorers run on every trial, writing `score.json` and `score_llm.json`
+alongside the stream JSONL.
+
+**Strict** (`score.py`) -- keyword match per planted pattern's signature,
+plus an experiment-ID overlap check. Cheap, deterministic, but
+under-credits: a perfectly valid "gate over-firing" observation the
+orchestrator would actually use looks like a hallucination to it.
+
+**LLM judge** (`score_llm.py`) -- `claude -p` with the rubric in
+`score_llm.py:RUBRIC`. Scores each reported pattern 0/1/2 and records
+`planted_recall: {A..S: bool}`. Missed planted patterns count as implicit 0/2
+so leaving signal on the table hurts `quality_ratio`.
+
+`quality_ratio = earned / (2 * (reported + missed_planted_count))`.
+
+## Re-baselining
+
+When the live `plugins/evo/skills/optimize/SKILL.md` changes in a way we
+want to carry forward as the new comparison floor, replace
+`baseline_SKILL.md` with the new snapshot:
+
+```bash
+cp plugins/evo/skills/optimize/SKILL.md scripts/rlm_eval/baseline_SKILL.md
+```
+
+Commit that as its own change with a note about what shifted. Until then,
+`baseline_SKILL.md` is the frozen V and should not drift with live edits.
+
+## Cost note
+
+`cost_usd` in `matrix.csv` comes from the `total_cost_usd` field of
+`claude -p --output-format json`. When the harness runs under a Claude Code
+subscription (OAuth), that number is a nominal reference, not a real charge.
+It's still useful for relative comparison across V and R.

--- a/scripts/rlm_eval/baseline_SKILL.md
+++ b/scripts/rlm_eval/baseline_SKILL.md
@@ -58,8 +58,6 @@ Repeat until interrupted or stall limit reached:
 
 ### 1. Read current state
 
-**Step 0 (always, before anything else): ensure you have read `.evo/project.md`.** Its contents define the optimization metric and goal; every pattern you report MUST be tied to a failure mode of that goal. If you haven't read it yet in this session, read it now -- before listing experiments, opening any `outcome.json`, or spawning sub-agents. If the file is missing, stop and tell the user.
-
 ```bash
 evo scratchpad          # full state: tree, best path, frontier, annotations, diffs, gates, what-not-to-try
 evo frontier            # explorable nodes (JSON)
@@ -71,7 +69,9 @@ evo diff <id> <other>   # diff between any two experiments
 evo gate list <id>      # effective gates for a node (inherited from ancestors)
 ```
 
-### 2. Analyze state and do structural aggregation
+On the first iteration, also read `.evo/project.md` to understand the optimization surface.
+
+### 2. Analyze state and write subagent briefs
 
 From the scratchpad, frontier, traces, and annotations, determine:
 - Which frontier nodes are most promising
@@ -82,56 +82,7 @@ From the scratchpad, frontier, traces, and annotations, determine:
 
 **Read the "Awaiting Decision" section of the scratchpad.** Evaluated nodes (ran, bad outcome, not yet discarded) are a cross-agent signal: if three subagents in the last round produced evaluated nodes that all failed the same gate, surface the pattern -- maybe the gate is too tight, maybe the approach has a shared flaw. Either tell the next round to avoid it, or propose a brief that attacks it directly. Without this cross-cutting read, each subagent rediscovers the same wall independently.
 
-**Structural pass.** For the evaluated nodes this round, load their `outcome.json` files into Python and aggregate: co-occurring `gate_failures`, shared zero-score task IDs in `benchmark.result.tasks`, recurring substrings across `error` fields.
-
-**Emit intersections explicitly.** After computing the per-pattern sets (call them A, B, ...), MUST emit each pairwise intersection `A ∩ B` as a distinct pattern entry whenever at least 2 experiments exhibit both. Intersections carry different strategic implications from their components (compound failures warrant different briefs than single-failure clusters) and do not reconstruct from sub-agent summaries -- this is a parent-level aggregation that must happen inline.
-
-**Improvers are a pattern too.** Enumerate the committed improvers (experiments with `outcome=committed` and `score > parent_score`) as a distinct pattern entry: they are candidate parent nodes for next-round branching and feed the brief's *Parent node* field.
-
-Hold all these findings; step 4's brief-writing combines them with the scan sub-agents' findings from step 3.
-
-### 3. Spawn scan sub-agents for cross-cutting free-text analysis
-
-**Hard rule (primary delegation).** The orchestrator MUST spawn at least one scan sub-agent via your host's parallel-subagent tool in every round before emitting any pattern. This applies to all scan input -- `outcome.json`, `traces/task_*.json`, annotations, and `error` fields alike -- regardless of file size, structure, or whether the orchestrator believes a script would be faster. An inline Python aggregation over `outcome.json` does NOT substitute for delegation; it may supplement sub-agent findings (step 2's structural pass still runs), but step 3's scan sub-agents MUST still run. If you reach step 4 without a completed scan sub-agent call in step 3, you have violated this rule -- stop and spawn one.
-
-**Narrow exception (verification).** After scan sub-agents have returned findings, the orchestrator MAY read individual trace files to: verify a specific finding before citing it in a brief, spot-check a pattern the orchestrator is unsure about, or pull a short quote for a brief's Objective or Pointer Traces field. These verification reads must be narrow (<=3 trace files per round, targeted at experiment IDs already surfaced by sub-agents). This exception does NOT let you skip the hard rule above -- it only governs what you may do after sub-agents have already run.
-
-Partition the evaluated experiments into batches small enough that each sub-agent can read its batch's traces in one pass. Spawn one scan sub-agent per batch in a **single batch** using your host's parallel-subagent tool (see "Host conventions"). They must execute in parallel, not sequentially.
-
-Pass this brief verbatim as the sub-agent's prompt:
-
-> You are a read-only evo scan sub-agent. Do not run experiments or edit code.
->
-> Start by reading `.evo/project.md` to understand the optimization goal and metric. All your findings should be relevant to this goal.
->
-> Your batch: `[exp_IDs]`.
->
-> For each experiment, read `outcome.json` and `traces/task_*.json`. Also consider `hypothesis` and prose `error` text.
->
-> Find patterns that will populate the next round's subagent briefs:
-> - **Shared failure causes** -- root-cause reasons recurring across 2+ experiments (the *why*, not the surface gate name). Feeds brief objectives.
-> - **Wall patterns** -- approaches or gates multiple experiments consistently fail on. Feeds brief boundaries / anti-patterns.
-> - **Compound-failure standouts** -- single experiments hitting multiple failure modes. Feeds brief pointer traces.
->
-> Prioritize patterns tied to the goal's core failure modes or critical tasks. Deprioritize incidental observations. Skip: trace-shape statistics, fixture-structural facts, hypothesis-string-reuse, or anything the orchestrator can't act on in a brief.
->
-> If your batch is still too heavy, partition further and spawn scan sub-agents recursively (same brief, smaller batch).
->
-> Return JSON only: `{"findings": [{"description": "<short>", "experiment_ids": ["exp_XXXX", ...], "evidence": ["<short snippet>", ...]}]}`
->
-> **Evidence must be verbatim quotes** from outcome.json fields, trace `messages`, or `error` text -- not paraphrases. Each description must be supported by the quoted evidence. **Do not speculate about causal chains** (e.g., "approach X regresses because it removes Y") unless a specific trace message or error field directly states that mechanism. If you cannot cite verbatim evidence for a finding, drop it -- err on under-reporting.
->
-> Evidence: short quotes (<200 chars each), max 3 per finding.
-
-Wait for all scan sub-agents to return. Reconcile near-duplicate findings (`timeout_error` ≈ `error_timeout`) by judgment and combine with the structural-pass findings from step 2.
-
-**Verify every pattern before emitting it.** For each pattern in your final output, confirm that at least one reported experiment's outcome.json or trace content contains evidence that directly supports the pattern's description. If you cannot cite a specific field value or quoted message as evidence, drop the pattern. Do not emit speculative causal attributions ("approach X regresses because it removes Y") unless the trace or error text explicitly states that mechanism. This filter applies to both sub-agent findings and your own inline observations.
-
-These unified, verified cross-cutting findings feed step 4's brief-writing.
-
-### 4. Write subagent briefs
-
-Write **one brief per subagent** with these four fields:
+Then write **one brief per subagent** with these four fields:
 
 1. **Objective** -- one sentence describing the bottleneck to attack and the evidence for it. Should name *where in the system's behavior* the gain is hiding (e.g., "tool-use error recovery fails after the first bad call across tasks 2, 5, 7") but **must not name specific files, functions, or concrete edits** -- that's the subagent's job after it reads the code.
 2. **Parent node** -- which experiment to branch from.
@@ -147,7 +98,7 @@ Be specific and bounded. Vague briefs like "improve accuracy" cause subagents to
 
 merge or re-scope one of them. The frontier/pruning logic handles tree-level exploration vs exploitation algorithmically -- the orchestrator's job is just to make sure the round's N briefs don't collapse onto each other.
 
-### 5. Spawn parallel optimization subagents
+### 3. Spawn parallel subagents
 
 Spawn all subagents in a **single batch** using your host's parallel-subagent tool (see "Host conventions" for examples). They must execute in parallel, not sequentially -- serial execution defeats the per-round width.
 
@@ -159,7 +110,7 @@ Each subagent prompt must include:
 - The iteration budget
 - A one-paragraph scratchpad summary (current best score, frontier nodes, recent failures) for context
 
-### 6. Collect results and update state
+### 4. Collect results and update state
 
 After all subagents complete:
 
@@ -181,7 +132,7 @@ Update notes with cross-cutting learnings:
   evo set <exp_id> --note "key insight from round N"
   ```
 
-### 7. Continue or stop
+### 5. Continue or stop
 
 **Continue** if:
 - Stall counter < stall limit

--- a/scripts/rlm_eval/generate_fixture.py
+++ b/scripts/rlm_eval/generate_fixture.py
@@ -1,0 +1,651 @@
+"""Generate a synthetic .evo fixture via case-spec + LLM narrative generation.
+
+Per-case flow:
+  1. Case specs declare count, outcome shape, hypothesis pool, narrative theme.
+  2. ONE batched LLM call per case returns N narrative objects (one per
+     experiment in that case).
+  3. Procedural assembly builds outcome.json + 20 task traces per experiment,
+     inlining the LLM-written narrative for failing tasks.
+
+Artefacts produced (identical to real evo on disk):
+  <out>/.evo/project.md                           -- objective, critical behaviors
+  <out>/.evo/run_0001/experiments/<id>/attempts/001/outcome.json
+  <out>/.evo/run_0001/experiments/<id>/attempts/001/traces/task_<tid>.json
+  <out>/ground_truth.json                          -- planted pattern declarations
+
+Usage:
+    python generate_fixture.py --size large --out fixtures/large --seed 1
+"""
+from __future__ import annotations
+import argparse, json, random, shutil, subprocess, sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+# ============================================================================
+# Case specs
+# ============================================================================
+
+# Each case defines:
+#   count            : how many experiments carry this pattern
+#   outcome          : "committed" | "evaluated" | "failed"
+#   score_delta_range: (min, max) score offset vs parent_score
+#   failing_tasks    : list of task_ids forced to 0.0 in benchmark.result.tasks
+#   gates            : list of gate specs to attach (name, error_theme if failing)
+#   hypothesis_pool  : pool of hypothesis strings (picked per experiment)
+#   force_hypothesis : if set, all experiments in this case use this exact string
+#   narrative_theme  : prose describing what the failing tasks' traces should say;
+#                      passed to the LLM for batched narrative generation
+#   becomes_parent   : if True, other experiments may branch from these (sets up tree)
+#   narrative_varied : if True, LLM is asked to use DIFFERENT wording per experiment
+
+CASES = {
+    # 3 experiments that actually improve the benchmark. They commit and become
+    # branching points for other experiments in the tree.
+    "S_improver": {
+        "count_per_size": {"small": 1, "medium": 2, "large": 3},
+        "outcome": "committed",
+        "score_delta_range": (0.05, 0.10),  # above parent
+        "failing_tasks": [],
+        "gates": [{"name": "_init_gate", "from": "config", "passes": True}],
+        "hypothesis_pool": [
+            "cache refund lookups to avoid duplicate API calls",
+            "batch parser calls for adjacent refund tasks",
+            "parallelize refund tool invocations",
+        ],
+        "narrative_theme": (
+            "successful approach: the agent's edit removes a bottleneck on refund "
+            "processing; benchmark score improves slightly. No gate failures."
+        ),
+        "becomes_parent": True,
+        "narrative_varied": True,
+    },
+
+    # 18 experiments share the refund_flow_guard gate failure. Grep-findable.
+    "A_gate_timeout": {
+        "count_per_size": {"small": 3, "medium": 8, "large": 18},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.10, -0.05),
+        "failing_tasks": ["t7"],  # t7 tanks because the gate timed out
+        "gates": [
+            {"name": "_init_gate", "from": "config", "passes": True},
+            {"name": "refund_flow_guard", "from": "inherited", "passes": False,
+             "error": "refund_flow timeout in task t7"},
+        ],
+        "hypothesis_pool": [
+            "retry on tool-use errors instead of aborting",
+            "raise max_tokens for the planning step",
+            "add few-shot examples for argument parsing",
+            "reorder tools so database calls come before web",
+            "shorten the system prompt header",
+            "add an explicit no-op tool to let the agent wait",
+        ],
+        "narrative_theme": (
+            "agent invokes the refund_flow tool for task t7; the tool call times "
+            "out; agent retries once with extended timeout; tool times out again; "
+            "agent fails the task. Keep the failure mode consistent across experiments."
+        ),
+        "narrative_varied": False,  # same narrative shape OK; A is structurally findable
+    },
+
+    # 12 experiments: task t7 and t12 both score 0.0. They share a dependency.
+    "B_task_coupling": {
+        "count_per_size": {"small": 2, "medium": 5, "large": 12},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.18, -0.10),
+        "failing_tasks": ["t7", "t12"],
+        "gates": [{"name": "_init_gate", "from": "config", "passes": True}],
+        "hypothesis_pool": [
+            "cache intermediate SQL plans between subtasks",
+            "swap the planner model from haiku to sonnet",
+            "chunk long inputs before the reasoning pass",
+            "validate refund amounts before submitting",
+        ],
+        "narrative_theme": (
+            "agent handles tasks t7 and t12 which share a refund-calculation "
+            "dependency. The dependency produces a bad intermediate result, and "
+            "both tasks fail downstream of it. Show the shared dependency failure."
+        ),
+        "narrative_varied": False,
+    },
+
+    # 5 experiments: intersection of A and B. Both refund_flow gate fails AND
+    # t7/t12 tank. These are the worst regressors.
+    "C_intersection": {
+        "count_per_size": {"small": 1, "medium": 2, "large": 5},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.22, -0.15),
+        "failing_tasks": ["t7", "t12"],
+        "gates": [
+            {"name": "_init_gate", "from": "config", "passes": True},
+            {"name": "refund_flow_guard", "from": "inherited", "passes": False,
+             "error": "refund_flow timeout in task t7"},
+        ],
+        "hypothesis_pool": [
+            "retry on tool-use errors instead of aborting",
+            "validate refund amounts before submitting",
+            "swap the planner model from haiku to sonnet",
+        ],
+        "narrative_theme": (
+            "compound failure: agent hits refund_flow timeout on task t7 AND the "
+            "shared refund-calculation dependency breaks t12 too. Both the gate "
+            "and the downstream task go red."
+        ),
+        "narrative_varied": False,
+    },
+
+    # 8 experiments: task t5 tanks with a refund-parsing failure described in
+    # varied wording. This is the semantic-clustering test -- no single
+    # substring grep catches all 8 narratives.
+    "D_semantic_root": {
+        "count_per_size": {"small": 2, "medium": 6, "large": 8},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.15, -0.08),
+        "failing_tasks": ["t5"],
+        "gates": [{"name": "_init_gate", "from": "config", "passes": True}],
+        "hypothesis_pool": [
+            "add locale-aware number parsing",
+            "strip currency symbols before decimal conversion",
+            "route ambiguous refund strings through a fallback parser",
+            "use a regex-based parser for refund amounts",
+            "convert refund strings to Decimal instead of float",
+            "add explicit format validation for refund inputs",
+        ],
+        "narrative_theme": (
+            "agent tries to parse a refund amount in task t5 and the parse FAILS. "
+            "The failure mode is always 'refund amount could not be parsed' BUT "
+            "YOU MUST USE DIFFERENT WORDING FOR EACH EXPERIMENT. Vary the "
+            "vocabulary: one says 'parser rejected', another 'unable to normalize', "
+            "another 'locale format mismatch', another 'decode step raised', "
+            "another 'off-spec stringified number', etc. No single substring "
+            "should catch all of them."
+        ),
+        "narrative_varied": True,  # THIS is the critical case for variation
+    },
+
+    # 6 experiments: all use a specific hypothesis string that consistently
+    # regresses. Wall pattern for brief-writing's "don't try this again".
+    "E_wall_hypothesis": {
+        "count_per_size": {"small": 1, "medium": 3, "large": 6},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.10, -0.06),
+        "failing_tasks": ["t3", "t9"],  # disjoint from t5, t7, t12
+        "gates": [{"name": "_init_gate", "from": "config", "passes": True}],
+        "force_hypothesis": "swap_parser_v2",
+        "narrative_theme": (
+            "agent attempts the 'swap_parser_v2' approach: swaps the refund "
+            "parser implementation. The new parser produces wrong output shape, "
+            "and multiple downstream tasks (t3, t9) fail as a result. The "
+            "approach consistently backfires."
+        ),
+        "narrative_varied": False,
+    },
+
+    # ~18 experiments of pure noise: slightly below baseline, no distinctive
+    # pattern, varied hypotheses from a broad pool.
+    "noise": {
+        "count_per_size": {"small": 1, "medium": 5, "large": 18},
+        "outcome": "evaluated",
+        "score_delta_range": (-0.06, 0.01),  # small regressions, some near baseline
+        "failing_tasks": [],  # no forced failure
+        "gates": [{"name": "_init_gate", "from": "config", "passes": True}],
+        "hypothesis_pool": [
+            "add retries with jitter",
+            "restructure the tool-use prompt into sections",
+            "use a larger context for the planner",
+            "cache tool outputs across similar queries",
+            "shrink the system prompt",
+            "pre-compute static lookups",
+            "reorder steps in the refund pipeline",
+            "add rate limiting to outbound calls",
+            "switch to streaming for long responses",
+            "batch tool calls where possible",
+            "add structured output for planner step",
+            "increase retry budget",
+        ],
+        "narrative_theme": (
+            "agent attempts the hypothesis; the change has no strong effect on "
+            "the benchmark; score stays near baseline with mild noise. No "
+            "distinctive failure mode; no specific task tanks."
+        ),
+        "narrative_varied": True,
+    },
+}
+
+
+# ============================================================================
+# LLM narrative generation
+# ============================================================================
+
+def _extract_json(text: str, case_id: str) -> dict:
+    """Robust JSON extraction from LLM output. Handles markdown fences,
+    unescaped control characters, and trailing prose."""
+    import re
+    s = text.strip()
+    # Strip markdown fences
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"\s*```$", "", s)
+    # Find first '{' and last '}' and slice
+    start = s.find("{")
+    end = s.rfind("}")
+    if start < 0 or end < 0 or end <= start:
+        debug_path = Path(f"/tmp/rlm_narr_{case_id}_raw.txt")
+        debug_path.write_text(text)
+        raise RuntimeError(f"no JSON object in {case_id} (raw saved to {debug_path})")
+    s = s[start:end + 1]
+    # Try strict first, then loose (strict=False permits control chars in strings)
+    for strict in (True, False):
+        try:
+            return json.loads(s, strict=strict)
+        except json.JSONDecodeError as e:
+            last_err = e
+    debug_path = Path(f"/tmp/rlm_narr_{case_id}_raw.txt")
+    debug_path.write_text(text)
+    raise RuntimeError(f"JSON parse failed for {case_id}: {last_err} (raw saved to {debug_path})")
+
+
+def generate_narratives(case_id: str, case: dict, count: int, seed: int) -> list[dict]:
+    """One batched LLM call per case. Returns N narrative objects of the form:
+        {"hypothesis": str, "failing_task_traces": {tid: {"messages": [...], "tool_calls": [...]}}}
+
+    Non-failing tasks are filled procedurally by the caller -- the LLM only
+    produces content for the failing tasks (or a generic activity snippet when
+    the case has no failing tasks, used to flavor a random task for noise/S).
+    """
+    claude = shutil.which("claude")
+    if not claude:
+        raise RuntimeError("claude CLI not on PATH")
+
+    failing = case["failing_tasks"] or ["<pick-one-task>"]
+    hyp_constraint = (
+        f'Use the exact hypothesis string "{case["force_hypothesis"]}" for every experiment.'
+        if "force_hypothesis" in case
+        else f'Pick a hypothesis per experiment from this pool (varying across experiments): {case["hypothesis_pool"]}'
+    )
+    varied_hint = (
+        "CRITICAL: each experiment MUST use DIFFERENT wording for the failure mode. "
+        "Vary vocabulary, tool-call details, and the exact error phrasing across experiments."
+        if case.get("narrative_varied")
+        else "Use a consistent narrative shape; minor detail variation is fine but the core failure wording can repeat."
+    )
+
+    # Retry loop: LLM occasionally drops a brace. Up to 3 tries.
+    for attempt in range(3):
+        try:
+            return _call_narratives(claude, case_id, case, count, failing, hyp_constraint, varied_hint)
+        except (RuntimeError, json.JSONDecodeError) as e:
+            if attempt == 2:
+                raise
+            print(f"  [retry] {case_id} attempt {attempt+1} failed ({e}); retrying...", file=sys.stderr)
+
+
+def _call_narratives(claude: str, case_id: str, case: dict, count: int,
+                     failing: list[str], hyp_constraint: str, varied_hint: str) -> list[dict]:
+    prompt = f"""You are generating synthetic agent-run traces for an evo benchmark fixture.
+
+Case: {case_id}
+Experiments to generate: {count}
+Theme: {case['narrative_theme']}
+Failing tasks per experiment: {failing}
+Hypotheses: {hyp_constraint}
+{varied_hint}
+
+For each experiment, produce ONE narrative object:
+- "hypothesis": a string matching the constraint above
+- "failing_task_traces": object mapping each failing task_id to:
+    {{
+      "messages": [ {{"role": "assistant"|"tool", "content": "<short>"}} , ... ],
+      "tool_calls": [ {{"name": "<tool>", "args": {{...}}, "ok": false, "error": "<short>"}} , ... ]
+    }}
+
+Rules:
+- 3-6 messages per failing task
+- 2-4 tool_calls per failing task, most with ok=false
+- Each message content under 250 chars
+- Each tool error under 200 chars
+- Realistic agent-transcript style, not generic filler
+
+Return ONLY a JSON object, no prose, no markdown fences. Double-check the braces and brackets match before outputting -- mismatched braces will break parsing.
+
+{{"narratives": [<narrative_object_1>, <narrative_object_2>, ..., <narrative_object_{count}>]}}
+"""
+
+    proc = subprocess.run(
+        [claude, "-p", "--output-format", "json", prompt],
+        capture_output=True, text=True, timeout=3600,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"LLM narrative call failed for {case_id} (rc={proc.returncode}): {proc.stderr[:400]}")
+
+    envelope = json.loads(proc.stdout)
+    raw = envelope.get("result", "") or ""
+    parsed = _extract_json(raw, case_id)
+    narratives = parsed.get("narratives", [])
+    if len(narratives) < count:
+        # Pad with duplicates if the LLM returned fewer than asked; still valid.
+        print(f"[warn] {case_id}: LLM returned {len(narratives)}, padding to {count}", file=sys.stderr)
+        while len(narratives) < count:
+            narratives.append(narratives[-1] if narratives else {"hypothesis": "fallback", "failing_task_traces": {}})
+    return narratives[:count]
+
+
+# ============================================================================
+# Procedural filler (non-failing tasks)
+# ============================================================================
+
+TOOL_NAMES = ["read_file", "grep", "edit_file", "bash", "python", "http_get", "sql_query", "vector_search"]
+NORMAL_ACTIVITY_SNIPPETS = [
+    "Inspecting the module before editing.",
+    "Calling the catalogue API for the needed record.",
+    "Batching adjacent lookups to reduce round-trips.",
+    "Validating the returned payload against the schema.",
+    "Routing to the standard handler for this task.",
+    "Caching the intermediate result for reuse.",
+    "Output format confirmed; emitting final answer.",
+    "Running the benchmark harness to capture the score.",
+]
+
+
+def make_normal_trace(rng: random.Random, task_id: str, task_score: float) -> dict:
+    """Generate a procedural 'normal activity' trace for a non-failing task."""
+    n_messages = rng.randint(3, 6)
+    messages = []
+    tool_calls = []
+    for _ in range(n_messages):
+        role = rng.choice(["assistant", "tool"])
+        if role == "tool":
+            tool = rng.choice(TOOL_NAMES)
+            messages.append({"role": "tool", "tool": tool, "content": rng.choice(NORMAL_ACTIVITY_SNIPPETS)})
+            tool_calls.append({
+                "name": tool,
+                "args": {"input": rng.choice(NORMAL_ACTIVITY_SNIPPETS)[:60]},
+                "ok": rng.random() > 0.15,
+            })
+        else:
+            messages.append({"role": "assistant", "content": rng.choice(NORMAL_ACTIVITY_SNIPPETS)})
+    return {
+        "task_id": task_id,
+        "score": task_score,
+        "messages": messages,
+        "tool_calls": tool_calls,
+    }
+
+
+# ============================================================================
+# Experiment assembly
+# ============================================================================
+
+def iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+TASK_IDS = [f"t{i}" for i in range(1, 21)]
+
+
+def build_experiment(
+    rng: random.Random,
+    exp_id: str,
+    case_id: str,
+    case: dict,
+    narrative: dict,
+    parent_id: str,
+    parent_score: float,
+    committed_sha: str | None = None,
+) -> tuple[dict, dict[str, dict]]:
+    """Assemble outcome.json + per-task traces using the narrative for failing tasks.
+
+    Returns (outcome_dict, traces_dict_by_task).
+    """
+    # 1. Per-task scores
+    lo, hi = case["score_delta_range"]
+    target_delta = rng.uniform(lo, hi)
+    target_score = max(0.0, min(1.0, parent_score + target_delta))
+
+    # Start with per-task scores dithered around target
+    tasks = {}
+    for t in TASK_IDS:
+        tasks[t] = round(rng.uniform(max(0.0, target_score - 0.10), min(1.0, target_score + 0.08)), 3)
+
+    # Force failing tasks to 0.0
+    for ft in case["failing_tasks"]:
+        tasks[ft] = 0.0
+
+    # Recompute overall score as the mean (realistic)
+    overall_score = round(sum(tasks.values()) / len(tasks), 3)
+
+    # 2. Gates
+    gates = []
+    for gspec in case["gates"]:
+        g = {
+            "name": gspec["name"],
+            "from": gspec["from"],
+            "command": ["bash", "-lc", f"check_{gspec['name']}.sh"],
+            "passed": gspec["passes"],
+            "error": gspec.get("error"),
+        }
+        gates.append(g)
+
+    # 3. Hypothesis
+    hypothesis = narrative.get("hypothesis") or (
+        case.get("force_hypothesis") or rng.choice(case.get("hypothesis_pool", ["unknown"]))
+    )
+
+    # 4. Timestamps
+    started = datetime.now(timezone.utc) - timedelta(minutes=rng.randint(5, 600))
+    finished = started + timedelta(seconds=rng.randint(30, 900))
+
+    outcome = {
+        "experiment_id": exp_id,
+        "attempt": 1,
+        "outcome": case["outcome"],
+        "hypothesis": hypothesis,
+        "parent_id": parent_id,
+        "parent_score": round(parent_score, 3),
+        "metric": "max",
+        "score": overall_score,
+        "started_at": iso(started),
+        "finished_at": iso(finished),
+        "benchmark": {
+            "command": ["bash", "-lc", "python bench.py"],
+            "returncode": 0,
+            "result": {"score": overall_score, "tasks": tasks},
+        },
+        "gates": gates,
+        "error": None,
+        "commit": committed_sha,
+    }
+
+    # 5. Traces
+    traces = {}
+    failing_task_traces = narrative.get("failing_task_traces", {}) or {}
+    for tid in TASK_IDS:
+        if tid in case["failing_tasks"] and tid in failing_task_traces:
+            ft = failing_task_traces[tid]
+            traces[tid] = {
+                "task_id": tid,
+                "score": tasks[tid],
+                "messages": ft.get("messages", []),
+                "tool_calls": ft.get("tool_calls", []),
+            }
+        else:
+            traces[tid] = make_normal_trace(rng, tid, tasks[tid])
+
+    return outcome, traces
+
+
+# ============================================================================
+# Fixture generation
+# ============================================================================
+
+PROJECT_MD_TEMPLATE = """# Project: refund-processing agent
+
+## Objective
+Maximize the benchmark score for a customer-service agent that handles
+refund requests. The benchmark runs 20 tasks covering different refund
+scenarios; score is the mean of per-task scores. Baseline (root) score is 0.62.
+
+## Critical behaviors
+- Correctly parse refund amounts in multiple input formats. Task `t5` is the
+  hardest parse case; agents frequently regress here.
+- Trigger `refund_flow_guard` only when a real refund-flow error occurs;
+  spurious firing or missing coverage both matter.
+- Pass `task_t7` and `task_t12` -- the two hardest refund-calculation tasks
+  (they share a refund-calculation dependency that breaks together).
+
+## Current frontier (committed improvers)
+{improver_list}
+
+## Known anti-patterns (from prior rounds)
+- `swap_parser_v2` has been attempted {e_count}+ times; consistently regresses
+  the benchmark. Avoid.
+
+## What's being optimized
+Per-attempt edits to the agent's tool-use logic, prompt structure, or
+parsing rules. Each attempt commits only if the benchmark score improves
+over the parent and no gates regress. Attempts that ran but didn't commit
+are marked `evaluated` and live in the frontier for subsequent rounds.
+"""
+
+
+def write_project_md(evo_dir: Path, improvers: list[dict], e_count: int) -> None:
+    if improvers:
+        lines = [f"- `{imp['experiment_id']}` (score {imp['score']}): {imp['hypothesis'][:80]}" for imp in improvers]
+        improver_list = "\n".join(lines)
+    else:
+        improver_list = "- (none yet -- all attempts have regressed)"
+    (evo_dir / "project.md").write_text(PROJECT_MD_TEMPLATE.format(
+        improver_list=improver_list, e_count=e_count,
+    ))
+
+
+def size_count(case: dict, size: str) -> int:
+    return case["count_per_size"].get(size, 0)
+
+
+def generate(size: str, out: Path, seed: int) -> None:
+    rng = random.Random(seed)
+    out.mkdir(parents=True, exist_ok=True)
+    evo_dir = out / ".evo"
+    root = evo_dir / "run_0001" / "experiments"
+    root.mkdir(parents=True, exist_ok=True)
+
+    # 1. Assign experiment IDs per case. Generate exp_0001.. sequentially.
+    total = sum(size_count(c, size) for c in CASES.values())
+    exp_ids = [f"exp_{i:04d}" for i in range(1, total + 1)]
+    rng.shuffle(exp_ids)
+
+    assignments: dict[str, list[str]] = {}  # case_id -> [exp_id]
+    cursor = 0
+    for case_id, case in CASES.items():
+        n = size_count(case, size)
+        assignments[case_id] = exp_ids[cursor:cursor + n]
+        cursor += n
+
+    # 1a. Handle the A/B/C intersection: C's exp_ids should also be treated as
+    # sharing A's gate and B's task failures. We achieve this by making C a
+    # distinct case (already done via its own gates + failing_tasks), but we
+    # need the ground_truth to reflect that C ⊂ A and C ⊂ B for scoring.
+    # Pattern sets for ground_truth:
+    a_ids = set(assignments["A_gate_timeout"]) | set(assignments["C_intersection"])
+    b_ids = set(assignments["B_task_coupling"]) | set(assignments["C_intersection"])
+    c_ids = set(assignments["C_intersection"])
+    d_ids = set(assignments["D_semantic_root"])
+    e_ids = set(assignments["E_wall_hypothesis"])
+    s_ids = set(assignments["S_improver"])
+
+    # 2. Generate narratives per case via LLM.
+    narratives: dict[str, list[dict]] = {}
+    for case_id, case in CASES.items():
+        n = len(assignments[case_id])
+        if n == 0:
+            narratives[case_id] = []
+            continue
+        print(f"  [llm] {case_id}: generating {n} narratives...", file=sys.stderr)
+        narratives[case_id] = generate_narratives(case_id, case, n, seed)
+
+    # 3. Build S (improvers) FIRST so their sha is available as parent for others.
+    improver_meta: list[dict] = []
+    for i, exp_id in enumerate(assignments["S_improver"]):
+        case = CASES["S_improver"]
+        narr = narratives["S_improver"][i]
+        sha = f"{rng.randrange(16**10):010x}"
+        outcome, traces = build_experiment(
+            rng, exp_id, "S_improver", case, narr,
+            parent_id="root", parent_score=0.62, committed_sha=sha,
+        )
+        write_experiment(root, exp_id, outcome, traces)
+        improver_meta.append({"experiment_id": exp_id, "score": outcome["score"], "hypothesis": outcome["hypothesis"]})
+
+    # 4. Build the rest, letting ~40% branch from an S experiment (tree depth).
+    rest_exp_ids = [e for case_id in CASES if case_id != "S_improver" for e in assignments[case_id]]
+    for case_id, case_exps in assignments.items():
+        if case_id == "S_improver":
+            continue
+        case = CASES[case_id]
+        for i, exp_id in enumerate(case_exps):
+            narr = narratives[case_id][i] if narratives[case_id] else {"hypothesis": "fallback", "failing_task_traces": {}}
+            if improver_meta and rng.random() < 0.4:
+                imp = rng.choice(improver_meta)
+                parent_id = imp["experiment_id"]
+                parent_score = imp["score"]
+            else:
+                parent_id = "root"
+                parent_score = 0.62
+            outcome, traces = build_experiment(
+                rng, exp_id, case_id, case, narr,
+                parent_id=parent_id, parent_score=parent_score,
+            )
+            write_experiment(root, exp_id, outcome, traces)
+
+    # 5. project.md + ground_truth.json
+    write_project_md(evo_dir, improver_meta, e_count=len(e_ids))
+
+    ground_truth = {
+        "size": size,
+        "seed": seed,
+        "total_experiments": total,
+        "patterns": [
+            {"id": "A", "signature": "refund_flow_guard gate fails with 'refund_flow timeout in task t7'",
+             "experiment_ids": sorted(a_ids)},
+            {"id": "B", "signature": "tasks t7 and t12 both score 0.0",
+             "experiment_ids": sorted(b_ids)},
+            {"id": "C", "signature": "intersection of A and B (refund_flow gate AND t7/t12 both zero)",
+             "experiment_ids": sorted(c_ids)},
+            {"id": "D", "signature": "task t5 tanks due to refund-amount parsing failures described in varied wording across traces",
+             "experiment_ids": sorted(d_ids)},
+            {"id": "E", "signature": "hypothesis 'swap_parser_v2' repeatedly attempted and consistently regresses",
+             "experiment_ids": sorted(e_ids)},
+            {"id": "S", "signature": "committed improvers worth extending",
+             "experiment_ids": sorted(s_ids)},
+        ],
+    }
+    (out / "ground_truth.json").write_text(json.dumps(ground_truth, indent=2))
+
+    # 6. Summary
+    print(f"wrote {total} experiments to {root}")
+    for p in ground_truth["patterns"]:
+        print(f"  pattern {p['id']} ({len(p['experiment_ids'])}): {p['experiment_ids'][:8]}{'...' if len(p['experiment_ids']) > 8 else ''}")
+    print(f"ground truth at {out / 'ground_truth.json'}")
+
+
+def write_experiment(root: Path, exp_id: str, outcome: dict, traces: dict[str, dict]) -> None:
+    a_dir = root / exp_id / "attempts" / "001"
+    a_dir.mkdir(parents=True, exist_ok=True)
+    (a_dir / "outcome.json").write_text(json.dumps(outcome, indent=2))
+    traces_dir = a_dir / "traces"
+    traces_dir.mkdir(exist_ok=True)
+    for tid, tr in traces.items():
+        (traces_dir / f"task_{tid}.json").write_text(json.dumps(tr))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--size", choices=["small", "medium", "large"], required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--seed", type=int, default=1)
+    args = ap.parse_args()
+    generate(args.size, args.out, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rlm_eval/generate_fixture.py
+++ b/scripts/rlm_eval/generate_fixture.py
@@ -39,6 +39,8 @@ from pathlib import Path
 #   becomes_parent   : if True, other experiments may branch from these (sets up tree)
 #   narrative_varied : if True, LLM is asked to use DIFFERENT wording per experiment
 
+SIZES = ["small", "medium", "large"]
+
 CASES = {
     # 3 experiments that actually improve the benchmark. They commit and become
     # branching points for other experiments in the tree.
@@ -522,7 +524,7 @@ def size_count(case: dict, size: str) -> int:
     return case["count_per_size"].get(size, 0)
 
 
-def generate(size: str, out: Path, seed: int) -> None:
+def generate(size: str, out: Path, seed: int, with_traces: bool = True) -> None:
     rng = random.Random(seed)
     out.mkdir(parents=True, exist_ok=True)
     evo_dir = out / ".evo"
@@ -553,21 +555,26 @@ def generate(size: str, out: Path, seed: int) -> None:
     e_ids = set(assignments["E_wall_hypothesis"])
     s_ids = set(assignments["S_improver"])
 
-    # 2. Generate narratives per case via LLM.
+    # 2. Generate narratives per case via LLM (skipped when with_traces=False;
+    #    the downstream build_experiment falls back to a generic hypothesis).
     narratives: dict[str, list[dict]] = {}
-    for case_id, case in CASES.items():
-        n = len(assignments[case_id])
-        if n == 0:
+    if with_traces:
+        for case_id, case in CASES.items():
+            n = len(assignments[case_id])
+            if n == 0:
+                narratives[case_id] = []
+                continue
+            print(f"  [llm] {case_id}: generating {n} narratives...", file=sys.stderr)
+            narratives[case_id] = generate_narratives(case_id, case, n, seed)
+    else:
+        for case_id in CASES:
             narratives[case_id] = []
-            continue
-        print(f"  [llm] {case_id}: generating {n} narratives...", file=sys.stderr)
-        narratives[case_id] = generate_narratives(case_id, case, n, seed)
 
     # 3. Build S (improvers) FIRST so their sha is available as parent for others.
     improver_meta: list[dict] = []
     for i, exp_id in enumerate(assignments["S_improver"]):
         case = CASES["S_improver"]
-        narr = narratives["S_improver"][i]
+        narr = narratives["S_improver"][i] if narratives["S_improver"] else {"hypothesis": "fallback", "failing_task_traces": {}}
         sha = f"{rng.randrange(16**10):010x}"
         outcome, traces = build_experiment(
             rng, exp_id, "S_improver", case, narr,

--- a/scripts/rlm_eval/rlm_eval.py
+++ b/scripts/rlm_eval/rlm_eval.py
@@ -99,7 +99,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
         out = THIS_DIR / "fixtures" / size
         if out.exists():
             shutil.rmtree(out)
-        generate(size, out, args.seed)
+        generate(size, out, args.seed, with_traces=args.with_traces)
     print(f"fixtures under {THIS_DIR / 'fixtures'}")
     return 0
 

--- a/scripts/rlm_eval/rlm_eval.py
+++ b/scripts/rlm_eval/rlm_eval.py
@@ -1,0 +1,502 @@
+"""Evaluation harness for the evo optimize skill.
+
+Cross-platform: works on macOS, Linux, WSL2, and Windows (with a weaker isolation
+layer on Windows because the Claude Code sandbox requires Seatbelt/bubblewrap).
+
+The harness isolates each trial in a temp dir, copies the target skill file in,
+runs `claude -p` against a synthetic fixture, and scores the output (strict
+keyword + Jaccard, plus LLM judge). Intended for validating skill changes
+against a planted-pattern fixture before merging.
+
+Subcommands:
+    check     preflight -- claude CLI present, OS capabilities, python version
+    setup     generate fixtures (small, medium, large) with LLM narratives
+    trial     run one isolated trial on a fixture with a given skill file
+    matrix    run N seeds on one size; write results CSV
+    score     (re)score an existing trial's parsed_output.json
+    clean     remove generated fixtures and /tmp/rlm_trial_* dirs
+
+Examples (portable -- same command works on all OSes):
+    python rlm_eval.py check
+    python rlm_eval.py setup
+    python rlm_eval.py trial --fixture fixtures/large --out trials/t001
+    python rlm_eval.py matrix --size large --seeds 5 --out trials/
+
+A future A/B experiment can use `--skill-path <other>` to compare a candidate
+file against the current SKILL.md; by default the current skill is used.
+"""
+from __future__ import annotations
+import argparse, csv, json, os, platform, re, shutil, subprocess, sys, tempfile, textwrap, time, uuid
+from pathlib import Path
+from typing import Optional
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = THIS_DIR.parent.parent
+PLUGIN_SKILL_DIR = REPO_ROOT / "plugins" / "evo" / "skills" / "optimize"
+
+# V/R comparison: V is the vanilla baseline snapshot kept in the eval dir;
+# R is the current live skill. This lets the harness do V-vs-R paired
+# comparisons forever, independent of what's shipped in SKILL.md.
+SKILL_V = THIS_DIR / "baseline_SKILL.md"
+SKILL_R = PLUGIN_SKILL_DIR / "SKILL.md"
+DEFAULT_SKILL = SKILL_R
+
+# Paths the agent must NOT read (ground truth, generator source, scorer, prior outputs)
+def leakage_deny_paths() -> list[str]:
+    """Absolute paths we want to prevent the trial agent from reading.
+
+    Covers the repo root (source of generator / scorer / ground truth), the
+    system temp dir (modern trial outputs), and POSIX `/tmp/` (legacy outputs
+    from earlier non-isolated runs on macOS where gettempdir != /tmp).
+    """
+    paths = {
+        str(REPO_ROOT),
+        str(Path(tempfile.gettempdir()) / "rlm_dryrun"),
+        str(Path(tempfile.gettempdir()) / "rlm_test_outputs"),
+    }
+    if platform.system() in {"Darwin", "Linux"}:
+        paths.add("/tmp/rlm_dryrun")
+        paths.add("/tmp/rlm_test_outputs")
+    return sorted(paths)
+
+# ------------------------------- preflight -------------------------------
+
+def cmd_check(_args: argparse.Namespace) -> int:
+    os_name = platform.system()
+    print(f"platform: {os_name} {platform.release()} ({platform.machine()})")
+    print(f"python: {sys.version.split()[0]}")
+    claude = shutil.which("claude")
+    if not claude:
+        print("claude CLI: NOT FOUND on PATH", file=sys.stderr)
+        print("  install via https://code.claude.com/docs/en/quickstart", file=sys.stderr)
+        return 1
+    ver = subprocess.run([claude, "--version"], capture_output=True, text=True)
+    print(f"claude CLI: {ver.stdout.strip()} ({claude})")
+
+    sandbox_supported = os_name in {"Darwin", "Linux"}
+    if os_name == "Windows":
+        # WSL2 reports as Linux inside the distro; this path is hit for native Windows only
+        print("sandbox: NOT SUPPORTED natively on Windows. Isolation will use permission "
+              "deny rules only (blocks Claude's Read/Edit tools, not Bash subprocesses). "
+              "For full OS-level isolation, run inside WSL2.")
+    elif sandbox_supported:
+        print(f"sandbox: supported ({'Seatbelt' if os_name == 'Darwin' else 'bubblewrap'})")
+    if not SKILL_R.exists():
+        print(f"skill R: MISSING at {SKILL_R}", file=sys.stderr)
+        return 2
+    if not SKILL_V.exists():
+        print(f"skill V (baseline): MISSING at {SKILL_V}", file=sys.stderr)
+        return 2
+    print(f"skill V (baseline): {SKILL_V}")
+    print(f"skill R (current):  {SKILL_R}")
+    return 0
+
+# ------------------------------- setup -------------------------------
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    from generate_fixture import generate, SIZES
+    for size in SIZES:
+        out = THIS_DIR / "fixtures" / size
+        if out.exists():
+            shutil.rmtree(out)
+        generate(size, out, args.seed)
+    print(f"fixtures under {THIS_DIR / 'fixtures'}")
+    return 0
+
+# ------------------------------- isolated trial -------------------------------
+
+def write_settings(trial_dir: Path) -> None:
+    """Write the project .claude/settings.json that locks the trial down.
+
+    Permission deny rules cover Claude's built-in Read tool and bash reads on
+    macOS/Linux (via sandbox). Writes are denied entirely -- the trial shouldn't
+    need them.
+    """
+    os_name = platform.system()
+    deny_paths = leakage_deny_paths()
+    # Permission rules use `//absolute` prefix in Claude Code
+    perm_deny = [f"Read(//{p.lstrip('/')}/**)" for p in deny_paths] + ["Edit", "Write"]
+    settings: dict = {
+        "permissions": {
+            "allow": ["Bash", "Read", "Grep", "Glob"],
+            "deny": perm_deny,
+        }
+    }
+    if os_name in {"Darwin", "Linux"}:
+        settings["sandbox"] = {
+            "enabled": True,
+            "filesystem": {
+                "denyRead": [f"//{p.lstrip('/')}" for p in deny_paths],
+            },
+        }
+    (trial_dir / ".claude").mkdir(parents=True, exist_ok=True)
+    (trial_dir / ".claude" / "settings.json").write_text(json.dumps(settings, indent=2))
+
+def build_prompt() -> str:
+    return textwrap.dedent("""
+        You are the evo optimization orchestrator performing the cross-round cross-cutting scan.
+
+        Skill context (read this file first): ./skill.md
+
+        The skill defines the procedure. Follow its steps, in order. Your deliverable is a list of cross-cutting patterns across the experiments under ./.evo/run_0001/experiments/. "Patterns" includes failure modes, wall-of-regression hypotheses, compound failures (intersections), AND successful improvers worth extending -- anything the next round's brief-writing could act on.
+
+        Output ONLY a JSON object, no prose, no markdown fences, with this shape:
+        {"patterns": [{"signature": "<short description>", "experiment_ids": ["exp_NNNN", ...]}, ...]}
+
+        An experiment belongs to a pattern only if its evidence actually exhibits it. Do not guess; verify.
+    """).strip()
+
+def run_trial(fixture_dir: Path, skill_path: Path, out_dir: Path,
+              keep_trial_dir: bool = True) -> dict:
+    """Run one isolated trial. Returns meta dict with duration, cost, turns, leaks."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    trial_id = uuid.uuid4().hex[:8]
+    trial_dir = Path(tempfile.gettempdir()) / f"rlm_trial_{trial_id}"
+    trial_dir.mkdir(parents=True, exist_ok=False)
+
+    # Stage only the fixture's .evo subtree and the chosen skill (renamed to neutral)
+    shutil.copytree(fixture_dir / ".evo", trial_dir / ".evo")
+    shutil.copy2(skill_path, trial_dir / "skill.md")
+    write_settings(trial_dir)
+
+    claude = shutil.which("claude")
+    if not claude:
+        raise RuntimeError("claude CLI not on PATH")
+
+    prompt = build_prompt()
+    stream_path = out_dir / "stream.jsonl"
+    stderr_path = out_dir / "stderr.log"
+
+    t0 = time.time()
+    with stream_path.open("w") as s, stderr_path.open("w") as e:
+        proc = subprocess.run(
+            [claude, "-p",
+             "--output-format", "stream-json",
+             "--verbose",
+             "--permission-mode", "default",
+             prompt],
+            cwd=str(trial_dir),
+            stdout=s, stderr=e,
+            timeout=3600,
+        )
+    wall = time.time() - t0
+    rc = proc.returncode
+
+    meta = _extract_meta(stream_path, out_dir)
+    meta["wall_seconds"] = round(wall, 2)
+    meta["returncode"] = rc
+    meta["trial_dir"] = str(trial_dir)
+
+    leaks = _scan_leaks(stream_path)
+    meta["leaks"] = leaks
+
+    (out_dir / "meta.json").write_text(json.dumps(meta, indent=2))
+    if not keep_trial_dir:
+        shutil.rmtree(trial_dir, ignore_errors=True)
+    return meta
+
+def _extract_patterns_json(raw: str) -> dict | None:
+    """Extract {"patterns": [...]} from LLM output, with repair for common
+    truncation (missing trailing `]}` or `}`). Returns None if unrecoverable."""
+    s = raw.strip()
+    # Strip markdown fences
+    s = re.sub(r"^```(?:json)?\s*", "", s)
+    s = re.sub(r"\s*```$", "", s)
+    start = s.find("{")
+    if start < 0:
+        return None
+    candidate = s[start:]
+    # Try as-is first
+    for attempt in (candidate, candidate + "}", candidate + "]}", candidate + "]}}"):
+        try:
+            parsed = json.loads(attempt, strict=False)
+            if isinstance(parsed, dict) and "patterns" in parsed:
+                return parsed
+        except json.JSONDecodeError:
+            continue
+    # Last resort: bracket-counting repair on the candidate
+    open_c = candidate.count("{")
+    close_c = candidate.count("}")
+    open_b = candidate.count("[")
+    close_b = candidate.count("]")
+    repaired = candidate + ("]" * (open_b - close_b)) + ("}" * (open_c - close_c))
+    try:
+        parsed = json.loads(repaired, strict=False)
+        if isinstance(parsed, dict) and "patterns" in parsed:
+            return parsed
+    except json.JSONDecodeError:
+        pass
+    return None
+
+
+def _extract_meta(stream_path: Path, out_dir: Path) -> dict:
+    events = []
+    with stream_path.open() as f:
+        for line in f:
+            if line.strip():
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    result_evt = next((e for e in reversed(events) if e.get("type") == "result"), None)
+    meta = {}
+    if result_evt:
+        meta.update({
+            "duration_ms": result_evt.get("duration_ms"),
+            "num_turns": result_evt.get("num_turns"),
+            "total_cost_usd": result_evt.get("total_cost_usd"),
+            "stop_reason": result_evt.get("stop_reason"),
+        })
+        raw = result_evt.get("result", "") or ""
+        parsed = _extract_patterns_json(raw)
+        if parsed is not None:
+            (out_dir / "parsed_output.json").write_text(json.dumps(parsed, indent=2))
+            meta["patterns_reported"] = len(parsed.get("patterns", []))
+        else:
+            (out_dir / "parsed_output.json").write_text("{}")
+            meta["parse_error"] = True
+    # Classify tool invocations.
+    # sub_model_calls counts any mechanism that spawns a fresh model session:
+    # native Agent tool calls (Claude Code's primitive) AND Bash-spawned
+    # `claude -p` subprocesses.
+    sub_model_calls = 0
+    agent_tool_calls = 0
+    bash_claude_spawns = 0
+    structured_queries = 0
+    for e in events:
+        if e.get("type") != "assistant":
+            continue
+        for b in e.get("message", {}).get("content", []):
+            if b.get("type") != "tool_use":
+                continue
+            name = b.get("name")
+            if name == "Agent":
+                agent_tool_calls += 1
+                sub_model_calls += 1
+            elif name == "Bash":
+                cmd = (b.get("input") or {}).get("command", "")
+                if re.search(r"\bclaude\b.*(-p\b|\bprint\b)", cmd):
+                    bash_claude_spawns += 1
+                    sub_model_calls += 1
+                elif re.search(r"\b(python|python3|jq|awk|grep|rg)\b", cmd) and re.search(r"outcome\.json|task_.*\.json|\.evo/", cmd):
+                    structured_queries += 1
+    meta["sub_model_calls"] = sub_model_calls
+    meta["agent_tool_calls"] = agent_tool_calls
+    meta["bash_claude_spawns"] = bash_claude_spawns
+    meta["structured_queries"] = structured_queries
+    return meta
+
+def _scan_leaks(stream_path: Path) -> list[dict]:
+    """Grep the stream for any tool_use referencing denied paths or ground-truth names."""
+    bad = [
+        re.escape(str(REPO_ROOT)),
+        r"rlm_dryrun",
+        r"rlm_test_outputs",
+        r"ground_truth",
+        r"generate_fixture",
+        r"rlm_eval[\\/]score",
+    ]
+    hits: list[dict] = []
+    with stream_path.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                m = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if m.get("type") != "assistant":
+                continue
+            for block in m.get("message", {}).get("content", []):
+                if block.get("type") != "tool_use":
+                    continue
+                inp_str = json.dumps(block.get("input", {}))
+                for pat in bad:
+                    if re.search(pat, inp_str):
+                        hits.append({
+                            "tool": block.get("name"),
+                            "pattern": pat,
+                            "input": block.get("input"),
+                        })
+    return hits
+
+def cmd_trial(args: argparse.Namespace) -> int:
+    if args.skill_path:
+        skill = Path(args.skill_path).resolve()
+    elif args.variant:
+        skill = SKILL_V if args.variant == "V" else SKILL_R
+    else:
+        skill = DEFAULT_SKILL
+    fixture = Path(args.fixture).resolve()
+    out = Path(args.out).resolve()
+    meta = run_trial(fixture, skill, out, keep_trial_dir=not args.cleanup)
+    print(json.dumps(meta, indent=2))
+    if meta.get("leaks"):
+        print(f"LEAKAGE DETECTED ({len(meta['leaks'])} hits) -- trial is invalid", file=sys.stderr)
+        return 3
+    return 0
+
+# ------------------------------- matrix -------------------------------
+
+def cmd_matrix(args: argparse.Namespace) -> int:
+    from generate_fixture import generate
+
+    # Resolve which variants to run. Default: V (baseline) + R (current).
+    if args.skill_path:
+        variants = [("custom", Path(args.skill_path).resolve())]
+    elif args.variants:
+        lut = {"V": SKILL_V, "R": SKILL_R}
+        variants = [(v, lut[v]) for v in args.variants]
+    else:
+        variants = [("V", SKILL_V), ("R", SKILL_R)]
+
+    out_root = Path(args.out).resolve()
+    out_root.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for seed in range(1, args.seeds + 1):
+        fixture_dir = out_root / f"seed_{seed}" / "fixture"
+        if fixture_dir.exists():
+            shutil.rmtree(fixture_dir)
+        generate(args.size, fixture_dir, seed)
+        for variant_name, skill in variants:
+            trial_out = out_root / f"seed_{seed}" / variant_name
+            print(f"[seed {seed} / {variant_name}] running...")
+            meta = run_trial(fixture_dir, skill, trial_out, keep_trial_dir=False)
+            strict = _score_against(trial_out, fixture_dir / "ground_truth.json")
+            llm = _score_llm_against(trial_out, fixture_dir / "ground_truth.json")
+            row = {
+                "seed": seed,
+                "variant": variant_name,
+                "strict_recall": strict.get("recall"),
+                "strict_halluc": strict.get("hallucinated"),
+                "llm_quality": llm.get("quality_ratio"),
+                "planted_found": llm.get("patterns_found_of_planted"),
+                "missed_planted": ",".join(llm.get("missed_planted", [])) or "-",
+                "num_turns": meta.get("num_turns"),
+                "agent_tool_calls": meta.get("agent_tool_calls"),
+                "bash_claude_spawns": meta.get("bash_claude_spawns"),
+                "structured_queries": meta.get("structured_queries"),
+                "wall_seconds": meta.get("wall_seconds"),
+                "cost_usd": meta.get("total_cost_usd"),
+                "leaks": len(meta.get("leaks", [])),
+            }
+            rows.append(row)
+            print(f"  -> strict_recall={row['strict_recall']} llm_quality={row['llm_quality']} "
+                  f"missed={row['missed_planted']} turns={row['num_turns']} "
+                  f"agent={row['agent_tool_calls']} cost=${row['cost_usd']}")
+    # Write CSV
+    csv_path = out_root / "matrix.csv"
+    if rows:
+        with csv_path.open("w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            w.writeheader()
+            w.writerows(rows)
+        print(f"\nwrote {csv_path}")
+    return 0
+
+def _score_llm_against(trial_out: Path, ground_truth: Path) -> dict:
+    """Run the LLM judge scorer and compute planted-found count."""
+    import score_llm as llm_scorer
+    parsed = trial_out / "parsed_output.json"
+    if not parsed.exists():
+        return {"quality_ratio": None, "patterns_found_of_planted": 0, "missed_planted": []}
+    gt = json.loads(ground_truth.read_text())
+    out = json.loads(parsed.read_text())
+    try:
+        result = llm_scorer.score(gt, out)
+    except Exception as e:
+        print(f"  [warn] LLM judge failed: {e}")
+        return {"quality_ratio": None, "patterns_found_of_planted": 0, "missed_planted": []}
+    (trial_out / "score_llm.json").write_text(json.dumps(result, indent=2))
+    recall = result.get("planted_recall", {})
+    found = sum(1 for v in recall.values() if v)
+    return {
+        "quality_ratio": result.get("quality_ratio"),
+        "patterns_found_of_planted": found,
+        "missed_planted": result.get("missed_planted", []),
+    }
+
+
+def _score_against(trial_out: Path, ground_truth: Path) -> dict:
+    import score as scorer
+    parsed = trial_out / "parsed_output.json"
+    if not parsed.exists():
+        return {"recall": None, "hallucinated": None, "patterns_found": 0}
+    gt = json.loads(ground_truth.read_text())
+    out = json.loads(parsed.read_text())
+    sc = scorer.score(gt, out)
+    (trial_out / "score.json").write_text(json.dumps(sc, indent=2))
+    return sc
+
+def cmd_score(args: argparse.Namespace) -> int:
+    sc = _score_against(Path(args.trial_dir).resolve(), Path(args.ground_truth).resolve())
+    print(json.dumps(sc, indent=2))
+    return 0
+
+# ------------------------------- cleanup -------------------------------
+
+def cmd_clean(args: argparse.Namespace) -> int:
+    targets = []
+    fx = THIS_DIR / "fixtures"
+    if fx.exists():
+        targets.append(fx)
+    for tmp in {Path(tempfile.gettempdir()), Path("/tmp")}:
+        if not tmp.exists():
+            continue
+        for p in tmp.glob("rlm_trial_*"):
+            targets.append(p)
+        for legacy in ("rlm_dryrun", "rlm_test_outputs", "rlm_iso", "rlm_iso_sanity"):
+            p = tmp / legacy
+            if p.exists():
+                targets.append(p)
+    for t in sorted(set(str(x) for x in targets)):
+        shutil.rmtree(t, ignore_errors=True)
+        print(f"removed {t}")
+    if not targets:
+        print("nothing to clean")
+    return 0
+
+# ------------------------------- main -------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog="rlm_eval")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("check").set_defaults(func=cmd_check)
+
+    p_setup = sub.add_parser("setup", help="generate fixtures")
+    p_setup.add_argument("--with-traces", action="store_true", default=True)
+    p_setup.add_argument("--no-traces", dest="with_traces", action="store_false")
+    p_setup.add_argument("--trace-chars", type=int, default=1000)
+    p_setup.add_argument("--seed", type=int, default=1)
+    p_setup.set_defaults(func=cmd_setup)
+
+    p_tr = sub.add_parser("trial", help="run one isolated trial")
+    p_tr.add_argument("--fixture", required=True)
+    p_tr.add_argument("--variant", choices=["V", "R"], help="V=baseline_SKILL.md, R=current plugins/evo/.../SKILL.md")
+    p_tr.add_argument("--skill-path", help="explicit path to a SKILL.md (overrides --variant)")
+    p_tr.add_argument("--out", required=True)
+    p_tr.add_argument("--cleanup", action="store_true", help="delete trial dir after")
+    p_tr.set_defaults(func=cmd_trial)
+
+    p_mx = sub.add_parser("matrix", help="run N seeds; default compares V (baseline) vs R (current)")
+    p_mx.add_argument("--size", choices=["small", "medium", "large"], default="large")
+    p_mx.add_argument("--seeds", type=int, default=5)
+    p_mx.add_argument("--variants", nargs="+", choices=["V", "R"], help="subset of variants (default: both)")
+    p_mx.add_argument("--skill-path", help="run a single custom skill path instead of V/R")
+    p_mx.add_argument("--out", required=True)
+    p_mx.set_defaults(func=cmd_matrix)
+
+    p_sc = sub.add_parser("score", help="(re)score an existing trial")
+    p_sc.add_argument("--trial-dir", required=True)
+    p_sc.add_argument("--ground-truth", required=True)
+    p_sc.set_defaults(func=cmd_score)
+
+    sub.add_parser("clean").set_defaults(func=cmd_clean)
+
+    args = ap.parse_args()
+    rc = args.func(args)
+    sys.exit(rc or 0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rlm_eval/score.py
+++ b/scripts/rlm_eval/score.py
@@ -1,0 +1,111 @@
+"""Score a model's pattern output against a fixture's ground truth.
+
+Model output expected shape (JSON):
+    {"patterns": [{"signature": str, "experiment_ids": [str, ...]}, ...]}
+
+Scoring logic:
+  A reported pattern matches a planted pattern when:
+    (a) its signature's keywords overlap the planted signature (fuzzy), AND
+    (b) Jaccard(reported_ids, planted_ids) >= id_threshold (default 0.6).
+
+Per planted pattern, we take the best-matching reported pattern (if any) and
+record whether it was found. Unmatched reported patterns are hallucinations.
+
+We also compute ID-level precision on the matched ones.
+"""
+from __future__ import annotations
+import argparse, json, re, sys
+from pathlib import Path
+
+# Planted signature -> keywords that any matching report must overlap
+SIGNATURE_KEYWORDS = {
+    "A": {"refund_flow", "gate", "timeout"},
+    "B": {"t7", "t12"},
+    "C": {"refund", "t7", "t12"},  # must hit both A and B terms
+    # D: t5 tanks (structural tell) + refund-parse semantic theme (varied wording)
+    "D": {"t5", "refund", "parse", "parsing", "normalize", "deserialize", "decode", "interpret", "malformed"},
+    # E: wall-pattern on a specific hypothesis that always regresses
+    "E": {"swap_parser", "wall", "repeated", "consistently", "regress", "hypothesis"},
+    # S: committed improvers (positive pattern)
+    "S": {"committed", "improver", "commit", "improvement", "frontier", "worth extending"},
+}
+# Minimum keyword hits for a match per pattern
+MIN_KEYWORD_HITS = {"A": 1, "B": 2, "C": 2, "D": 2, "E": 2, "S": 1}
+ID_JACCARD_THRESHOLD = 0.6
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+def keyword_hits(text: str, keywords: set[str]) -> int:
+    text_low = text.lower()
+    return sum(1 for kw in keywords if kw.lower() in text_low)
+
+def score(ground_truth: dict, model_output: dict) -> dict:
+    planted = {p["id"]: p for p in ground_truth["patterns"]}
+    reported = model_output.get("patterns", [])
+
+    # For each planted pattern, find best matching reported pattern
+    used_report_idx: set[int] = set()
+    per_pattern = []
+    for pid, planted_p in planted.items():
+        planted_ids = set(planted_p["experiment_ids"])
+        kw = SIGNATURE_KEYWORDS[pid]
+        min_hits = MIN_KEYWORD_HITS[pid]
+
+        best = None
+        best_j = 0.0
+        for idx, rep in enumerate(reported):
+            if idx in used_report_idx:
+                continue
+            if keyword_hits(rep.get("signature", ""), kw) < min_hits:
+                continue
+            rep_ids = set(rep.get("experiment_ids", []))
+            j = jaccard(rep_ids, planted_ids)
+            if j >= ID_JACCARD_THRESHOLD and j > best_j:
+                best = (idx, rep, j)
+                best_j = j
+
+        if best is not None:
+            idx, rep, j = best
+            used_report_idx.add(idx)
+            rep_ids = set(rep.get("experiment_ids", []))
+            id_precision = len(rep_ids & planted_ids) / len(rep_ids) if rep_ids else 0.0
+            id_recall = len(rep_ids & planted_ids) / len(planted_ids) if planted_ids else 0.0
+            per_pattern.append({
+                "id": pid,
+                "found": True,
+                "jaccard": round(j, 3),
+                "id_precision": round(id_precision, 3),
+                "id_recall": round(id_recall, 3),
+            })
+        else:
+            per_pattern.append({"id": pid, "found": False, "jaccard": 0.0,
+                                "id_precision": 0.0, "id_recall": 0.0})
+
+    hallucinated = len(reported) - len(used_report_idx)
+    recall = sum(1 for p in per_pattern if p["found"]) / len(per_pattern)
+    return {
+        "recall": round(recall, 3),
+        "patterns_found": sum(1 for p in per_pattern if p["found"]),
+        "patterns_total": len(per_pattern),
+        "hallucinated": hallucinated,
+        "per_pattern": per_pattern,
+    }
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ground-truth", type=Path, required=True)
+    ap.add_argument("--model-output", type=Path, required=True)
+    args = ap.parse_args()
+
+    gt = json.loads(args.ground_truth.read_text())
+    out = json.loads(args.model_output.read_text())
+    result = score(gt, out)
+    print(json.dumps(result, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rlm_eval/score_llm.py
+++ b/scripts/rlm_eval/score_llm.py
@@ -1,0 +1,198 @@
+"""LLM-based scorer for trial outputs.
+
+The strict scorer (score.py) credits only planted patterns, so it marks
+legitimate analytical observations as "hallucinations." This scorer uses
+`claude -p` as a judge with a rubric + examples to rate each reported pattern
+holistically, and also records recall against the planted patterns.
+
+Output JSON (written to <trial_dir>/score_llm.json):
+  {
+    "planted_recall": {"A": bool, "B": bool, "C": bool, "D": bool, "E": bool, "S": bool},
+    "per_pattern_scores": [{"idx": int, "score": 0|1|2, "reason": str}, ...],
+    "aggregate_score": int,
+    "max_possible": int,
+    "quality_ratio": float
+  }
+
+Scoring per reported pattern:
+  2 = correct planted pattern OR legitimate grounded observation the
+      orchestrator would actually use (gate coverage, per-experiment standout,
+      round-level framing, sub-pattern within a planted one)
+  1 = directionally correct but low value (trivially true, vague, or wrong IDs)
+  0 = invented / hallucinated / wrong about fixture data
+"""
+from __future__ import annotations
+import argparse, json, re, shutil, subprocess, textwrap
+from pathlib import Path
+
+RUBRIC = textwrap.dedent("""
+    You are scoring the output of an evo orchestrator's cross-cutting scan. The
+    orchestrator was asked to look at ~60 synthetic "evaluated experiments"
+    (each with outcome.json and trace files) and report cross-cutting failure
+    patterns.
+
+    You have:
+      1. GROUND TRUTH: the six patterns we deliberately planted in the fixture
+         (A, B, C, D, E, S), each with the exact experiment IDs that carry it.
+      2. MODEL OUTPUT: the list of patterns the model actually reported.
+
+    The fixture plants 6 pattern types:
+      A: shared gate failure (e.g., refund_flow_guard timeout)
+      B: shared zero-score task coupling (e.g., t7 and t12 co-zero)
+      C: intersection of A and B (compound failure)
+      D: semantic root cause in trace content (e.g., varied wording around a
+         single failure like refund-amount parsing)
+      E: wall-pattern hypothesis (same hypothesis repeatedly regresses, e.g.
+         `swap_parser_v2`)
+      S: committed improvers (outcome=committed, candidate parent nodes for
+         next-round branching)
+
+    Your job is two-fold:
+      (a) For each planted pattern (A/B/C/D/E/S), decide if the model found
+          it (true/false). A reported pattern counts as "found" if its
+          signature describes the same phenomenon and its experiment_ids
+          roughly match the planted set.
+      (b) For each reported pattern, give a score 0/1/2.
+
+    ---
+
+    Scoring rubric:
+
+    **2 = real value.** The reported pattern is either:
+      - A correct match to a planted pattern (signature describes the same
+        phenomenon; experiment_ids are largely correct -- small IDs-miss okay),
+      - OR a legitimate analytical observation the orchestrator would use when
+        writing briefs: gate-coverage analysis (e.g., "gate fires but task
+        isn't zero" = over-firing), per-experiment standouts (compound
+        failures), round-level framing (e.g., "most experiments regressed"),
+        sub-patterns within a planted one (e.g., "refund-validation hypotheses
+        among those failing refund gate").
+
+    **1 = directionally OK but low value.** Correctly describes fixture data
+    but either:
+      - trivially true (e.g., "all experiments have a hypothesis string"),
+      - significantly wrong on experiment_ids (e.g., reports 3 IDs for a
+        pattern that actually has 18),
+      - vague enough that the orchestrator can't act on it.
+
+    **0 = hallucinated.** The reported pattern:
+      - isn't grounded in the fixture (invented correlation),
+      - names experiment_ids that don't actually exhibit what's claimed,
+      - or contradicts the planted data.
+
+    ---
+
+    Examples (use these to calibrate your scoring):
+
+    GOOD (score 2):
+      {"signature": "refund_flow_guard gate fails with identical error across 18 experiments",
+       "experiment_ids": [<the 18 IDs planted for A>]}
+      -> 2. Matches planted Pattern A, IDs correct.
+
+      {"signature": "13 experiments fail refund_flow_guard gate despite t7 non-zero -- gate over-firing",
+       "experiment_ids": [<A minus C, the 13 IDs>]}
+      -> 2. Not a planted pattern, but legitimate gate-coverage analysis.
+         Orchestrator should use this when writing the next round's briefs.
+
+      {"signature": "exp_0030 shows compound failure: both smoke-test fails AND t7/t12 co-zero",
+       "experiment_ids": ["exp_0030"]}
+      -> 2. Per-experiment standout. One ID is fine when flagged as a
+         standout rather than a cross-cutting pattern.
+
+      {"signature": "59/60 experiments regressed below baseline of 0.62",
+       "experiment_ids": [<59 IDs>]}
+      -> 2. Round-level framing. Useful context for brief strategy.
+
+    LOW VALUE (score 1):
+      {"signature": "All experiments reuse hypothesis strings from a small pool",
+       "experiment_ids": [<all 60>]}
+      -> 1. True, but not specific enough to act on.
+
+      {"signature": "refund_flow_guard gate fails",
+       "experiment_ids": ["exp_0001", "exp_0002", "exp_0003"]}
+      -> 1. Right pattern, but only names 3 IDs when 18 actually have it.
+         Too partial to be fully useful.
+
+    HALLUCINATED (score 0):
+      {"signature": "Cache eviction causes timeouts across tasks",
+       "experiment_ids": [<random IDs>]}
+      -> 0. No cache-eviction signal in the fixture.
+
+      {"signature": "token_budget overrun correlates with refund tasks",
+       "experiment_ids": [<invented>]}
+      -> 0. No such correlation; the correlation is fabricated.
+
+    ---
+
+    Output JSON ONLY, no prose, this exact shape:
+
+    {
+      "planted_recall": {"A": true|false, "B": true|false, "C": true|false, "D": true|false, "E": true|false, "S": true|false},
+      "per_pattern_scores": [
+        {"idx": 1, "score": 2, "reason": "<short>"},
+        {"idx": 2, "score": 1, "reason": "<short>"},
+        ...
+      ]
+    }
+    """).strip()
+
+def build_prompt(ground_truth: dict, model_output: dict) -> str:
+    return (
+        RUBRIC
+        + "\n\n---\n\nGROUND TRUTH:\n"
+        + json.dumps(ground_truth, indent=2)
+        + "\n\n---\n\nMODEL OUTPUT:\n"
+        + json.dumps(model_output, indent=2)
+    )
+
+def score(ground_truth: dict, model_output: dict) -> dict:
+    claude = shutil.which("claude")
+    if not claude:
+        raise RuntimeError("claude CLI not on PATH")
+    prompt = build_prompt(ground_truth, model_output)
+    proc = subprocess.run(
+        [claude, "-p", "--output-format", "json", prompt],
+        capture_output=True, text=True, timeout=1800,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"judge call failed (rc={proc.returncode}): {proc.stderr[:500]}")
+    envelope = json.loads(proc.stdout)
+    raw = envelope.get("result", "") or ""
+    m = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not m:
+        raise RuntimeError(f"no JSON in judge result: {raw[:500]}")
+    parsed = json.loads(m.group(0))
+
+    # Compute aggregates. Each missed planted pattern counts as an implicit 0/2
+    # so that leaving signal on the table hurts the ratio.
+    per = parsed.get("per_pattern_scores", [])
+    recall = parsed.get("planted_recall", {})
+    missed_planted = [k for k, v in recall.items() if not v]
+    reported = len(per)
+    earned = sum(int(p.get("score", 0)) for p in per)
+    denom = 2 * (reported + len(missed_planted))
+
+    parsed["aggregate_score"] = earned
+    parsed["missed_planted"] = missed_planted
+    parsed["max_possible"] = denom
+    parsed["quality_ratio"] = round(earned / denom, 3) if denom else 0.0
+    parsed["_judge_cost_usd"] = envelope.get("total_cost_usd")
+    parsed["_judge_duration_ms"] = envelope.get("duration_ms")
+    return parsed
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ground-truth", type=Path, required=True)
+    ap.add_argument("--model-output", type=Path, required=True)
+    ap.add_argument("--out", type=Path, help="Write score JSON here")
+    args = ap.parse_args()
+    gt = json.loads(args.ground_truth.read_text())
+    out = json.loads(args.model_output.read_text())
+    result = score(gt, out)
+    s = json.dumps(result, indent=2)
+    print(s)
+    if args.out:
+        args.out.write_text(s)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Ports the RLM cross-cutting-scan rule into the optimize skill -- orchestrators delegate scans to parallel sub-agents instead of reading every trace inline, with a narrow verification-read exception and a required verification step before emitting a pattern.
- Adds `scripts/rlm_eval/`: paired V-vs-R harness (V = frozen pre-port skill, R = live ported skill) with sandbox isolation (macOS Seatbelt / Linux bubblewrap + permission deny rules) so the agent cannot read `ground_truth.json` or prior trials. Matrix over N seeds; CSV carries `variant`, `agent_tool_calls`, `bash_claude_spawns`, `quality_ratio`.
- Two scorers ship side-by-side: `score.py` (strict planted-only) and `score_llm.py` (0/1/2 rubric + `planted_recall` across A/B/C/D/E/S).
- `baseline_SKILL.md` is the frozen pre-port snapshot used as the V floor.

## Test plan

- [ ] `rlm_eval check` passes on a fresh clone
- [ ] V-vs-R matrix run produces expected CSV + score output