### PR TITLE
Resolve score parsing unreliability caused by shared stdout between benchmark logs and score output

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -424,7 +424,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         salvaged_score = None
         salvaged_result = None
         try:
-            trace_files = sorted(traces_dir.glob("*.json"))
+            trace_files = sorted(traces_dir.glob("task_*.json"))
             if trace_files:
                 task_scores = {}
                 for tf in trace_files:
@@ -702,16 +702,16 @@ def cmd_traces(args: argparse.Namespace) -> int:
             print("{}")
         return 0
     traces_dir = attempt_traces_dir(root, args.exp_id, attempt)
-    if args.task:
-        path = traces_dir / f"task_{args.task}.json"
-        print(path.read_text(encoding="utf-8"))
+        if args.task:
+            path = traces_dir / f"task_{args.task}.json"
+            print(path.read_text(encoding="utf-8"))
+            return 0
+        payload = {}
+        if traces_dir.exists():
+            for path in sorted(traces_dir.glob("task_*.json")):
+                payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
+        print(json.dumps(payload, indent=2))
         return 0
-    payload = {}
-    if traces_dir.exists():
-        for path in sorted(traces_dir.glob("*.json")):
-            payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
-    print(json.dumps(payload, indent=2))
-    return 0
 
 
 def cmd_annotate(args: argparse.Namespace) -> int:

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -702,16 +702,16 @@ def cmd_traces(args: argparse.Namespace) -> int:
             print("{}")
         return 0
     traces_dir = attempt_traces_dir(root, args.exp_id, attempt)
-        if args.task:
+    if args.task:
             path = traces_dir / f"task_{args.task}.json"
             print(path.read_text(encoding="utf-8"))
             return 0
-        payload = {}
-        if traces_dir.exists():
-            for path in sorted(traces_dir.glob("task_*.json")):
-                payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
-        print(json.dumps(payload, indent=2))
-        return 0
+    payload = {}
+    if traces_dir.exists():
+        for path in sorted(traces_dir.glob("task_*.json")):
+            payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
+    print(json.dumps(payload, indent=2))
+    return 0
 
 
 def cmd_annotate(args: argparse.Namespace) -> int:

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -319,7 +319,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             benchmark_record = {"command": benchmark_cmd, "returncode": bench.returncode, "result": None}
             raise RuntimeError(f"benchmark_exit_{bench.returncode}")
 
-        score, parsed = parse_score(bench.stdout)
+        score, parsed = parse_score(bench.stdout, traces_dir=str(traces_dir))
         benchmark_record = {"command": benchmark_cmd, "returncode": 0, "result": parsed}
 
         gate_passed = True

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -522,6 +522,21 @@ def fill_command_template(template: str, *, target: Path, worktree: Path) -> str
 
 
 def parse_score(stdout: str) -> tuple[float, dict[str, Any] | None]:
+    # First try to read from the result file in traces directory (more reliable)
+    traces_dir = os.environ.get("EVO_TRACES_DIR")
+    if traces_dir:
+        result_file = Path(traces_dir) / "result.json"
+        if result_file.exists():
+            try:
+                content = result_file.read_text(encoding="utf-8").strip()
+                if content:
+                    parsed = json.loads(content)
+                    if isinstance(parsed, dict) and "score" in parsed:
+                        return float(parsed["score"]), parsed
+            except (json.JSONDecodeError, OSError):
+                pass  # Fall back to parsing stdout
+    
+    # Fall back to original stdout parsing for backward compatibility
     stripped = stdout.strip()
     if not stripped:
         raise ValueError("Benchmark output was empty")

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -521,9 +521,8 @@ def fill_command_template(template: str, *, target: Path, worktree: Path) -> str
     return template.replace("{target}", str(target)).replace("{worktree}", str(worktree))
 
 
-def parse_score(stdout: str) -> tuple[float, dict[str, Any] | None]:
+def parse_score(stdout: str, traces_dir: str | None = None) -> tuple[float, dict[str, Any] | None]:
     # First try to read from the result file in traces directory (more reliable)
-    traces_dir = os.environ.get("EVO_TRACES_DIR")
     if traces_dir:
         result_file = Path(traces_dir) / "result.json"
         if result_file.exists():

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -532,7 +532,7 @@ def parse_score(stdout: str, traces_dir: str | None = None) -> tuple[float, dict
                     parsed = json.loads(content)
                     if isinstance(parsed, dict) and "score" in parsed:
                         return float(parsed["score"]), parsed
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, ValueError, TypeError):
                 pass  # Fall back to parsing stdout
     
     # Fall back to original stdout parsing for backward compatibility

--- a/plugins/evo/src/evo/dashboard.py
+++ b/plugins/evo/src/evo/dashboard.py
@@ -97,12 +97,12 @@ def create_app(root: Path | None = None) -> Flask:
 
     @app.get("/api/node/<exp_id>/traces")
     def node_traces(exp_id: str):
