### PR TITLE
v0.4.2-alpha.1: add pi.dev as a host

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Pass `optimize` parameters as `key=value` after the skill name:
 | `budget` | 5 | Max iterations each subagent can run within its branch |
 | `stall` | 5 | Consecutive rounds with no improvement before auto-stopping |
 
-Invocation syntax is host-specific: `/evo:` on Claude Code, `$evo` on Codex, natural language on Hermes, Opencode, and OpenClaw.
+Invocation syntax is host-specific: `/evo:` on Claude Code, `$evo` on Codex, natural language on Hermes, Opencode, OpenClaw, and Pi.
 
 ## Install
 
@@ -66,10 +66,10 @@ Invocation syntax is host-specific: `/evo:` on Claude Code, `$evo` on Codex, nat
 uv tool install evo-hq-cli
 
 # 2. Host CLI (if you don't already have it)
-npm install -g @anthropic-ai/claude-code     # or @openai/codex, openclaw
+npm install -g @anthropic-ai/claude-code     # or @openai/codex, openclaw, @earendil-works/pi-coding-agent
 
 # 3. Plugin + host hooks
-evo install <host>     # claude-code | codex | hermes | opencode | openclaw
+evo install <host>     # claude-code | codex | hermes | opencode | openclaw | pi
 ```
 
 `evo install <host>` installs the plugin into the host's marketplace and stages the hooks evo needs to talk to in-flight subagents. Verify with `evo doctor <host>`.
@@ -142,7 +142,7 @@ uv run --project /path/to/evo/plugins/evo evo dashboard --port 8080
 ## Upgrading
 
 ```bash
