### PR TITLE
0.3.3: Pareto-per-task as default, dominance aligned with GEPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ You give it a codebase. It discovers metrics to optimize, sets up the evaluation
 Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) -- where an LLM runs training experiments autonomously to beat its own best score. Autoresearch is a pure hill climb: try something, keep or revert, repeat on a single branch. Evo adds structure on top of that idea:
 
 - **Tree search over greedy hill climb.** Multiple directions can fork from any committed node, so exploration doesn't collapse to one path.
+- **Configurable frontier selection.** Argmax, top-K, ε-greedy, softmax, or [GEPA](https://arxiv.org/abs/2507.19457)-inspired Pareto-per-task. Configure from the dashboard to suit your task.
 - **Parallel semi-autonomous agents.** Spawn multiple subagents and run them simultaneously, each in its own git worktree. Each subagent reads traces, formulates hypotheses, and can run multiple iterations within its branch.
+- **Cross-cutting scans.** Each round the orchestrator fans out [RLM](https://arxiv.org/abs/2512.24601)-inspired scan sub-agents to read trace batches in parallel and report compound failure patterns -- gate-failure intersections, semantic root causes -- before writing the next round of briefs.
 - **Shared state.** Failure traces, annotations, and discarded hypotheses are accessible to every agent before it decides what to try next.
 - **Gating.** Regression tests or safety checks can be wired up as a gate. Experiments that don't pass get discarded.
 - **Observability.** A dashboard to monitor your experiments.
@@ -105,7 +107,7 @@ Under the hood, each experiment gets its own git worktree branching from its par
 
 ```
 Orchestrator (main agent)
-  - reads state, identifies failure patterns cross-cutting the tree
+  - reads state, fans out scan sub-agents to find cross-cutting failure patterns
   - writes a structured brief per subagent (objective, parent, boundaries, pointer traces)
   - collects results, prunes dead branches, adjusts strategy for next round
 

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.3.2"
+version = "0.3.3"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/plugins/evo/src/evo/frontier_strategies.py
+++ b/plugins/evo/src/evo/frontier_strategies.py
@@ -104,7 +104,9 @@ FRONTIER_STRATEGIES: dict[str, dict[str, Any]] = {
             "Preserves specialists the aggregate score would hide. Algorithm:\n\n"
             "1. For each task, find the top score across all frontier candidates.\n"
             "2. Collect candidates that tie for best on at least one task.\n"
-            "3. Drop any candidate weakly dominated by another on every task it wins.\n"
+            "3. Iteratively drop any candidate whose every winning front is also "
+            "won by another surviving candidate (set-cover dominance, lowest "
+            "aggregate score first).\n"
             "4. Sample K from the survivors with probability proportional to how "
             "many tasks each candidate is the best on.\n\n"
             "Honors `tasks_meta[task_id].direction` when the benchmark emits it "
@@ -112,9 +114,10 @@ FRONTIER_STRATEGIES: dict[str, dict[str, Any]] = {
             "back to the workspace-level `--metric` when a task has no direction.\n\n"
             "Intersects task keys across outcomes — a task only counts if every "
             "considered candidate reported it. Handles benchmark drift cleanly.\n\n"
-            "Inspired by GEPA (Agrawal et al., arXiv:2507.19457), specifically its "
-            "selection step. The genetic mutation + reflective LLM parts of GEPA "
-            "live elsewhere in evo's tree-search loop."
+            "Ports the candidate-selection algorithm from GEPA (Agrawal et al., "
+            "arXiv:2507.19457; gepa-ai/gepa src/gepa/gepa_utils.py). The genetic "
+            "mutation + reflective LLM parts of GEPA live elsewhere in evo's "
+            "tree-search loop."
         ),
         "params": [
             {"name": "k", "type": "int", "min": 1, "max": 50, "default": 5, "label": "Samples",
@@ -312,33 +315,17 @@ def _pick_pareto_per_task(nodes: list[dict], params: dict, metric: str,
         # Nothing to Pareto over (no tasks, or all below floor). Fall back to argmax.
         return _pick_argmax(nodes, {}, metric, outcomes, rng)
 
-    # Survivor set = union of per-task winners.
-    survivors: set[str] = set().union(*winners.values())
+    # GEPA-style dominance prune: drop y if for every front y is in, another
+    # surviving program also wins that front (set-cover semantics over per-task
+    # winning sets). Iterative -- removing one program can unblock removal of
+    # others. See gepa-ai/gepa src/gepa/gepa_utils.py: remove_dominated_programs.
+    aggregate = {n["id"]: _score_of(n, metric) for n in nodes}
+    survivors = _remove_dominated_set_cover(winners, aggregate)
 
-    # Dominance prune: drop A if some other B >= A on every task where A wins.
-    to_drop: set[str] = set()
-    for a in list(survivors):
-        a_winning_tasks = [t for t, w in winners.items() if a in w]
-        for b in survivors:
-            if a == b or b in to_drop:
-                continue
-            # b dominates a iff for every task where a wins, b's score >= a's score.
-            dominates = True
-            for t in a_winning_tasks:
-                bs = task_scores[b].get(t, float("-inf"))
-                as_ = task_scores[a].get(t, float("-inf"))
-                if bs < as_:
-                    dominates = False
-                    break
-            if dominates and any(
-                task_scores[b].get(t, float("-inf")) > task_scores[a].get(t, float("-inf"))
-                for t in a_winning_tasks
-            ):
-                to_drop.add(a)
-                break
-    survivors -= to_drop
+    if not survivors:
+        return _pick_argmax(nodes, {}, metric, outcomes, rng)
 
-    # Frequency weights.
+    # Frequency weights: number of fronts (tasks) each survivor wins.
     freq: dict[str, int] = {s: 0 for s in survivors}
     for w in winners.values():
         for s in w & survivors:
@@ -348,6 +335,43 @@ def _pick_pareto_per_task(nodes: list[dict], params: dict, metric: str,
     weights = [freq[n["id"]] for n in survivor_nodes]
     k = min(k, len(survivor_nodes))
     return _weighted_sample_without_replacement(survivor_nodes, weights, k, rng)
+
+
+def _is_dominated_by_cover(y: str, remaining: set[str],
+                            winners: dict[str, set[str]]) -> bool:
+    """y is dominated iff for every front y is in, some program in `remaining`
+    is also in that front."""
+    for front in winners.values():
+        if y not in front:
+            continue
+        if not any(other in remaining for other in front if other != y):
+            return False
+    return True
+
+
+def _remove_dominated_set_cover(winners: dict[str, set[str]],
+                                 aggregate: dict[str, float]) -> set[str]:
+    """Iteratively prune dominated programs, lowest aggregate score first.
+
+    Mirrors `remove_dominated_programs` in gepa-ai/gepa src/gepa/gepa_utils.py.
+    """
+    initial = set().union(*winners.values()) if winners else set()
+    if not initial:
+        return set()
+    ordered = sorted(initial, key=lambda p: aggregate.get(p, float("-inf")))
+    dominated: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for y in ordered:
+            if y in dominated:
+                continue
+            remaining = set(ordered) - {y} - dominated
+            if _is_dominated_by_cover(y, remaining, winners):
+                dominated.add(y)
+                changed = True
+                break
+    return set(ordered) - dominated
 
 
 PICKERS: dict[str, Callable[[list, dict, str, dict, random.Random], list[dict]]] = {

--- a/plugins/evo/src/evo/frontier_strategies.py
+++ b/plugins/evo/src/evo/frontier_strategies.py
@@ -134,7 +134,10 @@ FRONTIER_STRATEGIES: dict[str, dict[str, Any]] = {
     },
 }
 
-DEFAULT_FRONTIER_STRATEGY: dict[str, Any] = {"kind": "argmax", "params": {}}
+DEFAULT_FRONTIER_STRATEGY: dict[str, Any] = {
+    "kind": "pareto_per_task",
+    "params": {"k": 5, "task_floor": 0.0},
+}
 
 
 # --------------------------------------------------------------------------- #

--- a/plugins/evo/tests/test_frontier_strategies.py
+++ b/plugins/evo/tests/test_frontier_strategies.py
@@ -185,6 +185,20 @@ class TestParetoPerTask(unittest.TestCase):
         # dominates the other, so both land in the sample.
         self.assertEqual(picked, {"exp_A", "exp_B"})
 
+    def test_set_cover_dominance_drops_tied_subset_winner(self):
+        # A wins {t1} alone. B ties A on t1 AND wins t2 alone. Under set-cover
+        # dominance (GEPA semantics), every front A appears in (just t1) is
+        # also covered by B, so A is dominated and dropped. Score-vector
+        # dominance would keep A because B does not strictly beat A on t1.
+        outcomes = {
+            "exp_A": {"benchmark": {"result": {"tasks": {"t1": 0.9, "t2": 0.4}}}},
+            "exp_B": {"benchmark": {"result": {"tasks": {"t1": 0.9, "t2": 0.9}}}},
+        }
+        out, _ = fs.pick(NODES[:2], {"kind": "pareto_per_task", "params": {"k": 2, "task_floor": 0.0}},
+                         "max", outcomes=outcomes, seed=1)
+        picked = {n["id"] for n in out}
+        self.assertEqual(picked, {"exp_B"})
+
     def test_intersection_of_task_keys_when_drifting(self):
         # A and B agree on t1, t2; B also has t3 that A doesn't. Only the
         # intersection (t1, t2) should drive the Pareto front, so t3 doesn't

--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.3.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.3.2"
+version = "0.3.3"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
0.3.3. Flips the default `frontier_strategy` on new workspaces from `argmax` to `pareto_per_task`, and ports the dominance check in `pareto_per_task` to match GEPA's reference implementation.

## Frontier dominance

`_pick_pareto_per_task` was using score-vector dominance with a strict-inequality requirement, so a candidate that tied on its only winning task was kept. The [GEPA reference](https://github.com/gepa-ai/gepa/blob/main/src/gepa/gepa_utils.py) (`remove_dominated_programs`) uses set-cover dominance: drop y if for every front y is in, some other surviving program also wins that front.

Pruning is iterative now (lowest aggregate score first). The single-pass form could leave dominated programs in when removing one would have unblocked removal of another.

`test_set_cover_dominance_drops_tied_subset_winner` pins the divergence.

## Default flip

`DEFAULT_FRONTIER_STRATEGY` is now `pareto_per_task` with `k=5`, `task_floor=0.0`. Argmax was the placeholder from 641813a -- it returns one node, which collapses parallel rounds onto a single parent unless the orchestrator pulls extras from the structural pass's improvers list. GEPA itself ships its analogous Pareto sampler as the [default candidate selector](https://github.com/gepa-ai/gepa/blob/main/src/gepa/api.py) (`candidate_selection_strategy='pareto'`).

Existing workspaces keep `argmax` in `.evo/config.json` and stay on the old default until reconfigured via the dashboard or `evo frontier --strategy ...`. New `evo init` calls inherit `pareto_per_task`.

## README

Two bullets surface 0.3.x features the README hadn't mentioned: configurable frontier selection (argmax, top-K, ε-greedy, softmax, GEPA-inspired Pareto-per-task) and cross-cutting scans (RLM-inspired scan sub-agent fan-out). Architecture block now lists the scan sub-agents in the orchestrator step.

## Test plan

- `pytest tests/test_frontier_strategies.py` -- 31 passed including the new tied-subset case
- `python3 scripts/check_versions.py` -- all 7 sources at 0.3.3
- CI seven-way version match
- Dashboard picker round-trips the new default on a fresh `evo init`
