### PR TITLE
release-infra: pre-release npm dist-tag + version-check regex

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,17 @@ jobs:
         working-directory: sdk/node
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+        run: |
+          # Pre-release semver (e.g. 0.4.0-alpha.1, 0.4.0-rc.1) ships under
+          # the `alpha` dist-tag. Without this, `npm publish` would update
+          # `latest`, and existing stable users running `npm install
+          # @evo-hq/evo-agent` would silently get the pre-release.
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q '-'; then
+            npm publish --tag alpha
+          else
+            npm publish
+          fi
 
   publish-cli:
     if: |

--- a/plugins/evo/bin/evo-version-check
+++ b/plugins/evo/bin/evo-version-check
@@ -41,9 +41,14 @@ if ! command -v evo >/dev/null 2>&1; then
 fi
 
 CLI_OUTPUT=$(evo --version 2>/dev/null || true)
+# Capture the version token after `evo-hq-cli`. The previous regex matched
+# only `N.N.N`, which silently dropped pre-release suffixes (e.g.
+# `0.4.0-alpha.1` was captured as `0.4.0`) and produced a spurious mismatch
+# against the plugin manifest. Allow any non-whitespace string so semver
+# pre-releases and PEP 440 forms (`0.4.0a1`) both match.
 CLI_VERSION=$(
     printf '%s\n' "$CLI_OUTPUT" \
-    | grep -oE 'evo-hq-cli[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' \
+    | grep -oE 'evo-hq-cli[[:space:]]+[^[:space:]]+' \
     | awk '{print $2}' \
     | head -1
 )


### PR DESCRIPTION
Two release-infrastructure fixes needed before any pre-release tag (e.g. `0.4.0-alpha.1`) can ship safely.

## 1. Pre-release npm publishes go to `--tag alpha`, not `latest`

The publish workflow ran `npm publish` without `--tag`, which always updates the `latest` dist-tag regardless of semver pre-release suffix. A `0.4.0-alpha.1` publish would have made `npm install @evo-hq/evo-agent` (no version) silently return the alpha to every existing stable user.

After this PR:

- `npm install @evo-hq/evo-agent` → latest stable
- `npm install @evo-hq/evo-agent@alpha` → most recent alpha
- `npm install @evo-hq/evo-agent@0.4.0-alpha.1` → that specific version

PyPI doesn't need a corresponding change. PEP 440 marks `0.4.0a1` as a pre-release and `pip install` / `uv tool install` skip pre-releases by default.

## 2. `evo-version-check` handles pre-release version strings

The CLI-version regex stopped at `N.N.N`, so `evo-hq-cli 0.4.0-alpha.1` was captured as `0.4.0` and string-compared against a plugin manifest carrying `0.4.0-alpha.1`. The script always exit-1'd for any pre-release, blocking the discover skill's step 0 for any alpha user.

Loosened to capture any non-whitespace token after `evo-hq-cli`. Spot-checked across `0.4.0`, `0.4.0-alpha.1`, `0.4.0a1`, and a padded form.

## Why both in one PR

Same pre-release-readiness scope, same branch target. Cutting a `0.4.0-alpha.1` tag without either fix would either push to stable users (npm) or fail at discover step 0 (version-check). Both must land before the alpha.