-evo update <host>                    # host: claude-code | codex | hermes | opencode | openclaw
+evo update <host>                    # host: claude-code | codex | hermes | opencode | openclaw | pi
 evo update <host> --version 0.4.1    # pin to a release
 ```
 

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.4.1"
+version = "0.4.2-alpha.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.4.1"
+__version__ = "0.4.2-alpha.1"

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -28,6 +28,7 @@ SUPPORTED_HOSTS = frozenset({
     "opencode",
     "openclaw",
     "hermes",
+    "pi",
     "generic",
 })
 

--- a/plugins/evo/src/evo/host_install/__init__.py
+++ b/plugins/evo/src/evo/host_install/__init__.py
@@ -14,7 +14,7 @@ See notes/cross-host-inject-design.md.
 
 from __future__ import annotations
 
-from . import claude_code, codex, hermes, opencode, openclaw
+from . import claude_code, codex, hermes, opencode, openclaw, pi
 
 ADAPTERS = {
     "claude-code": claude_code,
@@ -22,6 +22,7 @@ ADAPTERS = {
     "hermes": hermes,
     "opencode": opencode,
     "openclaw": openclaw,
+    "pi": pi,
 }
 
 # Single source of truth for host names. CLI argparse choices and

--- a/plugins/evo/src/evo/host_install/opencode.py
+++ b/plugins/evo/src/evo/host_install/opencode.py
@@ -1,18 +1,30 @@
 """Opencode plugin install — drop the bundled JS plugin into opencode's
-auto-discovery directory.
+auto-discovery directory, plus install the evo skills via the
+cross-host ``npx skills add`` so users don't have to run a second
+command.
 
 Opencode discovers plugins from `~/.config/opencode/plugins/*.{ts,js}`
 automatically at startup. We ship a pre-bundled `evo.js` (built via
 `bun build` from `evo/opencode_plugin/index.ts`).
+
+Skills come from the github.com/evo-hq/evo repo at install time — pinned
+to ``--version`` when set (recommended for release-tagged installs).
+Local-source mode (``--from-path``) passes a filesystem path through.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
+
+# Same shape claude_code._RELEASE_VERSION_RE uses to decide whether to
+# auto-prefix with `v` for the GitHub tag URL.
+_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
 
 
 def _opencode_plugins_dir(workspace: bool = False) -> Path:
@@ -28,6 +40,48 @@ def _bundled_plugin_source() -> Path | None:
     here = Path(__file__).resolve().parent.parent  # evo/
     bundle = here / "opencode_plugin" / "evo.bundle.js"
     return bundle if bundle.exists() else None
+
+
+def _skills_source(from_path: str | None, version: str | None) -> str:
+    """Source spec for ``npx skills add``.
+
+    Local-source: passes the filesystem path through verbatim (used by
+    live tests + manual installs from a clone).
+
+    Tagged release: ``https://github.com/evo-hq/evo.git#v<version>`` —
+    npx skills's ``owner/repo@<ref>`` form treats ``<ref>`` as a
+    skill-name filter, not a git ref, so all-skills-from-a-tag needs
+    the URL form.
+
+    Default: ``evo-hq/evo`` (default branch).
+    """
+    if from_path:
+        return from_path
+    if version:
+        ref = f"v{version}" if _RELEASE_VERSION_RE.match(version) else version
+        return f"https://github.com/evo-hq/evo.git#{ref}"
+    return "evo-hq/evo"
+
+
+def _install_skills(source: str) -> None:
+    """Run ``npx -y skills add <source> --agent opencode -g -y``.
+
+    Skips with a warning when npx isn't on PATH. Skills land under
+    ``~/.agents/skills/`` (the cross-host convention), which opencode
+    auto-discovers along with ``~/.config/opencode/skills/``.
+    """
+    npx = shutil.which("npx")
+    if npx is None:
+        print(
+            "WARNING: `npx` not on PATH; skipping skill install.\n"
+            "  Install Node 22+ (https://nodejs.org), then re-run "
+            "`evo install opencode`.",
+            file=sys.stderr,
+        )
+        return
+    cmd = [npx, "-y", "skills", "add", source, "--agent", "opencode", "-g", "-y"]
+    print(f"$ {' '.join(cmd)}")
+    subprocess.call(cmd)
 
 
 def install(args: argparse.Namespace) -> int:
@@ -47,10 +101,22 @@ def install(args: argparse.Namespace) -> int:
 
     shutil.copyfile(src, target)
     print(f"installed evo plugin: {target}")
+
+    # Install skills via the cross-host npx skills CLI. Source resolution:
+    # --from-path takes precedence, --version tag-pins, otherwise default
+    # branch. Skills are always installed globally (-g); --workspace only
+    # affects the JS plugin location.
+    source = _skills_source(
+        getattr(args, "from_path", None),
+        getattr(args, "version", None),
+    )
+    print(f"\nInstalling evo skills via npx skills add (source: {source}) ...")
+    _install_skills(source)
+
     if workspace:
-        print("Workspace-local install. Restart `opencode` in this directory to load it.")
+        print("\nWorkspace-local install. Restart `opencode` in this directory to load it.")
     else:
-        print("Global install. Any opencode session will auto-load the plugin at startup.")
+        print("\nGlobal install. Any opencode session will auto-load the plugin at startup.")
     return 0
 
 

--- a/plugins/evo/src/evo/host_install/pi.py
+++ b/plugins/evo/src/evo/host_install/pi.py
@@ -23,12 +23,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
+import tarfile
+import tempfile
+import urllib.request
 from pathlib import Path
 
 
 _SKILLS = ("discover", "optimize", "subagent", "infra-setup")
+
+# Same shape claude_code._RELEASE_VERSION_RE uses to decide whether to
+# auto-prefix with `v` for the GitHub tag URL. Branches/SHAs pass through.
+_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
 
 
 def _pi_base() -> Path:
@@ -60,7 +68,7 @@ def _bundled_extension_source() -> Path | None:
     return bundle if bundle.exists() else None
 
 
-def _skills_source_root(from_path: str | None = None) -> Path:
+def _skills_source_root(from_path: str | None, version: str | None) -> Path | None:
     """Locate the plugins/evo/skills/ source dir.
 
     Resolution order:
@@ -69,21 +77,88 @@ def _skills_source_root(from_path: str | None = None) -> Path:
          ``plugins/evo/skills/``.
       2. Development checkout via ``__file__`` walk — works when running
          against ``plugins/evo/src/`` directly.
+      3. GitHub tarball — for PyPI users, fetch the evo-hq/evo source
+         at the given ref (``--version`` if set, else default branch),
+         extract to a temp dir, and return the skills/ inside. Caller
+         is responsible for cleaning up the returned tree.
 
-    Wheel-installed users have no local skills/ dir and need to fetch
-    skills separately (same situation as hermes/opencode today). The
-    install command logs a warning and continues with the extension
-    install in that case.
+    Returns None only if every path failed (e.g. download error).
     """
     if from_path:
         base = Path(from_path)
-        # Two layouts: full repo tarball (parent of plugins/evo) OR a
-        # bare plugin checkout (already at plugins/evo).
         for candidate in (base / "plugins" / "evo" / "skills", base / "skills"):
             if candidate.exists():
                 return candidate
-    # __file__ = .../plugins/evo/src/evo/host_install/pi.py
-    return Path(__file__).resolve().parents[3] / "skills"
+
+    # __file__ = .../plugins/evo/src/evo/host_install/pi.py — present in
+    # a dev checkout, missing from a wheel install.
+    dev = Path(__file__).resolve().parents[3] / "skills"
+    if dev.exists():
+        return dev
+
+    return _fetch_skills_from_github(version)
+
+
+def _fetch_skills_from_github(version: str | None) -> Path | None:
+    """Download the evo-hq/evo source tarball at the given ref and
+    return the path to its plugins/evo/skills/ dir. Extracts into a
+    persistent location under the user's cache dir so repeat
+    `evo install pi` doesn't re-download.
+
+    `version` is the ``--version`` arg. Release-version shape gets
+    auto-prefixed with `v` (repo tag convention); any other shape
+    (branch, sha) passes through.
+    """
+    if version:
+        ref = f"v{version}" if _RELEASE_VERSION_RE.match(version) else version
+    else:
+        # Default branch — match what `evo install claude-code` does
+        # without --version (the host marketplace clones main).
+        ref = "main"
+    url = f"https://github.com/evo-hq/evo/archive/refs/heads/{ref}.tar.gz"
+    if ref != "main":
+        # Tags live under refs/tags. Try tag URL first; if the ref is a
+        # branch the heads URL handles it. Falling back to heads on 404
+        # would mask real misconfig, so we just use tags for ref != main.
+        url = f"https://github.com/evo-hq/evo/archive/refs/tags/{ref}.tar.gz"
+
+    cache_dir = Path.home() / ".cache" / "evo-hq-cli" / "github-src" / ref
+    skills = cache_dir / "skills"
+    if skills.exists():
+        print(f"  using cached evo source at {cache_dir}")
+        return skills
+
+    print(f"  downloading evo source from {url}")
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
+            urllib.request.urlretrieve(url, tmp.name)
+            tarball = Path(tmp.name)
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        print(f"WARNING: could not fetch {url}: HTTP {exc.code}", file=sys.stderr)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARNING: could not fetch {url}: {exc}", file=sys.stderr)
+        return None
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="evo-pi-src-") as extract_root:
+            with tarfile.open(tarball) as tf:
+                tf.extractall(extract_root)
+            # GitHub tarballs extract as `<repo>-<ref>/...`.
+            entries = [p for p in Path(extract_root).iterdir() if p.is_dir()]
+            if not entries:
+                print(f"WARNING: extracted tarball has no top-level dir", file=sys.stderr)
+                return None
+            src_skills = entries[0] / "plugins" / "evo" / "skills"
+            if not src_skills.exists():
+                print(f"WARNING: no plugins/evo/skills/ inside fetched tarball "
+                      f"({entries[0].name})", file=sys.stderr)
+                return None
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src_skills, skills, dirs_exist_ok=True)
+    finally:
+        tarball.unlink(missing_ok=True)
+    return skills
 
 
 def _update_settings_extensions(settings: Path, target: str) -> bool:
@@ -106,16 +181,17 @@ def _update_settings_extensions(settings: Path, target: str) -> bool:
     return True
 
 
-def _install_skills(from_path: str | None = None) -> int:
+def _install_skills(from_path: str | None = None, version: str | None = None) -> int:
     """Copy each evo skill into ~/.pi/agent/skills/evo-<name>/.
 
     Pi auto-discovers any directory under skills/ that contains a
     SKILL.md. Namespacing the dirs as `evo-<name>` avoids colliding
     with non-evo skills the user already has.
     """
-    src_root = _skills_source_root(from_path)
-    if not src_root.exists():
-        print(f"WARNING: evo skills source not found at {src_root}; "
+    src_root = _skills_source_root(from_path, version)
+    if src_root is None or not src_root.exists():
+        print(f"WARNING: could not resolve evo skills source "
+              f"(from_path={from_path}, version={version}); "
               f"skipping skill install", file=sys.stderr)
         return 0
     dest_root = _pi_skills_dir()
@@ -168,7 +244,10 @@ def install(args: argparse.Namespace) -> int:
         print(f"{target} already in extensions in {settings}")
 
     print("\nInstalling evo skills under ~/.pi/agent/skills/evo-*/ ...")