-         traces_dir = experiments_dir_for(_root(), exp_id) / "traces"
-         payload = {}
-         if traces_dir.exists():
-             for path in sorted(traces_dir.glob("task_*.json")):
-                 payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
-         return jsonify(payload)
+        traces_dir = experiments_dir_for(_root(), exp_id) / "traces"
+        payload = {}
+        if traces_dir.exists():
+            for path in sorted(traces_dir.glob("task_*.json")):
+                payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
+        return jsonify(payload)
 
     @app.get("/api/node/<exp_id>/traces/<task_id>")
     def node_task_trace(exp_id: str, task_id: str):

--- a/plugins/evo/src/evo/dashboard.py
+++ b/plugins/evo/src/evo/dashboard.py
@@ -97,12 +97,12 @@ def create_app(root: Path | None = None) -> Flask:
 
     @app.get("/api/node/<exp_id>/traces")
     def node_traces(exp_id: str):
-        traces_dir = experiments_dir_for(_root(), exp_id) / "traces"
-        payload = {}
-        if traces_dir.exists():
-            for path in sorted(traces_dir.glob("*.json")):
-                payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
-        return jsonify(payload)
+         traces_dir = experiments_dir_for(_root(), exp_id) / "traces"
+         payload = {}
+         if traces_dir.exists():
+             for path in sorted(traces_dir.glob("task_*.json")):
+                 payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
+         return jsonify(payload)
 
     @app.get("/api/node/<exp_id>/traces/<task_id>")
     def node_task_trace(exp_id: str, task_id: str):

--- a/sdk/node/src/backend.js
+++ b/sdk/node/src/backend.js
@@ -16,9 +16,14 @@ export class LocalBackend {
     writeFileSync(path, JSON.stringify(trace, null, 2), "utf-8");
   }
 
-  emitResult(result) {
-    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
-  }
+   emitResult(result) {
+     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+     // Also write to traces directory for reliable parsing
+     if (this._tracesDir) {
+       const path = join(this._tracesDir, "result.json");
+       writeFileSync(path, JSON.stringify(result, null, 2), "utf-8");
+     }
+   }
 
   emitGateSummary({ passed, lines }) {
     for (const line of lines) {

--- a/sdk/python/src/evo_agent/_backend.py
+++ b/sdk/python/src/evo_agent/_backend.py
@@ -47,7 +47,12 @@ class LocalBackend:
         path.write_text(json.dumps(trace, indent=2), encoding="utf-8")
 
     def emit_result(self, result: dict[str, Any]) -> None:
+        # Emit to stdout for backward compatibility
         print(json.dumps(result, indent=2), file=self._stdout)
+        # Also emit to traces directory for reliable parsing
+        if self._traces_dir is not None:
+            result_path = self._traces_dir / "result.json"
+            result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
 
     def emit_gate_summary(self, *, passed: bool, lines: list[str]) -> None:
         for line in lines:

--- a/sdk/python/test/test_run.py
+++ b/sdk/python/test/test_run.py
@@ -67,7 +67,7 @@ def test_run_writes_trace_files_and_emits_score_json() -> None:
         assert emitted["score"] == 0.5, emitted
 
         files = sorted(p.name for p in traces_dir.iterdir())
-        assert files == ["task_0.json", "task_1.json"], files
+        assert set(files) == {"task_0.json", "task_1.json", "result.json"}, files
 
         t0 = json.loads((traces_dir / "task_0.json").read_text())
         assert t0["experiment_id"] == "exp-123"


### PR DESCRIPTION
Closes #9 
## Changes

1. SDK Backend  
**File:** `sdk/python/src/evo_agent/_backend.py`  
- Modified `LocalBackend.emit_result()` to write the result JSON to `EVO_TRACES_DIR/result.json` in addition to printing to stdout.  
- Provides a dedicated, log-free location for machine-readable score data while maintaining stdout compatibility.  

2. Score Parser  
**File:** `plugins/evo/src/evo/core.py`  
* Enhanced `parse_score()` to first check for `EVO_TRACES_DIR/result.json` (if `EVO_TRACES_DIR` is set).  
* Uses file-based score when available and valid, falling back to original stdout parsing for backward compatibility.  
* Eliminates interference from: Progress logs, `score`: pattern in logs, Post-finish prints

3. Test Update  
**File:** `sdk/python/test/test_run.py`  
- Adjusted test expectation to verify the new `result.json` file appears in the traces directory alongside task files.  


## Impact

- Benchmarks can now safely output logs/debug to stdout without corrupting score extraction.  
- Fixes `"Benchmark output was empty"` errors when benchmarks redirect stdout before Run initialization.  
- Preserves all existing workflows and integrations while adding robustness.  