### PR TITLE
0.3.1: fix frontier infra-event schema mismatch

### DIFF
--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/plugins/evo/src/evo/frontier_strategies.py
+++ b/plugins/evo/src/evo/frontier_strategies.py
@@ -416,9 +416,11 @@ def append_frontier_log(root: Path, strategy: dict[str, Any],
                         returned_ids: list[str], seed: int | None = None) -> dict[str, Any]:
     """Append a frontier-selection event to .evo/infra_log.json."""
     path = infra_path(root)
+    seed_str = f" seed={seed}" if seed is not None else ""
     event = {
         "kind": "frontier",
-        "at": utc_now(),
+        "timestamp": utc_now(),
+        "message": f"frontier({strategy.get('kind', '?')}) -> {len(returned_ids)} id(s){seed_str}",
         "strategy": strategy,
         "returned_ids": returned_ids,
     }

--- a/plugins/evo/src/evo/scratchpad.py
+++ b/plugins/evo/src/evo/scratchpad.py
@@ -211,7 +211,12 @@ def build_scratchpad(root: Path) -> str:
     if infra:
         for event in infra[-8:]:
             suffix = " (breaking)" if event.get("breaking") else ""
-            lines.append(f"- {event['timestamp']}: {event['message']}{suffix}")
+            # 0.3.0 frontier events shipped with key "at" and no "message"
+            # (#22). Read tolerantly so workspaces upgrading to >=0.3.1 don't
+            # KeyError on the pre-existing bad events still in their log.
+            ts = event.get("timestamp") or event.get("at") or "?"
+            msg = event.get("message") or f"{event.get('kind', '?')} event"
+            lines.append(f"- {ts}: {msg}{suffix}")
     else:
         lines.append("- No infrastructure events yet.")
 

--- a/plugins/evo/tests/test_frontier_strategies.py
+++ b/plugins/evo/tests/test_frontier_strategies.py
@@ -336,6 +336,30 @@ class TestLogging(unittest.TestCase):
             text = build_scratchpad(root)
             self.assertIn("frontier(softmax)", text)
 
+    def test_scratchpad_tolerates_legacy_frontier_event(self):
+        # Regression for #22: a workspace that ran `evo frontier` on 0.3.0
+        # has events with key "at" and no "message". build_scratchpad must
+        # render those events instead of KeyError'ing on upgrade.
+        from evo.core import default_graph
+        from evo.scratchpad import build_scratchpad
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / ".evo").mkdir()
+            (root / ".evo" / "meta.json").write_text(json.dumps({"active": None, "next_run": 0}))
+            (root / ".evo" / "config.json").write_text(json.dumps({"metric": "max"}))
+            (root / ".evo" / "graph.json").write_text(json.dumps(default_graph()))
+            (root / ".evo" / "annotations.json").write_text(json.dumps({"annotations": []}))
+            legacy = {
+                "kind": "frontier",
+                "at": "2026-04-26T11:00:00Z",
+                "strategy": {"kind": "argmax"},
+                "returned_ids": ["exp_A"],
+            }
+            (root / ".evo" / "infra_log.json").write_text(json.dumps({"events": [legacy]}))
+            text = build_scratchpad(root)
+            self.assertIn("2026-04-26T11:00:00Z", text)
+            self.assertIn("frontier event", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/evo/tests/test_frontier_strategies.py
+++ b/plugins/evo/tests/test_frontier_strategies.py
@@ -306,6 +306,36 @@ class TestLogging(unittest.TestCase):
             self.assertNotIn("seed", ev1)
             self.assertEqual(ev2["seed"], 42)
 
+    def test_event_matches_canonical_infra_schema(self):
+        # Regression for #22: scratchpad reads event['timestamp'] and
+        # event['message']; frontier events used to write 'at' and no
+        # message, KeyError'ing every downstream consumer.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / ".evo").mkdir()
+            (root / ".evo" / "meta.json").write_text(json.dumps({"active": None, "next_run": 0}))
+            (root / ".evo" / "config.json").write_text(json.dumps({}))
+            ev = fs.append_frontier_log(root, {"kind": "argmax", "params": {}}, ["exp_A"], seed=7)
+            self.assertIn("timestamp", ev)
+            self.assertIn("message", ev)
+            self.assertNotIn("at", ev)
+
+    def test_scratchpad_renders_after_frontier_log(self):
+        # Regression for #22: build_scratchpad must not KeyError on a
+        # frontier event in infra_log.json.
+        from evo.core import default_graph
+        from evo.scratchpad import build_scratchpad
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / ".evo").mkdir()
+            (root / ".evo" / "meta.json").write_text(json.dumps({"active": None, "next_run": 0}))
+            (root / ".evo" / "config.json").write_text(json.dumps({"metric": "max"}))
+            (root / ".evo" / "graph.json").write_text(json.dumps(default_graph()))
+            (root / ".evo" / "annotations.json").write_text(json.dumps({"annotations": []}))
+            fs.append_frontier_log(root, {"kind": "softmax", "params": {"temperature": 1, "k": 1}}, ["exp_A"], seed=7)
+            text = build_scratchpad(root)
+            self.assertIn("frontier(softmax)", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.3.0"
+version = "0.3.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
Fixes #22, where `append_frontier_log` (`plugins/evo/src/evo/frontier_strategies.py:421`) wrote events with key `"at"` while the rest of the infra-log path (`core.py:380/394`, `cli.py:540/1192`, `scratchpad.py:214`) uses `"timestamp"`. Calling `evo frontier` once left `infra_log.json` in a state that KeyError'd `evo scratchpad`, `evo discard`, and the commit phase of `evo run` -- even on otherwise successful runs.

Frontier events also lacked the `"message"` field that `scratchpad.py:214` reads, so renaming the key alone would not have rendered. Both fields now match the canonical infra-event shape (`{timestamp, message, ...}`) used by `core.append_infra_event`, with message formatted as `frontier(<kind>) -> N id(s)[ seed=K]`.

Existing tests asserted `kind`, `returned_ids`, `strategy`, `seed` but never the timestamp key or the integration with `build_scratchpad` -- which is how the schema drift slipped through. Two regression tests added:

- `test_event_matches_canonical_infra_schema` asserts the event dict carries `timestamp` + `message` and never `at`.
- `test_scratchpad_renders_after_frontier_log` calls `build_scratchpad` after `append_frontier_log` and asserts the rendered text contains the new message format.

Bumps all 7 lockstep version sources to 0.3.1 (CLI + plugin manifests + Python SDK + Node SDK).

## Test plan

- [x] `python3 scripts/check_versions.py` -> all 7 sources at 0.3.1
- [x] `uv run --project plugins/evo python -m unittest plugins.evo.tests.test_frontier_strategies.TestLogging` -> 4/4 pass (2 new + 2 pre-existing)
- [ ] CI matrix green on this PR