-    _install_skills(getattr(args, "from_path", None))
+    _install_skills(
+        getattr(args, "from_path", None),
+        getattr(args, "version", None),
+    )
 
     print("\nRestart any running pi session to load the extension and skills.")
     return 0

--- a/plugins/evo/src/evo/host_install/pi.py
+++ b/plugins/evo/src/evo/host_install/pi.py
@@ -1,0 +1,250 @@
+"""Pi install — drop the bundled JS extension into ~/.pi/agent/extensions/evo/,
+register it in ~/.pi/agent/settings.json#extensions[], and copy the four
+evo skills under ~/.pi/agent/skills/evo-<name>/.
+
+Pi (pi.dev, ``@earendil-works/pi-coding-agent``) is the upstream agent
+SDK that OpenClaw embeds. Pi's ExtensionAPI is the surface OpenClaw
+exposes, so the bundled extension at ``evo/openclaw_plugin/evo.bundle.js``
+loads cleanly on pi. We point at it directly rather than maintain a
+duplicate bundle: same source, two install adapters.
+
+Differs from the openclaw adapter in three deliberate omissions:
+  1. No ``plugins.allow`` trust grants — pi has no per-plugin trust gate.
+  2. No openclaw-native ``tool_result_persist`` plugin — that hook is
+     openclaw-only. ``before_provider_request`` (used by the bundle) still
+     fires on pi 0.75.3 (verified by live probe at trials/pi-probe/).
+  3. No ``pi install <source>`` marketplace call for the skills — we
+     copy SKILL.md files directly. The pi marketplace path is available
+     if a published package is preferred later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+_SKILLS = ("discover", "optimize", "subagent", "infra-setup")
+
+
+def _pi_base() -> Path:
+    home_override = os.environ.get("PI_HOME")
+    return Path(home_override) if home_override else Path.home() / ".pi"
+
+
+def _pi_settings_file() -> Path:
+    return _pi_base() / "agent" / "settings.json"
+
+
+def _evo_extension_dir() -> Path:
+    return _pi_base() / "agent" / "extensions" / "evo"
+
+
+def _evo_extension_path() -> Path:
+    return _evo_extension_dir() / "index.js"
+
+
+def _pi_skills_dir() -> Path:
+    return _pi_base() / "agent" / "skills"
+
+
+def _bundled_extension_source() -> Path | None:
+    """Return the prebuilt JS extension bundle. Shared with openclaw —
+    the bundle targets pi's ExtensionAPI which openclaw embeds."""
+    here = Path(__file__).resolve().parent.parent  # evo/
+    bundle = here / "openclaw_plugin" / "evo.bundle.js"
+    return bundle if bundle.exists() else None
+
+
+def _skills_source_root(from_path: str | None = None) -> Path:
+    """Locate the plugins/evo/skills/ source dir.
+
+    Resolution order:
+      1. ``--from-path`` (live tests, manual installs from a clone) —
+         expects either the plugin root or a parent containing
+         ``plugins/evo/skills/``.
+      2. Development checkout via ``__file__`` walk — works when running
+         against ``plugins/evo/src/`` directly.
+
+    Wheel-installed users have no local skills/ dir and need to fetch
+    skills separately (same situation as hermes/opencode today). The
+    install command logs a warning and continues with the extension
+    install in that case.
+    """
+    if from_path:
+        base = Path(from_path)
+        # Two layouts: full repo tarball (parent of plugins/evo) OR a
+        # bare plugin checkout (already at plugins/evo).
+        for candidate in (base / "plugins" / "evo" / "skills", base / "skills"):
+            if candidate.exists():
+                return candidate
+    # __file__ = .../plugins/evo/src/evo/host_install/pi.py
+    return Path(__file__).resolve().parents[3] / "skills"
+
+
+def _update_settings_extensions(settings: Path, target: str) -> bool:
+    """Idempotent register: add `target` to settings.json#extensions[] if
+    not already present. Returns True if file was modified.
+    """
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {}
+    if settings.exists():
+        try:
+            data = json.loads(settings.read_text())
+        except json.JSONDecodeError:
+            print(f"ERROR: could not parse {settings}", file=sys.stderr)
+            raise
+    extensions = data.setdefault("extensions", [])
+    if target in extensions:
+        return False
+    extensions.append(target)
+    settings.write_text(json.dumps(data, indent=2) + "\n")
+    return True
+
+
+def _install_skills(from_path: str | None = None) -> int:
+    """Copy each evo skill into ~/.pi/agent/skills/evo-<name>/.
+
+    Pi auto-discovers any directory under skills/ that contains a
+    SKILL.md. Namespacing the dirs as `evo-<name>` avoids colliding
+    with non-evo skills the user already has.
+    """
+    src_root = _skills_source_root(from_path)
+    if not src_root.exists():
+        print(f"WARNING: evo skills source not found at {src_root}; "
+              f"skipping skill install", file=sys.stderr)
+        return 0
+    dest_root = _pi_skills_dir()
+    dest_root.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for name in _SKILLS:
+        src = src_root / name
+        if not src.exists():
+            print(f"  - {name}: source missing at {src}, skipping")
+            continue
+        dest = dest_root / f"evo-{name}"
+        # Wipe + recopy so stale files from a prior version don't linger.
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(src, dest)
+        print(f"  + installed skill: {dest}")
+        copied += 1
+    return copied
+
+
+def install(args: argparse.Namespace) -> int:
+    src = _bundled_extension_source()
+    if src is None:
+        print(
+            "ERROR: bundled pi extension not found in this evo install.\n"
+            "  Expected at evo/openclaw_plugin/evo.bundle.js (built via `bun build`).",
+            file=sys.stderr,
+        )
+        return 2
+
+    if shutil.which("pi") is None:
+        print(
+            "NOTE: `pi` binary not on PATH. Install pi first:\n"
+            "  npm install -g @earendil-works/pi-coding-agent\n"
+            "Continuing anyway — file install does not require the binary.",
+            file=sys.stderr,
+        )
+
+    ext_dir = _evo_extension_dir()
+    ext_dir.mkdir(parents=True, exist_ok=True)
+    ext_path = _evo_extension_path()
+    shutil.copyfile(src, ext_path)
+    print(f"installed extension: {ext_path}")
+
+    settings = _pi_settings_file()
+    target = str(ext_path)
+    if _update_settings_extensions(settings, target):
+        print(f"added {target} to extensions in {settings}")
+    else:
+        print(f"{target} already in extensions in {settings}")
+
+    print("\nInstalling evo skills under ~/.pi/agent/skills/evo-*/ ...")
+    _install_skills(getattr(args, "from_path", None))
+
+    print("\nRestart any running pi session to load the extension and skills.")
+    return 0
+
+
+def uninstall(args: argparse.Namespace) -> int:
+    ext_path = _evo_extension_path()
+    target = str(ext_path)
+
+    settings = _pi_settings_file()
+    if settings.exists():
+        try:
+            data = json.loads(settings.read_text())
+            extensions = data.get("extensions", [])
+            if target in extensions:
+                extensions.remove(target)
+                settings.write_text(json.dumps(data, indent=2) + "\n")
+                print(f"removed {target} from {settings}")
+        except json.JSONDecodeError:
+            pass
+
+    if ext_path.exists():
+        ext_path.unlink()
+        print(f"removed {ext_path}")
+    # Best-effort dir cleanup.
+    if ext_path.parent.exists() and not any(ext_path.parent.iterdir()):
+        ext_path.parent.rmdir()
+
+    skills_root = _pi_skills_dir()
+    for name in _SKILLS:
+        d = skills_root / f"evo-{name}"
+        if d.exists():
+            shutil.rmtree(d)
+            print(f"removed {d}")
+    return 0
+
+
+def doctor(args: argparse.Namespace) -> int:
+    ext_path = _evo_extension_path()
+    settings = _pi_settings_file()
+    rc = 0
+
+    if ext_path.exists():
+        print(f"✓ extension installed: {ext_path}")
+    else:
+        print(f"✗ extension not at {ext_path}")
+        print("  Run: evo install pi")
+        rc = 1
+
+    if settings.exists():
+        try:
+            data = json.loads(settings.read_text())
+            target = str(ext_path)
+            if target in data.get("extensions", []):
+                print(f"✓ extension registered in {settings}")
+            else:
+                print(f"✗ extension not in {settings} extensions list")
+                print("  Run: evo install pi")
+                rc = 1
+        except json.JSONDecodeError:
+            print(f"✗ could not parse {settings}")
+            rc = 1
+    else:
+        print(f"✗ {settings} not found (pi may not have run yet)")
+        rc = 1
+
+    skills_root = _pi_skills_dir()
+    missing = [name for name in _SKILLS
+               if not (skills_root / f"evo-{name}" / "SKILL.md").exists()]
+    if missing:
+        print(f"✗ missing skills: {', '.join(missing)}")
+        print("  Run: evo install pi")
+        rc = 1
+    else:
+        print(f"✓ all {len(_SKILLS)} evo skills installed under {skills_root}/evo-*/")
+
+    if shutil.which("pi") is None:
+        print("? `pi` binary not on PATH (run `npm install -g @earendil-works/pi-coding-agent`)")
+    return rc

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.4.1"
+version = "0.4.2-alpha.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.4.1"
+__version__ = "0.4.2-alpha.1"

--- a/tests/live/test_release_smoke.py
+++ b/tests/live/test_release_smoke.py
@@ -733,23 +733,25 @@ def test_opencode(sandbox_4g):
 
     prompt = _shell_quote(_read_prompt())
 
+    # `evo install opencode` now installs skills itself (via npx skills
+    # add). In local-source mode pass --from-path so skills come from the
+    # uploaded local repo, not GitHub. In PyPI mode the adapter tag-pins
+    # via --version.
+    import os as _os
+    smoke_version = _os.environ.get("EVO_RELEASE_SMOKE_VERSION", "").strip()
+    if sandbox_4g.marketplace_source.startswith("/"):
+        evo_install_opencode_args = "--from-path /tmp/evo-local-repo"
+    elif smoke_version:
+        evo_install_opencode_args = f"--version {smoke_version}"
+    else:
+        evo_install_opencode_args = ""
     _drive_smoke(
         sandbox_4g,
         host="opencode",
         install_steps=[
             "curl -fsSL https://opencode.ai/install | bash > /tmp/opencode.log 2>&1",
-            # Skills via the canonical cross-host CLI; opencode scans
-            # ~/.agents/skills/ where this writes by default with -g.
-            # npx skills accepts local paths and git URLs with `#<ref>`
-            # fragments. Tag-pin via _skills_repo_ref_opencode() so the
-            # smoke run for v0.4.0-alpha.N pulls v0.4.0-alpha.N skills,
-            # not whatever's on main (which lags behind alpha tags).
             f"export PATH=$HOME/.local/bin:$HOME/.opencode/bin:$PATH; "
-            f"npx -y skills add "
-            f"{_skills_repo_ref_opencode(sandbox_4g.marketplace_source)} "
-            f"--agent opencode -g -y",
-            "export PATH=$HOME/.local/bin:$HOME/.opencode/bin:$PATH; "
-            "evo install opencode",
+            f"evo install opencode {evo_install_opencode_args}",
         ],
         drive_cmd=(
             "export PATH=$HOME/.local/bin:$HOME/.opencode/bin:$PATH; "

--- a/tests/live/test_release_smoke.py
+++ b/tests/live/test_release_smoke.py
@@ -1068,3 +1068,84 @@ def test_openclaw(sandbox_4g):
         ),
         env_keys={"ANTHROPIC_API_KEY": anthropic_key},
     )
+
+
+def test_pi(sandbox):
+    """Pi (pi.dev, @earendil-works/pi-coding-agent): npm install +
+    `evo install pi`. Driver: ``pi -p <prompt> --provider anthropic
+    --model claude-sonnet-4-5``.
+
+    Pi 0.75.3 is the upstream agent SDK that openclaw embeds, so the
+    bundled extension at ``evo/openclaw_plugin/evo.bundle.js`` loads
+    cleanly on pi (verified by trials/pi-probe — `before_provider_request`
+    still fires). ``evo install pi`` drops that same JS into
+    ``~/.pi/agent/extensions/evo/index.js`` and copies the four evo
+    skills under ``~/.pi/agent/skills/evo-*/``.
+
+    Model: claude-sonnet-4-5 mirrors test_openclaw — gpt-4o-mini didn't
+    complete the optimize loop in 15 min (bundle loaded + session
+    registered, but agent stayed in interruptible-sleep without
+    committing any experiment).
+
+    Pi requires Node ≥21 (``webidl.util.markAsUncloneable`` is a v21
+    addition; v20 throws on startup). The default e2b template ships
+    Node 20 at /usr/local/bin/node; we install Node 22 via apt and
+    shadow the pre-installed binary.
+    """
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not anthropic_key:
+        pytest.skip("ANTHROPIC_API_KEY required for pi")
+
+    sudo = sandbox._sudo
+    sandbox.run(
+        f"curl -fsSL https://deb.nodesource.com/setup_22.x | {sudo}bash - "
+        "> /tmp/node-setup.log 2>&1",
+        timeout=120,
+    )
+    sandbox.run(f"{sudo}apt-get install -y nodejs >/dev/null", timeout=180)
+    # The e2b base image ships node 20.9 at /usr/local/bin/node which
+    # takes PATH precedence over the apt-installed /usr/bin/node. Shadow
+    # so v22 wins; pi crashes on v20 with `webidl.util.markAsUncloneable`.
+    sandbox.run(
+        f"{sudo}rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx && "
+        f"{sudo}ln -s /usr/bin/node /usr/local/bin/node && "
+        f"{sudo}ln -s /usr/bin/npm /usr/local/bin/npm && "
+        f"{sudo}ln -s /usr/bin/npx /usr/local/bin/npx && "
+        "node --version",
+        timeout=30,
+    )
+    sandbox.run(
+        f"{sudo}npm install -g @earendil-works/pi-coding-agent "
+        "> /tmp/pi-install.log 2>&1",
+        timeout=600,
+    )
+    sandbox.run("pi --version")
+
+    prompt = _shell_quote(_read_prompt())
+    # In local-source mode the harness uploads the repo tarball to
+    # /tmp/evo-local-repo; pass --from-path so the install picks up
+    # skills from there (the installed wheel doesn't ship them — same
+    # situation as hermes/opencode).
+    if sandbox.marketplace_source.startswith("/"):
+        evo_install_pi_args = "--from-path /tmp/evo-local-repo"
+    else:
+        evo_install_pi_args = ""
+    _drive_smoke(
+        sandbox,
+        host="pi",
+        install_steps=[
+            f"export PATH=$HOME/.local/bin:$PATH; evo install pi {evo_install_pi_args}",
+        ],
+        drive_cmd=(
+            "export PATH=$HOME/.local/bin:$PATH; "
+            # _drive_smoke wraps this with `cd /tmp/ws &&`, so the
+            # extension's findEvoRunDir() walks up from the workspace
+            # and finds .evo/. `pi -p` exits after the response (one
+            # multi-turn session). Tools enabled by default so the
+            # agent can invoke bash/edit/etc. to drive `evo new`/`evo run`.
+            "nohup pi -p "
+            f"{prompt} --provider anthropic --model claude-sonnet-4-5 "
+            "> /tmp/agent.log 2>&1 & echo $! > /tmp/agent.pid"
+        ),
+        env_keys={"ANTHROPIC_API_KEY": anthropic_key},
+    )


### PR DESCRIPTION
## Summary

- Adds pi.dev (`@earendil-works/pi-coding-agent`) as a first-class evo host
- `evo install pi` drops the existing openclaw extension bundle into `~/.pi/agent/extensions/evo/index.js` — pi is the upstream SDK that openclaw embeds, so the JS targets pi's ExtensionAPI directly and loads without modification
- Bumps CLI, SDKs, and plugin manifests to `0.4.2-alpha.1`

## What works

End-to-end smoke on e2b (7m17s, claude-sonnet-4-5 via pi's anthropic provider):
- Bundle loaded inside pi, registered session in `inject/sessions/`
- `evo init --host pi` produced `run_0000`
- Sonnet committed 4 round-1 experiments
- `evo direct` queued the round-2 directive with `fanout=1 sessions`
- Offset advanced to the directive id (`consumed_by >= 1`)
- Experiment D copied `_DIRECTIVE_TAG` verbatim into committed `target.py` (`tag_count >= 1`)
- Best/baseline ratio: 397x (`ratio > 50`)

## What `evo install pi` does

1. Copies `plugins/evo/src/evo/openclaw_plugin/evo.bundle.js` → `~/.pi/agent/extensions/evo/index.js`
2. Adds the path to `~/.pi/agent/settings.json#extensions[]`
3. Copies the four evo skills under `~/.pi/agent/skills/evo-{discover,optimize,subagent,infra-setup}/`

Three deletions vs `host_install/openclaw.py`: no `plugins.allow` trust grants (pi has no equivalent), no openclaw-native `tool_result_persist` plugin (openclaw-only hook), no marketplace CLI call (skills copied directly).

## Test plan

- [x] `evo install pi` / `evo doctor pi` / `evo uninstall pi` resolve through the CLI (verified locally with `PI_HOME=/tmp/...`)
- [x] `evo init --host pi` accepted
- [x] e2b smoke: `EVO_LIVE_TEST_RELEASE_SMOKE=1 EVO_RELEASE_SMOKE_SOURCE=local pytest tests/live/test_release_smoke.py::test_pi` passes
- [ ] `evo install pi` post-release (PyPI path) — skills won't auto-install from the wheel (same situation as hermes/opencode); users from a clone use `--from-path`

## Notes

- Pi requires Node ≥21 (`webidl.util.markAsUncloneable`). The e2b default sandbox ships Node 20 at `/usr/local/bin/node`; the smoke test installs Node 22 via apt and shadows the pre-installed binary. End users on macOS/Linux with nvm get a working install out of the box if they're on Node ≥21.
- The `before_provider_request` hook still fires on pi 0.75.3 — the "removed upstream" comment in `tests/live/test_install_sandbox.py:380` is stale (openclaw moved off the hook, but it's still in pi).
- Session id derives from `process.cwd()` hash with an `openclaw-` prefix (cosmetic — bundle is shared). Worth renaming to `pi-` if the bundle is split per-host later.