### PR TITLE
v0.4.2-alpha.2: pi skill-text fix + auto-install pi-subagents

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,6 +165,52 @@ jobs:
             npm publish
           fi
 
+  publish-node-pi:
+    needs: preflight
+    if: |
+      startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(github.ref, 'refs/tags/pi-evo-v') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'node'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Sync bundle + skills from plugins/evo/
+        run: bash plugins/evo/npm/scripts/sync-from-source.sh
+      - name: Verify tag matches package version
+        working-directory: plugins/evo/npm
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          VERSION=$(node -p "require('./package.json').version")
+          case "$TAG" in
+            v*)         EXPECTED="v${VERSION}" ;;
+            pi-evo-v*)  EXPECTED="pi-evo-v${VERSION}" ;;
+            *)          EXPECTED="" ;;
+          esac
+          if [ -n "$EXPECTED" ] && [ "$TAG" != "$EXPECTED" ]; then
+            echo "Tag $TAG does not match package.json version $VERSION (expected $EXPECTED)"
+            exit 1
+          fi
+      - name: Publish to npm
+        working-directory: plugins/evo/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Pre-release semver (e.g. 0.4.2-alpha.2) ships under the
+          # `alpha` dist-tag so stable users running `pi install
+          # npm:@evo-hq/pi-evo` don't silently get the pre-release.
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q '-'; then
+            npm publish --tag alpha
+          else
+            npm publish
+          fi
+
   publish-cli:
     needs: preflight
     if: |

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.1",
+  "version": "0.4.2-alpha.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.1",
+  "version": "0.4.2-alpha.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/npm/README.md
+++ b/plugins/evo/npm/README.md
@@ -1,0 +1,38 @@
+# @evo-hq/pi-evo
+
+Evo plugin for [pi-coding-agent](https://pi.dev) — adds the `/discover`,
+`/optimize`, `/subagent`, and `/infra-setup` skills, plus a `before_provider_request`
+extension that consumes `evo direct` mid-run inject messages.
+
+## Install
+
+```bash
+pi install npm:@evo-hq/pi-evo
+```
+
+Pi auto-registers the extension under `~/.pi/agent/extensions/` and discovers
+the skills under `~/.pi/agent/skills/`. No additional setup steps.
+
+A parallel-subagent provider ([`pi-subagents`](https://pi.dev/packages/pi-subagents))
+is bundled — pi's default toolkit has no fanout primitive, and evo's `optimize`
+skill needs one to run multiple experiments per round.
+
+## What ships in this package
+
+| Path | Purpose |
+|---|---|
+| `extensions/evo/index.js` | Bundled JS that hooks `before_provider_request`, drains the workspace inject queue, appends `[evo direct]` directives to the outgoing LLM payload |
+| `skills/discover/` | First-run setup: explore repo, propose optimization dimensions, build benchmark, run first experiment |
+| `skills/optimize/` | The search loop: parallel subagents form hypotheses, edit, get scored, frontier picks next branch |
+| `skills/subagent/` | Per-experiment brief contract for the optimize round's fanout |
+| `skills/infra-setup/` | Provider matrix for remote-sandbox backends (Modal, E2B, Daytona, etc.) |
+
+## Versioning
+
+This package is versioned in lockstep with the [evo-hq/evo](https://github.com/evo-hq/evo)
+release line. The skills + bundled extension are sync'd from `plugins/evo/` in
+the source repo at publish time (see `scripts/sync-from-source.sh`).
+
+## Source
+
+[github.com/evo-hq/evo](https://github.com/evo-hq/evo) (Apache-2.0)

--- a/plugins/evo/npm/extensions/evo/index.js
+++ b/plugins/evo/npm/extensions/evo/index.js
@@ -1,0 +1,244 @@
+// ../opencode_plugin/drain.ts
+import * as fs from "fs";
+import * as path from "path";
+var QUEUE_SCHEMA_VERSION = 1;
+function injectRoot(runDir) {
+  return path.join(runDir, "inject");
+}
+function sessionFile(runDir, sid) {
+  return path.join(injectRoot(runDir), "sessions", `${sid}.json`);
+}
+function workspaceEventsPath(runDir) {
+  return path.join(injectRoot(runDir), "events", "workspace.jsonl");
+}
+function expEventsPath(runDir, expId) {
+  return path.join(injectRoot(runDir), "events", `${expId}.jsonl`);
+}
+function offsetFile(runDir, sid) {
+  return path.join(injectRoot(runDir), "offsets", `${sid}.json`);
+}
+function markerFile(runDir, sid) {
+  return path.join(injectRoot(runDir), "markers", `${sid}.flag`);
+}
+function readJsonOrNull(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+function atomicWriteJson(p, data) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(data));
+  fs.renameSync(tmp, p);
+}
+function unlinkIfExists(p) {
+  try {
+    fs.unlinkSync(p);
+  } catch {}
+}
+function readEventsAfter(queuePath, afterId) {
+  if (!fs.existsSync(queuePath))
+    return [];
+  let text;
+  try {
+    text = fs.readFileSync(queuePath, "utf8");
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const line of text.split(`
+`)) {
+    const trimmed = line.trim();
+    if (!trimmed)
+      continue;
+    let rec;
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const recId = rec?.id;
+    if (typeof recId !== "string")
+      continue;
+    if (afterId === null || recId > afterId) {
+      out.push(rec);
+    }
+  }
+  return out;
+}
+function readOffset(runDir, sid, queue) {
+  const data = readJsonOrNull(offsetFile(runDir, sid));
+  if (!data)
+    return null;
+  if (queue === "workspace")
+    return data.last_workspace_event_id ?? null;
+  if (queue === "exp")
+    return data.last_exp_event_id ?? null;
+  return null;
+}
+function nowIso() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "+00:00");
+}
+function writeOffset(runDir, sid, opts) {
+  const p = offsetFile(runDir, sid);
+  let data = readJsonOrNull(p) ?? {};
+  data.schema_version = QUEUE_SCHEMA_VERSION;
+  data.session_id = sid;
+  if (opts.workspaceId !== undefined && opts.workspaceId !== null) {
+    data.last_workspace_event_id = opts.workspaceId;
+  }
+  if (opts.expId !== undefined && opts.expId !== null) {
+    data.last_exp_event_id = opts.expId;
+  }
+  data.updated_at = nowIso();
+  atomicWriteJson(p, data);
+}
+function formatDirectiveText(events) {
+  const lines = [];
+  for (const ev of events) {
+    if (ev.text)
+      lines.push(`[evo direct] ${ev.text}`);
+  }
+  return lines.join(`
+`);
+}
+function getSession(runDir, sid) {
+  return readJsonOrNull(sessionFile(runDir, sid));
+}
+function isRegistered(runDir, sid) {
+  return fs.existsSync(sessionFile(runDir, sid));
+}
+var REGISTRY_SCHEMA_VERSION = 1;
+function registerSession(runDir, sid, host, expId = null) {
+  const p = sessionFile(runDir, sid);
+  const now = nowIso();
+  const existing = readJsonOrNull(p);
+  if (existing) {
+    existing.last_seen_at = now;
+    atomicWriteJson(p, existing);
+    return;
+  }
+  const rec = {
+    schema_version: REGISTRY_SCHEMA_VERSION,
+    session_id: sid,
+    host,
+    pid: process.pid,
+    registered_at: now,
+    last_seen_at: now,
+    exp_id: expId,
+    parent_session_id: null
+  };
+  atomicWriteJson(p, rec);
+}
+function findEvoRunDir(cwd) {
+  const envRunDir = process.env.EVO_RUN_DIR;
+  if (envRunDir)
+    return envRunDir;
+  let dir = cwd || process.cwd();
+  while (dir !== "/" && dir !== "") {
+    const evoDir = path.join(dir, ".evo");
+    if (fs.existsSync(evoDir)) {
+      try {
+        const runs = fs.readdirSync(evoDir).filter((n) => n.startsWith("run_")).sort();
+        if (runs.length === 0)
+          return null;
+        return path.join(evoDir, runs[runs.length - 1]);
+      } catch {
+        return null;
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir)
+      break;
+    dir = parent;
+  }
+  return null;
+}
+function drainSession(runDir, sessionId) {
+  const sess = getSession(runDir, sessionId);
+  if (!sess) {
+    unlinkIfExists(markerFile(runDir, sessionId));
+    return { text: null, newWorkspaceOffset: null, newExpOffset: null };
+  }
+  const expId = sess.exp_id;
+  let events = [];
+  let newWorkspaceOffset = null;
+  let newExpOffset = null;
+  if (expId) {
+    const lastId = readOffset(runDir, sessionId, "exp");
+    const newEvents = readEventsAfter(expEventsPath(runDir, expId), lastId);
+    events = newEvents;
+    if (newEvents.length > 0)
+      newExpOffset = newEvents[newEvents.length - 1].id;
+  } else {
+    const lastId = readOffset(runDir, sessionId, "workspace");
+    const newEvents = readEventsAfter(workspaceEventsPath(runDir), lastId);
+    events = newEvents;
+    if (newEvents.length > 0)
+      newWorkspaceOffset = newEvents[newEvents.length - 1].id;
+  }
+  const text = events.length > 0 ? formatDirectiveText(events) : null;
+  if (newWorkspaceOffset || newExpOffset) {
+    writeOffset(runDir, sessionId, {
+      workspaceId: newWorkspaceOffset,
+      expId: newExpOffset
+    });
+  }
+  unlinkIfExists(markerFile(runDir, sessionId));
+  return { text, newWorkspaceOffset, newExpOffset };
+}
+
+// index.ts
+import * as crypto from "crypto";
+function deriveSessionId() {
+  const hash = crypto.createHash("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  return `openclaw-${hash}`;
+}
+function register(api) {
+  const drainedTexts = [];
+  const ensureRegistered = () => {
+    const runDir = findEvoRunDir();
+    if (!runDir)
+      return null;
+    const sid = deriveSessionId();
+    if (!isRegistered(runDir, sid)) {
+      registerSession(runDir, sid, "openclaw");
+    }
+    return { sid, runDir };
+  };
+  const appendToPayload = (event, text) => {
+    if (Array.isArray(event.payload?.input)) {
+      event.payload.input.push({
+        role: "user",
+        content: [{ type: "input_text", text }]
+      });
+    } else if (Array.isArray(event.payload?.messages)) {
+      event.payload.messages.push({
+        role: "user",
+        content: [{ type: "text", text }]
+      });
+    }
+  };
+  api.on("session_start", () => {
+    ensureRegistered();
+  });
+  api.on("before_provider_request", (event, _ctx) => {
+    const ctx = ensureRegistered();
+    if (!ctx)
+      return;
+    const result = drainSession(ctx.runDir, ctx.sid);
+    if (result.text)
+      drainedTexts.push(result.text);
+    if (drainedTexts.length === 0)
+      return;
+    const combined = drainedTexts.join(`
+`);
+    appendToPayload(event, combined);
+    return event.payload;
+  });
+}
+export {
+  register as default
+};

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@evo-hq/pi-evo",
+  "version": "0.4.2-alpha.2",
+  "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-coding-agent",
+    "evo",
+    "evo-hq",
+    "coding-agent",
+    "optimization"
+  ],
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"]
+  },
+  "dependencies": {
+    "pi-subagents": "*"
+  },
+  "bundledDependencies": ["pi-subagents"],
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "pi-agent-core": "*",
+    "pi-coding-agent": "*",
+    "pi-tui": "*",
+    "typebox": "*"
+  },
+  "files": ["extensions", "skills", "README.md", "LICENSE"],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evo-hq/evo.git",
+    "directory": "plugins/evo/npm"
+  },
+  "homepage": "https://github.com/evo-hq/evo#readme",
+  "bugs": "https://github.com/evo-hq/evo/issues"
+}

--- a/plugins/evo/npm/scripts/sync-from-source.sh
+++ b/plugins/evo/npm/scripts/sync-from-source.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copy the canonical evo bundle + skills from plugins/evo/ into this
+# package. Source of truth lives in plugins/evo/; this package is a
+# distribution surface for npm. CI runs this before `npm publish` so
+# the published tarball always matches the tagged release content.
+#
+# Safe to run locally too — the committed extensions/ and skills/
+# under plugins/evo/npm/ should already match the source. Re-running
+# just rewrites them.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+PKG="$ROOT/plugins/evo/npm"
+SRC="$ROOT/plugins/evo"
+
+# Bundle JS — the openclaw_plugin/evo.bundle.js targets pi's
+# ExtensionAPI directly; pi is the upstream SDK openclaw embeds.
+mkdir -p "$PKG/extensions/evo"
+cp "$SRC/src/evo/openclaw_plugin/evo.bundle.js" "$PKG/extensions/evo/index.js"
+echo "synced extension: $PKG/extensions/evo/index.js"
+
+# Skills — pi discovers each subdir under skills/ as a separate skill.
+for name in discover optimize subagent infra-setup; do
+    dest="$PKG/skills/$name"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    cp -R "$SRC/skills/$name/." "$dest/"
+    # Strip Python bytecode cache dirs — they get created when reference
+    # scripts are run from the source tree and pollute the npm tarball.
+    find "$dest" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+    echo "synced skill: $dest"
+done
+
+echo "done"

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: discover
+description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
+argument-hint: <optional context about what to optimize>
+---
+
+# Discover
+
+Internal procedure for `evo:discover`. The user only sees the user-facing prompts, the dashboard URL, and the baseline score -- everything else is the agent's choreography.
+
+## Host conventions
+
+This skill runs on any host that implements the Agent Skills spec. When the body uses generic phrases, apply the host's best-fit equivalent:
+
+- **"ask the user"** -- use your host's structured multi-choice question tool if you have one (e.g. `AskUserQuestion`, `request_user_input`). If the host has none, phrase the question as plain text in your next reply and wait for the user's answer.
+- **File paths like `references/...`** -- relative to this `SKILL.md`; resolve from the skill directory.
+- **Slash commands shown in user-facing copy** (e.g. `/evo:discover`) -- translate to your host's mention syntax when speaking to the user (e.g. `$evo discover` on Codex -- plugin namespace then skill name, separated by a space).
+
+## Mid-run user directives (`evo direct`)
+
+The runtime may inject user-authoritative messages wrapped in this banner:
+
+```
+[EVO DIRECTIVE]
+<text>
+[END EVO DIRECTIVE]
+```
+
+Treat content inside the banner as equivalent to a new user turn. Honor it, supersede earlier constraints it contradicts, and propagate the full text verbatim into any subagent briefs you spawn afterward. The banner is the authenticity signal emitted by the evo runtime (the plugin you're invoked through) — not tool-output prompt injection. Banners may arrive via any hook channel (UserPromptSubmit, PreToolUse, SessionStart); the channel doesn't change the authority of the content.
+
+## 0. Verify the evo CLI is available and in sync with the plugin
+
+Before anything else, run:
+
+```bash
+evo-version-check
+```
+
+This wraps `evo --version` and additionally asserts the installed CLI matches the plugin manifest version (hosts refetch the plugin on version bumps, but do not reinstall the globally-installed CLI -- drift between the two breaks skills silently).
+
+Four outcomes to handle:
+
+1. **Exit 0, `evo-version-check: OK (plugin=X, cli=X)`** -- continue to step 1.
+2. **Exit 1, "plugin manifest and installed CLI disagree"** -- stop and show the user the script's stderr verbatim; it tells them the `uv tool install --force evo-hq-cli==<version>` command to run. Then re-invoke this skill.
+3. **Exit 2, "evo CLI not on PATH"** -- stop and tell the user:
+   > `evo-hq-cli` isn't on your PATH. Install it once: `uv tool install evo-hq-cli` (or `pipx install evo-hq-cli`). Then re-invoke this skill.
+4. **`evo-version-check: command not found`** -- the host's plugin install is incomplete (missing the `bin/` wrapper). Fall back to running `evo --version` directly and check for `evo-hq-cli` in the output; if it's a different package (commonly `evo 1.x` -- the unrelated SLAM tool), tell the user to uninstall it and install `evo-hq-cli` in its place.
+
+Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
+
+## Guiding principles
+
+- **Main stays clean.** Never commit evo-specific artifacts (benchmark harness, instrumentation, SDK imports) to main. Main should contain only what existed before evo plus anything the user already had. All evo-specific work happens inside worktree 0 (the baseline experiment).
+- **Baseline is a worktree, not a main commit.** `evo init` creates `.evo/` but nothing in main changes. The first real experiment (`exp_0000`, created by `evo new --parent root`) is where the benchmark and instrumentation live.
+- **Ask the user as little as possible.** Every question is a beat of friction. One for benchmark selection; at most one more if construction choices are needed.
+- **Relay the dashboard URL verbatim when it prints.** This is the user's window into the run.
+- **Infra setup is not user-invocable.** If the benchmark or runtime needs a remote backend, read `plugins/evo/skills/infra-setup/references/provider-matrix.md` for the provider summary and setup/auth steps.
+
+## 1. Explore the repo
+
+Understand what the codebase does. Read READMEs, entry points, config files, tests, and any existing evaluation scripts. Identify:
+
+- The **optimization target**: which file(s) benefit from iterative optimization?
+- **Metric direction for each candidate**: is higher better (`max`) or lower better (`min`)?
+- **Critical behaviors worth gating**: invariants that must never break regardless of score (e.g., "refund flow works", "core tests pass", "output is valid JSON"). Gates are commands that exit 0 on success, non-zero on failure.
+
+## 2. Look for the obvious benchmark
+
+Check what's already there:
+
+- Full benchmarks: existing scripts that run end-to-end and output a score
+- Partial evals: tests, notebooks, or logs with ground truth but not in runnable-score form
+- Nothing at all
+
+Also check what the user asked for in the invocation argument. If they named a specific metric or target, that's intent.
+
+**If one benchmark is obviously the right one** — a runnable eval that measures what the user clearly cares about, or what the repo is plainly built to do — use it. Skip step 3, go to step 4 with that benchmark as the only candidate.
+
+**If it's not obvious** — multiple candidate surfaces, no existing eval, user didn't specify intent, or the existing eval covers a narrow slice while the interesting optimization sits elsewhere — run step 3.
+
+## 3. Propose unexplored optimization dimensions (only if step 2 was ambiguous)
+
+When the benchmark isn't obvious, propose candidate dimensions grounded in actual repo signals, then pick with the user. See `references/proposing-dimensions.md` for the full rubric, project-type examples, and presentation format. Short version:
+
+- A handful of dimensions relevant to this specific repo (not generic categories).
+- Ground each in repo signals: already-instrumented code, stated goals in READMEs, TODO/FIXME patterns, domain defaults.
+- Rank by signal × slack × cost answered in prose (no numeric scores — they're vibes).
+
+## 4. Ask the user to pick the benchmark
+
+If step 2 produced one obvious benchmark, confirm it in one sentence and move on — no ranked list needed.
+
+Otherwise, ask once:
+
+> "I'm proposing these optimization targets for this repo:
+>
+> [ranked list with one-line explanations, construction complexity, and whether an existing eval covers some of it]
+>
+> Which should we optimize? Recommended: [default pick with reasoning]."
+
+Record the selection. If step 3 ran, save non-picked dimensions to `.evo/project.md` under "Future experiment candidates" after init.
+
+## 5. Ask the user for instrumentation mode
+
+Three cases, in order of how to handle them:
+
+1. **Selected benchmark already exists AND is already instrumented for evo** (you can see `from evo_agent import Run`, an `import { Run } from '@evo-hq/evo-agent'`, or the inline `log_task` / `logTask` helpers in the benchmark source). No wiring needed. Skip this question entirely. Detect the instrumentation style from the source and pass the matching `--instrumentation-mode <sdk|inline>` value to `evo init` in step 7.
+
+2. **Selected benchmark already exists but is NOT instrumented** (it just prints a score JSON, or it's a test runner that doesn't yet write per-task traces). Wiring is needed. **Ask the question.**
+
+3. **Selected benchmark needs to be constructed from scratch** (case B or C from step 4). Wiring is needed. **Ask the question.**
+
+For cases 2 and 3, ask once:
+
+> "I can wire up the benchmark in one of two ways:
+>
+> 1. **SDK mode** -- install the evo agent SDK with this project's package manager/runtime (for example `uv add --dev evo-hq-agent`, `python -m pip install evo-hq-agent`, or `npm install @evo-hq/evo-agent`). Richer per-task logs, ~5 lines of user code.
+> 2. **Inline mode** -- paste a ~30-line helper directly into the benchmark. Zero new dependencies. Same data contract."
+
+Pass the answer to `evo init` via `--instrumentation-mode <sdk|inline>` in step 7. **Never install packages without this confirmation.** If you skip the question (case 1), still pass the detected mode to `evo init` so optimize/subagent runs see a consistent value.
+
+## 6. Prepare main (without committing to it)
+
+The agent never creates commits on main. Main stays byte-identical to what the user committed before evo ran. Two things to set up, both local-only.
+
+**Order matters: do 6a (audit) before 6b (excludes).** The excludes in 6b will hide files inside `node_modules/`, `dist/`, `build/`, etc. from `git status`. If you run the audit *after* adding excludes, you'll be blind to anything missing inside those directories -- and benchmark dependencies often live exactly there.
+
+### 6a. Detect (don't auto-commit) dirty or untracked dependencies
+
+`evo new` forks a worktree from the current branch's HEAD commit, **not from your dirty working tree**. Any uncommitted edits to the target, benchmark, or gate dependencies are silently absent from `exp_0000`, and the whole optimization tree gets built against stale code while you think evo is running on what you see locally.
+
+Run three checks, in this order:
+
+1. **Tracked-but-modified files** -- run `git diff --name-only` and `git diff --cached --name-only`. If any output line is the optimization target, an existing benchmark file, a gate-referenced script, or any of their import-graph dependencies, **stop and ask the user to commit or stash before continuing**. Do not commit on their behalf -- the user might be in the middle of an unrelated change.
+
+2. **Untracked files visible to git** -- run `git status --short --untracked-files=all` and look for `??` entries that the target or gates will reference. Classify each:
+   - **Part of the user's project** (e.g., a smoke test they wrote but hadn't committed) -- stop and ask the user to commit it to main themselves.
+   - **Evo-specific new files** (a new gate script you're about to write, a new test fixture) -- do not create these in main. Defer to step 10; they go into the baseline worktree and commit to experiment 0's branch. Every descendant experiment inherits via git branching.
+
+3. **Explicit paths inside soon-to-be-ignored directories** -- inspect the benchmark command and every gate command for path references (e.g., `./dist/eval-helper`, `node_modules/some-tool/cli.js`, `build/golden_outputs/`). For each such path, run `git ls-files --error-unmatch <path>` to confirm it's tracked. If any aren't, stop and ask the user to commit them. This catches dependencies that step 6b is about to hide from `git status`.
+
+Any one of these three checks failing is a hard stop. Do not proceed to 6b or beyond until the working tree is clean with respect to anything evo will read.
+
+Anything else (benchmark harness, instrumentation) always gets constructed inside the baseline worktree, never in main.
+
+### 6b. Add local-only git excludes
+
+After the audit passes, append to `.git/info/exclude` (**not** `.gitignore` -- we do not commit to main):
+
+```
+.evo/
+__pycache__/
+*.pyc
+.pytest_cache/
+node_modules/
+dist/
+build/
+```
+
+`.git/info/exclude` is git's per-clone ignore file -- same effect as `.gitignore`, but never committed, never shared, invisible to history. Right tool for per-machine tooling state.
+
+## 7. Initialize the workspace
+
+```bash
+evo init --name "<short project name>" \
+  --target <file> --benchmark "<command using {worktree} and {target}>" --metric <max|min> \
+  --host <claude-code|codex|opencode|openclaw|hermes|pi|generic> \
+  --instrumentation-mode <sdk|inline> [--gate "<gate command>"] \
+  [--commit-strategy <all|tracked-only>]
+```
+
+**`--host` is required.** Pass the host runtime you (the orchestrator) are running under. Allowed values: `claude-code`, `codex`, `opencode`, `openclaw`, `hermes`, `pi`, `generic`. This is recorded in `.evo/meta.json` so other commands can adapt to host-specific conventions. Pick the value matching the runtime you invoked `discover` from. Use `evo host set <value>` later if you change runtimes.
+
+**`--name` should be a short human-readable project label** for dashboard display, chosen from the repository/product context. Existing workspaces without a name fall back to the repo directory name; do not hand-edit config just to migrate them.
+
+**`--commit-strategy` is optional.** Default is `all`. Override with `--commit-strategy tracked-only` only when you want the stricter shisa-kanko flow where new files must be staged explicitly and acknowledged at `evo run` time.
+
+**Placeholder semantics.** Benchmark and gate commands support two placeholders, resolved lazily at run time by `evo run` / gate evaluation:
+
+- `{worktree}` resolves to the absolute path of the experiment's worktree directory (e.g. `/path/to/repo/.evo/run_0000/worktrees/exp_0000`). Use this to reference files that live on the experiment branch, not on main.
+- `{target}` resolves to the absolute path of the target file *inside that worktree* (e.g. `{worktree}/agent/solve.py`). Use this when your benchmark needs to load or exec the target dynamically.
+
+**Critical rule:** `evo run` executes from the main repo root. When the benchmark script is constructed inside the worktree (the default in this flow), the command **must** reference it via `{worktree}` or the path won't resolve.
+
+Example for a benchmark written at `{worktree}/benchmark.py` that will be committed to exp_0000:
+
+```bash
+evo init \
+  --name "ARC AGI solver" \
+  --target agent/solve.py \
+  --benchmark "python3 {worktree}/benchmark.py --target {target}" \
+  --metric max \
+  --host claude-code
+```
+
+Use the same runtime entry point the project already uses, but make sure the command does not assume uncommitted runtime state exists inside the worktree. Worktrees are git checkouts; untracked directories such as local virtualenvs, build caches, and downloaded models are usually not present there. If the benchmark needs setup or a package-manager runner, configure evo's runtime recipe instead of baking local paths into the benchmark command:
+
+```bash
+evo config runtime set --prepare "uv sync" --before-run "make reset-test-state" --prefix "uv run"
+evo config runtime show
+```
+
+`prepare` and `before-run` execute in the experiment workspace. `prefix` is prepended to benchmark and gate commands.
+
+`evo init` creates `.evo/`, the synthetic `root` node, and auto-starts the dashboard. It prints a line like:
+
+```
+Dashboard live: http://127.0.0.1:8080 (pid 12345)
+```
+
+**Relay that line back to the user verbatim.** If port 8080 is busy, evo auto-increments -- show whatever port prints. The URL is how the user watches the run.
+
+**Runtime environment.** If the benchmark needs keys or other runtime variables, configure them through evo rather than copying `.env` into worktrees or hand-editing `config.json`:
+
+```bash
+evo env load .env --all
+evo env load .env --allow KEY1,KEY2
+evo env show
+```
+
+Values are resolved fresh by the orchestrator on each `evo run`. Config stores dotenv source metadata and key names, not secret values. The benchmark and gates receive the resolved env; gates do not receive `EVO_*` artifact variables.
+
+## 8. Set up gates
+
+Gates inherit down the experiment tree -- children automatically get all ancestor gates.
+
+**Gate semantics (read this first).** `evo run` decides "gate passed" purely from the command's exit code: 0 = pass, non-zero = fail. A benchmark-style command that just prints `{"score": 0.0}` and exits 0 **passes the gate**. That defeats the purpose. Every gate command must be wired to exit non-zero when the protected behavior regresses. Two ways to do that:
+
+- **Test-suite gates** -- `pytest`, `cargo test`, `npm test`, etc. already exit non-zero on failure. Use them as-is.
+- **Score-threshold gates** -- gate the benchmark on a minimum acceptable score. The benchmark script needs a flag like `--min-score <float>` that exits 1 when the computed score falls below the threshold. The `inline_instrumentation.{py,js}` helpers in `references/` show the pattern: `write_result()` returns the final score; the script can then compare and `sys.exit(1)`.
+
+Examples:
+
+```bash
+# Test-suite gate: pytest already exits non-zero on failures (use uv run --with if pytest isn't already a dep)
+evo gate add root --name core_tests --command "uv run --with pytest pytest tests/core/ -x"
+
+# Score-threshold gate: benchmark exits 1 if pass rate on protected tasks drops below 0.9
+evo gate add root --name refund_flow --command "python3 {worktree}/benchmark.py --target {target} --task-ids 5 --min-score 0.9"
+
+# Custom validation: smoke test that crashes (non-zero exit) on broken target
+evo gate add root --name no_crash --command "python3 smoke_test.py --target {target}"
+```
+
+If a benchmark you constructed doesn't yet have a `--min-score` mode, add it now (a few lines: parse the threshold flag, compute the score, `sys.exit(1)` if below). Without it the gate is decorative.
+
+Gate commands support `{target}` and `{worktree}` placeholders with the same semantics as benchmark commands (resolved at run time, not at registration). Registering a gate that references `{worktree}/benchmark.py` before the benchmark exists is safe -- the placeholder resolves only when the gate is evaluated, which happens during `evo run` after the benchmark is committed.
+
+Verify registered gates:
+
+```bash
+evo gate list root
+```
+
+**Gate pairing rule based on benchmark provenance:**
+
+- **If the selected benchmark already existed in the repo** (not constructed from scratch): gates are optional at this step, but if you register any benchmark-derived gate, it must use a score-threshold (`--min-score` or equivalent) -- not a bare invocation. Subagents can add more during optimization.
+- **If the benchmark was constructed from scratch** (case B or C from the A/B/C classification): a Goodhart-mitigation gate is **mandatory** before the baseline can run, AND that gate must be a real pass/fail check (score-threshold or correctness assertion that exits non-zero on regression), not a bare benchmark rerun. See `references/constructing-benchmark.md` section 6 on "Required gate pairing." Do not proceed to `evo new` or `evo run` without it. This is the safety against metric gaming -- it is not optional.
+
+## 9. Create the baseline worktree
+
+```bash
+evo new --parent root -m "baseline: instrument + score"
+```
+
+This returns experiment id (typically `exp_0000`) and its worktree path. All subsequent construction work happens inside that worktree -- **never in main**.
+
+## 10. Work inside the baseline worktree
+
+Cd into the worktree path returned by `evo new`. Then:
+
+### 10a. Construct the benchmark (if needed)
+
+If the selected benchmark is new, build it in the worktree. See `references/constructing-benchmark.md` for the full procedure:
+
+- Design the scoring function (range, direction, meaningful-improvement threshold)
+- Assemble test cases (10-20 for programmatic, 15-30 for fuzzy, realistic workload for perf)
+- Write the runnable harness (helper/SDK writes the score JSON to `$EVO_RESULT_PATH`; stdout and stderr are free for user output)
+- Goodhart check (document gaming strategies, mitigate each with a gate or held-out slice)
+- Held-out validation slice (60/70 training, 30/40 held-out) if the benchmark is hand-written
+
+Do not run separate determinism checks during setup. Note the benchmark's determinism property in `project.md` (step 12) and move on. Variance surfaces during optimization itself, where it can be handled with real evidence rather than guessed at during setup.
+
+### 10b. Apply instrumentation
+
+Based on the instrumentation mode passed to `evo init`:
+
+Paths below are relative to this `SKILL.md` file (resolve them against the skill directory).
+
+- **SDK mode**: add `from evo_agent import Run` (Python) or `import { Run } from '@evo-hq/evo-agent'` (Node) to the benchmark script. Wrap the eval loop per `references/sdk_python.py` or `references/sdk_node.js`.
+- **Inline mode**: copy the helper from `references/inline_instrumentation.py` (or `.js`) into the benchmark. Use `log_task` / `logTask` per task and `write_result` / `writeResult` once at the end.
+
+The wire protocol is the same either way: `task_<id>.json` written to `$EVO_TRACES_DIR`, score JSON written to `$EVO_RESULT_PATH`. Stdout is free for user output.
+
+### 10c. Cheap validation run
+
+Before the full baseline, validate the toolchain with the cheapest possible end-to-end run (single task, smallest split, dry-run flag -- whatever is fastest). Run the check from the main repo root:
+
+```bash
+evo run exp_0000 --check
+evo gate check exp_0000
+```
+
+`--check` runs the configured benchmark and gates and writes artifacts to a fresh check directory, but does **not** commit, evaluate, or consume retry budget. It uses evo's real placeholder substitution, runtime env resolution, remote workspace routing, and absolute `EVO_RESULT_PATH` / `EVO_TRACES_DIR` paths, so do not hand-roll a `mktemp` wrapper. Inspect the check artifacts with `evo show exp_0000` (the latest check appears under `attempts`).
+
+Use `evo gate check <exp_id>` when only gate wiring changed or when you need to validate inherited gates without running the benchmark. It writes a `gate_check.json` artifact under the same checks directory and also does not mutate experiment state.
+
+The check asserts `result.json` exists, is non-empty, and is a JSON object with a numeric `score`. Also verify:
+
+- All dependencies resolve and the command completes.
+- Traces appear in `$EVO_TRACES_DIR` (if applicable).
+- Each gate script runs cleanly on the unmodified target.
+
+Fix any issues and re-validate before proceeding.
+
+### 10d. Commit inside the worktree
+
+Logical commits are ideal but not required. Minimal acceptable:
+
+1. `add: benchmark harness + test cases`
+2. `add: instrumentation` (only in SDK mode -- inline mode keeps the harness and instrumentation in one file, so this commit collapses into the previous one)
+
+Use git from inside the worktree directory. These commits are on the experiment's branch, not main.
+
+**Before the first commit in the worktree, add a `.gitignore`** for build artifacts and any stray evo workspace writes that shouldn't land on the experiment branch. At minimum:
+
+```
+.evo/
+__pycache__/
+*.pyc
+.pytest_cache/
+node_modules/
+dist/
+build/
+```
+
+Otherwise, running the benchmark once before committing will drag bytecode caches, `.pytest_cache/`, or stray `.evo/` writes into the experiment's tree and pollute every descendant branch. Belt-and-suspenders with step 10c's "run from main repo root" rule: even if cwd slips, the ignore catches it.
+
+## 11. Run the baseline
+
+**First, cd back to main repo root.** If the previous step left the shell inside the worktree, `evo run` will fail with "workspace not initialized" because `.evo/` only lives at the main repo root.
+
+```bash
+cd <main-repo-root>
+evo run exp_0000
+```
+
+`evo run` executes the benchmark, captures the score, runs all inherited gates, and marks the experiment `committed` in a single step. Its output line ends with something like `COMMITTED exp_0000 0.4286`.
+
+**Do NOT call `evo done` afterward.** In the current CLI, `evo run` is terminal: the experiment is already committed when it returns successfully, and calling `evo done exp_0000 --score <n>` errors with `"exp_0000 has status 'committed' -- cannot record again"`. The `evo done` command exists for cases where a human recorded a score outside of `evo run`, which is not the discover flow.
+
+If gates failed, `evo run` exits non-zero and leaves the experiment in a failed state. Fix the benchmark or target inside the worktree, commit, then `evo run exp_0000` again.
+
+**If `evo run` fails with a path error** (typically: `benchmark.py` not found), the stored benchmark command is missing the `{worktree}` placeholder. Confirm with `evo config get benchmark`, then fix it in place: `evo config set benchmark "<correct command>"`. Re-run `evo run exp_0000` if attempts remain; otherwise `evo discard exp_0000 --reason "..."` and re-allocate.
+
+## 12. Write `.evo/project.md`
+
+Lives at the top level of `.evo/` (run-agnostic, stable path regardless of active run). `evo init` creates an empty stub; overwrite it.
+
+Document:
+- What the target does
+- What can be changed by optimization vs what must stay stable
+- How to interpret benchmark output (score meaning, direction)
+- **Benchmark determinism** -- one line, pick what fits:
+  - `deterministic by construction` -- pure code, no randomness, no network
+  - `uses LLMs with temp=0` -- expected to be deterministic in practice; flag if it isn't
+  - `sampling-based, variance expected` -- inherent noise; optimize will need multi-run strategies
+- Environment requirements discovered during validation
+- What each gate protects
+- Benchmark gaming risks identified during the Goodhart check
+- Future experiment candidates (the non-picked dimensions from step 3)
+
+## 13. Report to the user
+
+End the skill by reporting in chat:
+
+- The dashboard URL (if not already mentioned)
+- The baseline experiment ID and score
+- The chosen optimization dimension and why
+- A one-liner on next steps: "Run `/evo:optimize` to start the optimization loop."
+- **Resume after crash:** if the host, the shell, or the machine restarts mid-flow, re-invoke `evo:optimize`. Evo reads `.evo/` and resumes from the last committed experiment -- no special restore procedure.
+- **State is local to this machine:** experiment commits on branches like `evo/run_0000/exp_*` survive `git push --all`, but orchestration state (graph, annotations, project notes) lives only in `.evo/`. If that history matters to you, back up `.evo/` separately (e.g., `tar -czf evo-state-$(date +%F).tar.gz .evo/`).
+
+## Inspection commands (for debugging, reference only)
+
+```bash
+evo show <id>                       # full state of one experiment (attempts, diffs, annotations, notes)
+evo config show                     # redacted workspace configuration
+evo config runtime show             # runtime prepare/before-run/prefix recipe
+evo env show                        # redacted runtime env metadata
+evo traces <id> <task>              # per-task trace
+evo annotate <id> <task> "analysis" # record failure analysis
+evo scratchpad                      # bounded state summary
+evo gate list <id>                  # effective gates at a node (inherited)
+evo gate check <id>                 # run effective gates without benchmark or state mutation
+```
+
+## Rules
+
+- Do NOT modify main after `evo init` unless the user explicitly asks. All new artifacts live in worktree 0.
+- Do NOT install packages without the user's confirmation from step 5.
+- Do NOT skip the held-out gate pairing when the benchmark was constructed from scratch. The gate is the safety net against Goodhart gaming, regardless of whether the benchmark is deterministic.
+- Do NOT skip the Goodhart check when the benchmark was constructed from scratch. Gate pairing is mandatory, not optional.

--- a/plugins/evo/npm/skills/discover/references/constructing-benchmark.md
+++ b/plugins/evo/npm/skills/discover/references/constructing-benchmark.md
@@ -1,0 +1,167 @@
+# Constructing a benchmark from scratch
+
+Used when the chosen optimization dimension doesn't have an existing eval -- you have to build the harness. This happens often in early-stage projects, or when the proposed dimension is an unexplored one nobody's measured before.
+
+**All construction happens inside the baseline worktree (experiment 0), not in main.** Main stays free of evo-specific infrastructure. The constructed benchmark becomes part of the baseline commit; all descendant experiments inherit it automatically.
+
+## Contents
+
+- Design the scoring function
+- Assemble test cases
+- Write the runnable harness
+- Goodhart check
+- Held-out validation slice
+- Required gate pairing
+- Commit discipline
+
+## 1. Design the scoring function
+
+Before writing any code, decide exactly what the score means. Answer in one sentence each:
+
+- **What single number does the benchmark output?** (e.g., "mean pass rate across N tasks")
+- **Higher is better, or lower?** (`--metric max` vs `--metric min`)
+- **What's the theoretical range?** (0.0 to 1.0 / unbounded / bounded by implementation)
+- **What does a "meaningful" improvement look like?** (noise floor vs real signal)
+
+If you can't answer these cleanly, the benchmark is premature -- iterate on the design before coding.
+
+## 2. Assemble test cases
+
+Benchmark quality is dominated by test case quality. Cheap-but-wrong tests produce noise or invite gaming.
+
+**For programmatic benchmarks** (deterministic scoring like pass/fail):
+
+- Aim for 10-20 cases at minimum -- fewer than 10 and random noise dominates.
+- Include at least one edge case per category of input (empty, malformed, boundary, large).
+- Each case should have a clear, independently-verifiable expected output.
+
+**For LLM-as-judge or fuzzy scoring:**
+
+- Write 15-30 cases with natural-language descriptions of what "good" looks like.
+- Include a calibration set: 3-5 obviously-good and 3-5 obviously-bad responses. Verify your judge scores them correctly before trusting it on ambiguous cases.
+
+**For performance benchmarks** (latency, throughput, memory):
+
+- Use realistic workload shapes, not synthetic microbenchmarks -- p99 on a real trace is more useful than average on a loop.
+- Warm up before measuring (first run is often JIT/cache-cold).
+- Take multiple samples and report the aggregate (p50/p95/p99 or mean+stderr), not a single run.
+
+## 3. Write the runnable harness
+
+Output contract (same as existing evo benchmarks):
+
+- **score channel:** a single JSON object with a `score` field and optional `tasks` breakdown, written to `$EVO_RESULT_PATH`. Example: `{"score": 0.78, "tasks": {"0": 1.0, "1": 0.5, ...}}`
+- **stdout / stderr:** free for user output (logs, progress, debug)
+- **exit code:** 0 on successful completion (even if score is low); non-zero only on infrastructure failure (import error, missing data, etc.)
+
+Use the SDK or inline instrumentation depending on the user's earlier choice (recorded in `.evo/meta.json` as `instrumentation_mode`).
+
+## 4. Goodhart check
+
+The core risk of a constructed benchmark: *evo will optimize the metric, not the underlying thing you care about*. Every constructed benchmark needs an explicit Goodhart audit before being committed.
+
+Ask these questions:
+
+1. **Can the metric go up without the underlying thing improving?** Think of at least one degenerate way to game it (e.g., "special-case the exact inputs in the test set", "output a constant that averages well", "return early with a trivial answer"). If you can think of gaming strategies, evo will find them faster.
+
+2. **Can the metric go up while breaking something obviously important?** E.g., optimizing latency by dropping correctness, or optimizing accuracy by eliminating an entire class of input.
+
+3. **What's the held-out signal that would catch gaming?** If evo gets a suspiciously high score, what independent test would reveal the gaming?
+
+Document the answers in `.evo/project.md` under a "Benchmark gaming risks" section, and mitigate each with either:
+
+- A **held-out validation slice** (see next section)
+- A **paired gate** (see required gate pairing section)
+- A **sanity assertion** baked into the scoring function
+
+## 5. Held-out validation slice
+
+When constructing a benchmark from hand-written test cases, split them:
+
+- **Training slice** (what evo sees): 60-70% of cases. This is the score evo optimizes.
+- **Held-out slice** (what evo can't see): 30-40% of cases. Evaluated separately after each committed experiment.
+
+If the training score improves but the held-out score doesn't (or regresses), evo is overfitting to the specific training cases. The held-out score becomes either a gate or an annotation that the orchestrator watches.
+
+For the initial v0.1.0 flow, implement the held-out slice as a **gate** (next section). For a later iteration, add first-class support in the evo CLI for "hidden eval" scoring that's orthogonal to the optimization score.
+
+## 6. Required gate pairing
+
+Any benchmark constructed from scratch MUST be paired with at least one gate. The gate catches gaming that the optimizer-visible metric can't.
+
+Common pairings:
+
+| Benchmark style | Minimum paired gate |
+|---|---|
+| Hand-written task pass rate | Held-out slice (other tasks, not visible during optimization) |
+| Latency / performance | Correctness test (the optimized code must still produce the same outputs) |
+| LLM-as-judge rating | Structural validity check (output parses / is well-formed) |
+| Quality-of-output score | Sanity assertion that catches degenerate outputs (empty, constant, out-of-range) |
+
+Add the gate via `evo gate add root --name <name> --command <command>` during the discover flow. The gate runs alongside every experiment. An experiment that breaks a gate is not committed even if the benchmark score improves; it remains an evaluated node until an agent fixes and reruns it or explicitly discards it.
+
+**The gate command must exit non-zero on regression.** `evo run` checks exit code, not stdout. A bare `python3 benchmark.py --task-ids 5,6,9` always exits 0 because the benchmark script's contract is "exit 0 unless infrastructure broke" -- it prints a low score but never fails. To make a benchmark-derived gate actually catch regressions, the benchmark needs a `--min-score <threshold>` flag (or equivalent) that:
+
+1. Computes the score on the requested slice as usual.
+2. Compares against the threshold.
+3. Calls `sys.exit(1)` (or `process.exit(1)`) when the score is below the threshold.
+
+The inline helpers (`references/inline_instrumentation.py` / `.js`) make this easy: `write_result()` returns the final score, so you can do something like:
+
+```python
+score = write_result()
+if args.min_score is not None and score < args.min_score:
+    print(f"GATE FAIL: score {score:.4f} below minimum {args.min_score}", file=sys.stderr)
+    sys.exit(1)
+```
+
+When you pick the threshold for the held-out gate, set it to the baseline score on that slice (or slightly below if the slice is small enough that one-task variance matters). That gives you "any regression on the held-out tasks fails the gate" semantics.
+
+## 7. Commit discipline
+
+All construction artifacts are committed to experiment 0's branch, not main:
+
+- `benchmark.py` (or equivalent) -- the harness script
+- Test fixtures, golden outputs, calibration data
+- Any new gate scripts (if gates reference new files rather than existing tests)
+- The instrumented form of the target (SDK or inline)
+
+**Add a `.gitignore` first, before the first commit.** Running the benchmark will produce build artifacts (`__pycache__/`, `.pytest_cache/`, `node_modules/`, etc.) that will be captured by `git add -A` and pollute the experiment branch. Also include `.evo/` as a guard -- validation runs should target the main repo root's workspace, but if anything lands in the worktree's `.evo/` by accident, don't commit it. Minimum contents:
+
+```
+.evo/
+__pycache__/
+*.pyc
+.pytest_cache/
+node_modules/
+dist/
+build/
+```
+
+Commit in logical chunks where possible:
+
+1. "add: .gitignore for build artifacts"
+2. "add: benchmark harness + test cases"
+3. "add: instrumentation" (only in SDK mode -- inline mode keeps harness and instrumentation in one file)
+
+Running `evo run <exp_id>` captures the baseline score and marks the experiment committed in a single step. No separate `evo done` is needed.
+
+## Rollback
+
+If the Goodhart check flags an unmitigable gaming risk, or the benchmark doesn't run cleanly, discard experiment 0 with `evo discard <exp_id>` and restart from root with a simpler benchmark.
+
+## A note on non-determinism
+
+Some benchmarks have inherent noise (LLM calls, random sampling, concurrent execution, network latency). We deliberately skip a front-loaded multi-run determinism check during setup -- it costs real money for LLM-based benchmarks and delays the first optimization iteration for limited safety value at this stage of the project.
+
+Honest accounting of what this means today:
+
+- Current evo compares experiment scores directly and supports bounded retries for evaluated nodes, but it does **not** yet average across independent runs or use confidence intervals. A noisy benchmark can therefore commit a "lucky" experiment as a real improvement.
+- The held-out gate remains the only safety net against benchmark gaming and overfitting. It is mandatory whenever the benchmark was constructed from scratch (see "Required gate pairing" above).
+- Multi-run / variance-aware optimization is on the roadmap but not implemented yet. Until it lands, **noisy benchmarks should be expected to produce noisier optimization trees** -- some committed experiments will not reproduce.
+
+Record what you know about the benchmark's determinism in `.evo/project.md`, one line under "Benchmark determinism":
+
+- `deterministic by construction` -- pure code, no randomness, no network. Safest case.
+- `uses LLMs with temp=0` -- expected to be deterministic in practice; flag in project.md if observed runs disagree.
+- `sampling-based, variance expected` -- inherent noise. Optimization will be noisier; rely on the held-out gate as the truthful signal.

--- a/plugins/evo/npm/skills/discover/references/inline_instrumentation.js
+++ b/plugins/evo/npm/skills/discover/references/inline_instrumentation.js
@@ -1,0 +1,97 @@
+/**
+ * Inline instrumentation for Node benchmarks. Paste into the benchmark and
+ * call logTask() per task + writeResult() once at the end.
+ *
+ * Contract:
+ * - Reads EVO_TRACES_DIR, EVO_EXPERIMENT_ID, EVO_RESULT_PATH from process.env.
+ * - Writes traces/task_<id>.json per task.
+ * - Writes the final result JSON to EVO_RESULT_PATH, or stdout if unset.
+ */
+
+import {
+  writeFileSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  renameSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+const TRACES_DIR = process.env.EVO_TRACES_DIR || null;
+const EXPERIMENT_ID = process.env.EVO_EXPERIMENT_ID || "unknown";
+const RESULT_PATH = process.env.EVO_RESULT_PATH || null;
+const SCORES = {};
+const TASK_META = {};
+const STARTED_AT = new Date().toISOString().replace(/\.\d{3}Z$/, "+00:00");
+
+if (TRACES_DIR) mkdirSync(TRACES_DIR, { recursive: true });
+
+/**
+ * Record the result for one task. `direction` is "max" (higher is better,
+ * default) or "min" (lower is better, e.g. latency). Set it only when this
+ * task's direction differs from the benchmark's top-level --metric.
+ * Propagates to tasks_meta in the final result JSON.
+ */
+export function logTask(taskId, score, { summary, failureReason, log, direction, ...extra } = {}) {
+  taskId = String(taskId);
+  if (direction !== undefined && direction !== "max" && direction !== "min") {
+    throw new Error(`direction must be 'max' or 'min', got ${JSON.stringify(direction)}`);
+  }
+  SCORES[taskId] = score;
+  if (direction !== undefined) TASK_META[taskId] = { direction };
+  if (!TRACES_DIR) return;
+  const trace = {
+    experiment_id: EXPERIMENT_ID,
+    task_id: taskId,
+    status: score >= 0.5 ? "passed" : "failed",
+    score,
+    ended_at: new Date().toISOString().replace(/\.\d{3}Z$/, "+00:00"),
+  };
+  if (direction !== undefined) trace.direction = direction;
+  if (summary !== undefined) trace.summary = summary;
+  if (failureReason !== undefined) trace.failure_reason = failureReason;
+  if (log !== undefined) trace.log = log;
+  Object.assign(trace, extra);
+  writeFileSync(join(TRACES_DIR, `task_${taskId}.json`), JSON.stringify(trace, null, 2), "utf-8");
+}
+
+export function writeResult(score) {
+  const ids = Object.keys(SCORES);
+  if (score === undefined) {
+    score = ids.length === 0 ? 0.0 : ids.reduce((a, id) => a + SCORES[id], 0) / ids.length;
+  }
+  score = Math.round(score * 10000) / 10000;
+  const result = {
+    score,
+    tasks: { ...SCORES },
+    started_at: STARTED_AT,
+    ended_at: new Date().toISOString().replace(/\.\d{3}Z$/, "+00:00"),
+  };
+  if (Object.keys(TASK_META).length > 0) {
+    result.tasks_meta = Object.fromEntries(
+      Object.entries(TASK_META).map(([k, v]) => [k, { ...v }])
+    );
+  }
+  const payload = JSON.stringify(result, null, 2);
+  if (RESULT_PATH) {
+    mkdirSync(dirname(RESULT_PATH), { recursive: true });
+    // Claim + tmp+rename: duplicate writers fail-fast; crash mid-publish
+    // leaves an empty file (caught by load_result) not a partial write.
+    try {
+      closeSync(openSync(RESULT_PATH, "wx"));
+    } catch (e) {
+      if (e.code === "EEXIST") {
+        throw new Error(
+          `${RESULT_PATH} already exists; only one writeResult() per attempt`
+        );
+      }
+      throw e;
+    }
+    const tmp = RESULT_PATH + ".tmp";
+    writeFileSync(tmp, payload, "utf-8");
+    renameSync(tmp, RESULT_PATH);
+  } else {
+    process.stdout.write(payload + "\n");
+  }
+  return score;
+}

--- a/plugins/evo/npm/skills/discover/references/inline_instrumentation.py
+++ b/plugins/evo/npm/skills/discover/references/inline_instrumentation.py
@@ -1,0 +1,109 @@
+"""Inline instrumentation for Python benchmarks. Paste into the benchmark
+and call `log_task()` per task + `write_result()` once at the end.
+
+Contract:
+- Reads EVO_TRACES_DIR, EVO_EXPERIMENT_ID, EVO_RESULT_PATH from env.
+- Writes traces/task_<id>.json per task.
+- Writes the final result JSON to EVO_RESULT_PATH, or stdout if unset.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_TRACES_DIR = Path(os.environ["EVO_TRACES_DIR"]) if os.environ.get("EVO_TRACES_DIR") else None
+_EXPERIMENT_ID = os.environ.get("EVO_EXPERIMENT_ID", "unknown")
+_RESULT_PATH = os.environ.get("EVO_RESULT_PATH")
+_SCORES: dict[str, float] = {}
+_TASK_META: dict[str, dict[str, Any]] = {}
+_STARTED_AT = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+if _TRACES_DIR:
+    _TRACES_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def log_task(
+    task_id: str,
+    score: float,
+    *,
+    summary: str | None = None,
+    failure_reason: str | None = None,
+    log: list[Any] | None = None,
+    direction: str | None = None,
+    **extra: Any,
+) -> None:
+    """Record the result for one task. Writes task_<id>.json immediately.
+
+    *direction* is "max" (higher is better, default) or "min" (lower is
+    better, e.g. latency). Only set it when this task's direction differs
+    from the benchmark's top-level `--metric`. Propagates to `tasks_meta`
+    in the final result JSON for downstream selection strategies.
+    """
+    task_id = str(task_id)
+    if direction is not None and direction not in ("max", "min"):
+        raise ValueError(f"direction must be 'max' or 'min', got {direction!r}")
+    _SCORES[task_id] = score
+    if direction is not None:
+        _TASK_META[task_id] = {"direction": direction}
+    if _TRACES_DIR is None:
+        return
+    trace: dict[str, Any] = {
+        "experiment_id": _EXPERIMENT_ID,
+        "task_id": task_id,
+        "status": "passed" if score >= 0.5 else "failed",
+        "score": score,
+        "ended_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    if direction is not None:
+        trace["direction"] = direction
+    if summary is not None:
+        trace["summary"] = summary
+    if failure_reason is not None:
+        trace["failure_reason"] = failure_reason
+    if log is not None:
+        trace["log"] = log
+    trace.update(extra)
+    (_TRACES_DIR / f"task_{task_id}.json").write_text(
+        json.dumps(trace, indent=2), encoding="utf-8"
+    )
+
+
+def write_result(score: float | None = None) -> float:
+    """Write the final score JSON to $EVO_RESULT_PATH (or stdout if unset)
+    and return the score. The return lets callers gate on --min-score
+    without recomputing the aggregate.
+    """
+    if score is None:
+        score = sum(_SCORES.values()) / len(_SCORES) if _SCORES else 0.0
+    score = round(score, 4)
+    result = {
+        "score": score,
+        "tasks": dict(_SCORES),
+        "started_at": _STARTED_AT,
+        "ended_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    if _TASK_META:
+        result["tasks_meta"] = {k: dict(v) for k, v in _TASK_META.items()}
+    payload = json.dumps(result, indent=2)
+    if _RESULT_PATH:
+        target = Path(_RESULT_PATH)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Claim + tmp+rename: duplicate writers fail-fast; crash mid-publish
+        # leaves an empty file (caught by load_result) not a partial write.
+        try:
+            os.close(os.open(target, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+        except FileExistsError:
+            raise RuntimeError(
+                f"{target} already exists; only one write_result() per attempt"
+            ) from None
+        tmp = target.with_name(target.name + ".tmp")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, target)
+    else:
+        print(payload)
+    return score

--- a/plugins/evo/npm/skills/discover/references/proposing-dimensions.md
+++ b/plugins/evo/npm/skills/discover/references/proposing-dimensions.md
@@ -1,0 +1,52 @@
+# Proposing unexplored optimization dimensions
+
+Used only when the benchmark isn't obvious — no existing eval, ambiguous user intent, or the existing eval covers a narrow slice while the interesting optimization sits elsewhere. If the right benchmark *is* obvious, use it and skip this exercise.
+
+When this step does run, the goal is to propose a handful of dimensions for this repo that aren't already measured. Existing benchmarks cover what the authors already worried about; that's where slack is lowest.
+
+## Where to look
+
+1. **Already-instrumented code.** Grep for `time.`, `perf_counter`, `@profile`, `Counter(`, `metrics.`. What's tracked hints at what authors cared about; what isn't is where slack lives.
+2. **Stated goals.** READMEs, module docstrings, and comments often name what the project values ("fast JSON parsing", "robust against malformed input"). If a stated goal isn't measured, that's a proposal.
+3. **Author pain points.** Grep for `TODO`, `FIXME`, `XXX`, `HACK`. Check the issue tracker if accessible.
+4. **Project-type defaults.** The table below, as a starting point.
+
+## Ranking
+
+For each candidate, answer three questions honestly in prose. No scores — a 1-5 slack rating from an LLM is a vibe, not a measurement.
+
+- **Signal.** Does moving this metric actually correlate with "the project is better"? Or is it a proxy that could drift from what the user cares about?
+- **Slack.** Has anyone hill-climbed this before in this repo? Is there plausibly room to improve, or is the current value already near a floor/ceiling?
+- **Cost per run.** How long and how expensive is one benchmark run? The optimization loop runs many — expensive dimensions compound into real time and money.
+
+Rank on a combined judgment of those three. Construction effort (the one-time cost of building the harness) is not a ranking input — flag it qualitatively when presenting, let the user weigh it.
+
+## Project-type defaults
+
+Start with the obvious column, then look hard at the non-obvious column.
+
+| Project type | Obvious (often already done) | Non-obvious (usually unexplored) |
+|---|---|---|
+| LLM / agent | Task pass rate on a benchmark | Token efficiency per correct answer, calibration error, refusal rate on ambiguous tasks, behavior under prompt injection, latency per tool call, recovery from tool errors |
+| Web API / backend | Test pass rate, integration tests | p99 latency on hot endpoints, memory per request, error rate under synthetic load, cold-start time, allocation count per request |
+| ML training | Validation accuracy, loss | Sample efficiency (accuracy per 1k tokens seen), robustness to input perturbations, generalization gap, inference memory, convergence speed |
+| Library / SDK | API tests passing | Import time, allocation count per call, TypeScript strict-mode coverage, docs coverage, cold-import latency, binary size |
+| Compiler / DSL | Correctness on standard suite | Output code size, compile time, optimization quality on standard benchmarks, error message quality (LLM-as-judge), stack trace usefulness |
+| Data pipeline | End-to-end correctness | Throughput (rows/sec), memory peak per batch, late-data handling, schema-drift resilience, idempotency under replay |
+| CLI tool | Unit tests | Cold-start time, memory footprint, output stability across runs, exit-code correctness on edge inputs, help-text discoverability |
+| RAG / retrieval | Recall@K | Embedding cost per indexed doc, query latency p99, answer grounding rate (% of claims traceable to source), robustness to paraphrased queries |
+
+## Presenting to the user
+
+For each ranked dimension include:
+
+- **What it measures** (one sentence)
+- **Why it matters for this project** (tied to what the repo actually does, not generic)
+- **Construction complexity**: *None* (existing eval already produces this score) / *Minor* (wrap or instrument what exists) / *Substantial* (new test cases, scoring logic, or data)
+- **Existing coverage** if any
+
+Recommend the highest-ranked dimension whose construction is *None* or *Minor*. If every top pick is *Substantial*, say so and let the user decide whether the signal is worth the work.
+
+## Non-picked dimensions
+
+Save unused dimensions to `.evo/project.md` under a "Future experiment candidates" section — useful when the first dimension plateaus.

--- a/plugins/evo/npm/skills/discover/references/sdk_node.js
+++ b/plugins/evo/npm/skills/discover/references/sdk_node.js
@@ -1,0 +1,28 @@
+// Node SDK usage example. Install: `npm install @evo-hq/evo-agent`.
+//
+// The SDK auto-reads $EVO_TRACES_DIR, $EVO_EXPERIMENT_ID, and
+// $EVO_RESULT_PATH. Traces flush on each report() so the dashboard can
+// stream progress live.
+
+import { Run, Gate } from '@evo-hq/evo-agent';
+
+// ---- Benchmark run ----
+
+const run = new Run();
+for (const task of tasks) {
+  const result = await evaluate(task);
+  run.log(task.id, { output: result.output });
+  run.report(task.id, { score: result.score });
+}
+await run.finish();
+// finish(): writes score JSON to $EVO_RESULT_PATH (or stdout if unset)
+// and one task_<id>.json per task under $EVO_TRACES_DIR.
+
+// ---- Gate (exits 0 all-pass / 1 any-fail) ----
+
+const gate = new Gate();
+for (const task of criticalTasks) {
+  const result = await evaluate(task);
+  gate.check(task.id, { score: result.score });
+}
+await gate.finish();

--- a/plugins/evo/npm/skills/discover/references/sdk_python.py
+++ b/plugins/evo/npm/skills/discover/references/sdk_python.py
@@ -1,0 +1,43 @@
+"""Python SDK usage examples.
+
+Install `evo-hq-agent` with this project's package manager/runtime, for example
+`uv add --dev evo-hq-agent` or `python -m pip install evo-hq-agent`.
+
+The SDK auto-reads $EVO_TRACES_DIR, $EVO_EXPERIMENT_ID, and $EVO_RESULT_PATH.
+Traces flush on each report() so the dashboard can stream progress live.
+"""
+
+from evo_agent import Run, Gate
+
+
+# ---- Benchmark run ----
+
+run = Run()
+try:
+    for task in tasks:
+        run.log(task["id"], "starting task")
+        try:
+            result = evaluate(task, agent)
+            run.log(task["id"], {"output": result.output})
+            run.report(
+                task["id"],
+                score=result.score,
+                summary=f"reward={result.score:.2f}",
+                failure_reason=None if result.passed else "task_failed",
+            )
+        except Exception as exc:
+            run.log(task["id"], {"error": repr(exc)})
+            run.report(task["id"], score=0.0, failure_reason="exception")
+finally:
+    run.finish()
+# finish() writes score JSON to $EVO_RESULT_PATH (or stdout if unset) and one
+# task_<id>.json per task under $EVO_TRACES_DIR. Catch expected per-task errors;
+# an uncaught exception before finish() means evo correctly sees a crashed run.
+
+
+# ---- Gate (exits 0 all-pass / 1 any-fail) ----
+
+with Gate() as gate:
+    for task in critical_tasks:
+        result = evaluate(task, agent)
+        gate.check(task["id"], score=result.score)

--- a/plugins/evo/npm/skills/discover/scripts/validate_result.py
+++ b/plugins/evo/npm/skills/discover/scripts/validate_result.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate a benchmark result file.
+
+Usage: python3 validate_result.py <path-to-result.json>
+
+Exits 0 if the file exists, is non-empty, and is a JSON object with a
+numeric 'score'. Exits 1 with a diagnostic on stderr otherwise.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <result.json>", file=sys.stderr)
+        return 1
+
+    path = Path(sys.argv[1])
+
+    if not path.exists():
+        print(f"FAIL: {path} does not exist", file=sys.stderr)
+        return 1
+
+    if path.stat().st_size == 0:
+        print(f"FAIL: {path} is empty", file=sys.stderr)
+        return 1
+
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"FAIL: {path} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(obj, dict):
+        print(f"FAIL: expected JSON object, got {type(obj).__name__}", file=sys.stderr)
+        return 1
+
+    if "score" not in obj:
+        print(f"FAIL: missing 'score' field. Keys: {list(obj.keys())}", file=sys.stderr)
+        return 1
+
+    try:
+        score = float(obj["score"])
+    except (TypeError, ValueError):
+        print(f"FAIL: 'score' is not numeric: {obj['score']!r}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {path}, score = {score}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: infra-setup
+description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
+disable-model-invocation: true
+---
+
+# Infra Setup
+
+Use this when the user wants to change where experiments run: local worktrees, pool slots, or a remote provider such as Modal, E2B, Daytona, AWS, Azure, SSH, manual, or a custom dotted-path provider.
+
+## Goals
+
+- Be explicit about the target backend/provider.
+- Check prerequisites before mutating evo config.
+- Never install provider SDKs silently.
+- Give one actionable auth command per provider.
+- Keep provider credentials separate from benchmark runtime env.
+
+## Flow
+
+1. Identify the target:
+   - `worktree` or `pool` means local backends.
+   - `modal`, `e2b`, `ssh:...`, or another remote spec means `backend=remote`.
+2. If the target is remote, parse the provider choice the same way evo CLI does:
+- `modal`
+- `e2b`
+- `daytona`
+- `aws`
+- `azure`
+- `manual`
+- `ssh:user@host[:port]`
+   - another built-in provider name
+   - dotted import path for a custom provider
+3. Check whether `evo` is on PATH and whether it is the expected `evo-hq-cli` package (`evo --version`). If the provider SDK is missing, evo's provider loader prints the provider-specific extra or SDK package to install; use that message rather than guessing.
+4. For SDK-backed providers, verify the SDK import only when you can run the check in the same environment that owns the `evo` executable. If missing, ask the user before installing it.
+   - If `evo` was installed with `uv tool` or `pip`/`venv`, prefer the matching extra on `evo-hq-cli`:
+     - `uv-tool`: `uv tool install --reinstall 'evo-hq-cli[<provider-extra>]'`
+     - `venv` / `pip`: `python -m pip install 'evo-hq-cli[<provider-extra>]'`
+   - If `evo` was installed with `pipx`, inject the provider SDK into the same `evo-hq-cli` environment:
+     - `pipx`: `pipx inject evo-hq-cli <provider-sdk>`
+5. Check auth and show exactly one provider-specific auth command or setup step. Use `references/provider-matrix.md`.
+6. Once prerequisites are satisfied, run the explicit config command:
+
+```bash
+evo config backend remote --provider <provider> --provider-config ...
+```
+
+Or for local backends:
+
+```bash
+evo config backend worktree
+evo config backend pool --workspaces /abs/slot-a,/abs/slot-b
+```
+
+7. Be explicit that incomplete provider setup usually surfaces on
+   `evo new --remote <provider> ...`, because that is where remote
+   allocation and bootstrap actually happen.
+8. If the benchmark itself needs application keys, configure runtime env
+   separately with `evo env load <path> --all` or
+   `evo env load <path> --allow KEY1,KEY2`. Provider auth provisions the
+   sandbox; runtime env is what benchmark/gate processes see.
+
+## Pre-assumptions
+
+Before trying to switch a workspace to a remote provider, confirm the basics:
+
+- the target backend is clear from the user's request; only ask if the
+  intent is genuinely ambiguous between `worktree`, `pool`, and `remote`
+- the machine running evo has the right provider SDK or transport installed
+- the user has auth for that provider available now, not "somewhere else"
+- the provider-specific minimum config exists
+  - `modal`: auth + optional config
+  - `e2b`: API key + optional config
+  - `daytona`: API key and API URL/target if needed
+  - `aws`: creds, region, image, SSH key pair/private key, and usually network config
+  - `azure`: subscription, resource group, region, SSH key/private key, and VM/image choices
+  - `ssh`: reachable host, working SSH user, and key/port if needed
+  - `manual`: reachable remote endpoint URL and bearer token
+- for SSH-backed VM providers, the guest assumptions are plausible before allocation:
+  - the image enables SSH
+  - the SSH user matches the image
+  - the image architecture matches the selected instance type
+  - the host can run evo's remote workspace runtime
+
+## Provider notes
+
+See `references/provider-matrix.md` for the compact provider summary, common config, and provider-specific setup/auth command.

--- a/plugins/evo/npm/skills/infra-setup/references/provider-matrix.md
+++ b/plugins/evo/npm/skills/infra-setup/references/provider-matrix.md
@@ -1,0 +1,25 @@
+## Provider Matrix
+
+Use this as the compact summary. This is setup guidance, not a runtime dependency list for evo itself.
+
+| Provider | What evo uses at runtime | Setup / auth | Common config |
+|---|---|---|---|
+| `modal` | Modal Python SDK | If missing, install `evo-hq-cli[modal]` (or inject `modal` with `pipx`); then run `modal token new` | `app_name`, `gpu`, `region`, `timeout_seconds`, `health_timeout_seconds`, `apt_install`, `pip_install` |
+| `e2b` | E2B Python SDK | If missing, install `evo-hq-cli[e2b]` (or inject `e2b` with `pipx`); then `export E2B_API_KEY=...` | `template`, `api_key`, `domain`, `root`, `timeout_seconds`, `health_timeout_seconds`, `allow_internet_access`, `secure` |
+| `daytona` | Daytona Python SDK | If missing, install `evo-hq-cli[daytona]` (or inject `daytona` with `pipx`); then `export DAYTONA_API_KEY=...` | `api_key`, `api_url`, `target`, `timeout_seconds`, `health_timeout_seconds`, `ssh_host`, `ssh_port`, `ssh_token_ttl_minutes`, `sandbox_timeout_seconds` |
+| `aws` | `boto3` | If missing, install `evo-hq-cli[aws]` (or inject `boto3` with `pipx`); then export AWS creds and region | `region`, `image_id`, `key_name`, `key`, `instance_type`, `subnet_id`, `security_group_ids`, `ssh_user`, `ssh_port`, `timeout_seconds`, `health_timeout_seconds`, `keep_warm` |
+| `azure` | Azure Python SDK (`azure-identity`, `azure-mgmt-resource`, `azure-mgmt-network`, `azure-mgmt-compute`) | If missing, install `evo-hq-cli[azure]`; then use `az login` or Azure env creds, and provide subscription/resource-group config | `subscription_id`, `resource_group`, `location`, `vm_size`, `image`, `key`, `ssh_public_key`, `ssh_user`, `ssh_cidr`, `vnet_cidr`, `subnet_cidr`, `ssh_port`, `timeout_seconds`, `health_timeout_seconds`, `keep_warm` |
+| `ssh` | local `ssh` transport | `ssh user@host` must work first; then add `-i` / `-p` if needed | `host`, `key`, `port`, `tunnel_port`, `keep_warm`, `health_timeout_seconds` |
+| `manual` | existing remote workspace endpoint | no provisioning; only ask for URL/token if the user explicitly wants manual mode | `base_url`, `bearer_token`, `workspace_root`, `bundle_dir` |
+
+Notes:
+- `evo` runtime uses the provider SDK or transport listed in the second column.
+- The `evo-hq-cli[<provider>]` extras are the preferred install path when the provider SDK is missing.
+- Provider auth/setup is operator guidance. It is not the same thing as evo's runtime dependency surface.
+- Common failures are usually one of: missing SDK import, missing auth state/env var, unreachable host/port, or provider-specific bootstrap mismatch.
+- Incomplete provider setup usually surfaces on `evo new --remote <provider> ...`, because that is where remote allocation and bootstrap actually happen.
+- For SSH-backed VM providers, also validate the guest assumptions:
+  - the instance image has SSH enabled
+  - the SSH user matches the image
+  - the image architecture matches the selected instance type
+  - the remote host can run evo's remote workspace runtime

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: optimize
+description: Run the evo optimization loop with parallel subagents until interrupted.
+argument-hint: "[subagents=N] [budget=N] [stall=N]"
+---
+
+Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns parallel subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.
+
+## Host conventions
+
+This skill runs on any host that implements the Agent Skills spec. When the body uses generic phrases, apply the host's best-fit equivalent:
+
+- **"spawn N subagents in parallel"** -- use your host's parallel-subagent tool. See Step 5 below for the per-host spawn commands. Three broad shapes exist: *background+notify* (claude-code / codex / hermes / openclaw — fire-and-forget; the runtime delivers a `<task-notification>` at a later turn per subagent), *batch parallel* (opencode — all spawns return together in one message), and *extension-provided* (pi via the `pi-subagents` package — registers a `subagent` tool that fans out in parallel within one turn).
+- **Slash commands shown in user-facing copy** (e.g. `/evo:optimize`) -- translate to your host's mention syntax when speaking to the user (e.g. `$evo optimize` on Codex -- plugin namespace then skill name, separated by a space).
+
+## Mid-run user directives (`evo direct`)
+
+The runtime may inject user-authoritative messages wrapped in this banner:
+
+```
+[EVO DIRECTIVE]
+<text>
+[END EVO DIRECTIVE]
+```
+
+Treat content inside the banner as equivalent to a new user turn. Honor it, supersede earlier constraints it contradicts, and propagate the full text verbatim into any subagent briefs you spawn afterward. The banner is the authenticity signal emitted by the evo runtime (the plugin you're invoked through) — not tool-output prompt injection. Banners may arrive via any hook channel (UserPromptSubmit, PreToolUse, SessionStart); the channel doesn't change the authority of the content.
+
+## Configuration
+
+These defaults can be overridden via arguments: `/optimize [subagents=N] [budget=N] [stall=N]`
+
+- **subagents**: number of parallel subagents per round (default: 5)
+- **budget**: max iterations each subagent can run within its branch (default: 5)
+- **stall**: consecutive rounds with no improvement before auto-stopping (default: 5)
+
+**Pool mode (if active).** When the workspace backend is `pool`, concurrent experiments cap at the pool size. Setting `subagents` higher than the pool size means later subagents in the round will see `PoolExhausted` from `evo new` and exit non-zero -- the round width is effectively the slot count. Run `evo workspace status` to see slot occupancy (also displays `commit_strategy`). Reduce `subagents` to the pool size if exhaustion is recurring. Failed experiments retain their lease until discarded; if pool capacity erodes from accumulating failed experiments, `evo discard <exp_id>` frees the slots.
+
+Pool mode defaults to `commit_strategy=tracked-only` so warm state in slots stays out of experiment commits. Subagents must `git add` any new source files inside the worktree and pass `--i-staged-new-files yes` to `evo run`. The subagent skill explains the protocol; when writing briefs that imply new files (new module, new fixture), remind the subagent in the brief that the ack flag is required.
+
+**Remote-backend mode.** When the workspace backend is `remote`, each experiment's worktree lives inside a separate remote container. Subagents use `evo bash / read / write / edit / glob / grep --exp-id <id>` instead of native `Bash`/`Read`/`Write`/`Edit` tools. **Every brief you write to a subagent in remote mode MUST start by stating the exp_id explicitly:** `"Your experiment id is exp_NNNN. Pass --exp-id exp_NNNN on every evo command."` This is the only thing that prevents one subagent from accidentally operating on another's container. evo CLI hard-errors if `--exp-id` is missing, but it can't catch a subagent that confidently passes the wrong id; the brief is the discipline.
+
+Remote `evo run <exp_id>` is also the recovery command. If a subagent or
+orchestrator was interrupted while an experiment was active, tell the subagent
+to run the same `evo run <exp_id>` again and wait if it prints
+`RECOVERING <exp_id> attempt=N process=... state=...`. That means evo is
+reattaching to the existing remote process and finalizing the original attempt;
+starting a new experiment or discarding the active one is only appropriate after
+evo reports the attempt is unrecoverable.
+
+For expensive benchmarks, design recovery around `EVO_CHECKPOINT_DIR`, not
+process checkpoint/restore. evo mirrors checkpoint files into
+`attempts/NNN/checkpoints/` during remote runs and writes `attempt_state.json`
+for phase-level recovery. If the remote container itself dies, arbitrary process
+memory is gone; the benchmark must know how to continue from its checkpoint
+files or the attempt should be treated as `remote_infra_failure`.
+
+**Infra setup is not user-invocable.** If a remote provider is missing SDKs, auth, or setup details, read `plugins/evo/skills/infra-setup/references/provider-matrix.md`. It summarizes what each provider actually needs and replaces the old per-provider prompt files.
+
+**Runtime recipe/env.** Benchmark runtime is evo configuration, not something subagents should rediscover or copy into worktrees. Use `evo config runtime show` for prepare/before-run/prefix and `evo env show` for redacted env sources. If a run fails because expected runtime setup or env is missing, report it as setup failure or configure it from the orchestrator; do not patch benchmark code to bake in secrets or local paths. Use `evo run <exp_id> --check` for non-committing wiring validation; do not invent ad-hoc validation wrappers.
+
+**CLI reference.** If you are unsure which command to use, read `plugins/evo/skills/references/cli-quick-reference.md`. It is the canonical command map; this skill only repeats the high-frequency commands.
+
+## Prerequisites
+
+- Workspace must be initialized (`evo status` should succeed)
+- A baseline experiment must be committed (run `/discover` first)
+- All benchmark dependencies must be available in the environment
+
+## Architecture
+
+```
+Orchestrator (this agent):
+  - Reads state, identifies failure patterns cross-cutting the tree
+  - Writes one brief per subagent: objective + parent + boundaries + pointer traces
+  - Verifies briefs are diverse (no two attacking the same surface)
+  - Collects results, prunes dead branches, adjusts strategy
+
+  Subagent A (brief, budget: N iterations):
+    - Reads its pointer traces, forms the concrete edit
+    - Creates experiment, edits target, runs benchmark, analyzes
+    - If budget remains and sees a promising follow-up, continues
+    - Can run up to N serial experiments on its own branch
+    - Returns: what it tried, what worked, what it learned
+
+  Subagent B (different brief, budget: N iterations):
+    - Same protocol, non-overlapping objective
+    ...
+```
+
+Both layers read traces; the depth differs. The orchestrator scans for cross-cutting patterns (which failures are common, which branches plateau) -- enough to pick N non-overlapping briefs. Subagents read their pointer traces in depth, enough to commit to a concrete edit. Structured briefs are what prevent parallel subagents from duplicating each other's work.
+
+**Session lineage.** Dispatching a child of a committed experiment forks the parent experiment's own session, not a separately-warmed explorer. The child inherits the parent's full transcript -- reads, edits, benchmark output -- so the prefix cache carries through generations. Explorer warming runs only for children of root, where the parent has no session.
+
+**Trace instrumentation style**: `.evo/meta.json`'s `instrumentation_mode` records `sdk` vs `inline`. Subagents must stay consistent with it (see the **evo subagent skill** for details).
+
+## The Loop
+
+Repeat until interrupted or stall limit reached:
+
+### 1. Read current state
+
+**Step 0 (always, before anything else): ensure you have read `.evo/project.md`.** Its contents define the optimization metric and goal; every pattern you report MUST be tied to a failure mode of that goal. If you haven't read it yet in this session, read it now -- before listing experiments, opening any `outcome.json`, or spawning sub-agents. If the file is missing, stop and tell the user.
+
+**Step 0.1 (one-time auto-migration): ensure the workspace knows what runtime you are.** Run `evo host show`. If it prints `<not set>`, the workspace pre-dates the host signature field — declare your runtime now: `evo host set <one of: claude-code, codex, opencode, openclaw, hermes, pi, generic>`. You know what runtime you're operating in (your system prompt, env vars like `CLAUDECODE=1`, your own self-identity); pick the matching value. If genuinely unsure, use `generic`. Do not ask the user — this is a one-time silent migration. Subsequent rounds skip this step (`evo host show` returns the recorded value).
+
+```bash
+evo scratchpad          # bounded state summary (tree, frontier, awaiting decision, gates, annotations, what-not-to-try, notes)
+evo status              # one-line summary
+evo frontier            # explorable nodes ranked by the configured strategy (JSON envelope: {strategy, nodes[{id,score,rank,...}], generated_at})
+evo show <id>           # full state of one node (attempts, diffs, annotations, notes, effective gates) -- the cleanest one-node getter
+evo awaiting            # evaluated nodes awaiting commit/discard decision
+evo discards [--like <text>]  # discarded nodes; useful for "have we tried this before"
+evo notes               # all notes (per-node + workspace), recent first
+evo annotations         # all annotations (filterable with --task/--exp)
+evo path <id>           # root-to-node chain with scores
+evo diff <id> [<other>] # diff vs parent (or between two experiments)
+evo gate list <id>      # effective gates for a node (inherited from ancestors)
+evo gate check <id>     # run effective gates without benchmark or state mutation
+evo infra log           # recorded infra/strategy events (epoch bumps, harness changes)
+
+# Settings (read)
+evo config show               # everything; use the next three for narrower views
+evo config get <field>        # one field
+evo config backend show       # current execution backend + provider config
+evo config runtime show       # runtime prepare/before-run/prefix recipe
+evo env show                  # redacted runtime env metadata
+```
+
+### 2. Analyze state and do structural aggregation
+
+From the scratchpad, frontier, traces, and annotations, determine:
+- Which frontier nodes are most promising (`evo frontier` returns them already ranked under the configured strategy -- use its ordering rather than re-ranking; override with `evo frontier --strategy ...` only if you have a specific reason)
+- What failure patterns are most common and impactful
+- What strategies have been tried and their outcomes
+- Which branches are plateauing or exhausted
+- What gates exist on each frontier node (`evo gate list <id>`) -- subagents must satisfy these
+
+**Read the "Awaiting Decision" section of the scratchpad.** Evaluated nodes (ran, bad outcome, not yet discarded) are a cross-agent signal: if three subagents in the last round produced evaluated nodes that all failed the same gate, surface the pattern -- maybe the gate is too tight, maybe the approach has a shared flaw. Either tell the next round to avoid it, or propose a brief that attacks it directly. Without this cross-cutting read, each subagent rediscovers the same wall independently.
+
+**Structural pass.** For the evaluated nodes this round, load their `outcome.json` files into Python and aggregate: co-occurring `gate_failures`, shared zero-score task IDs in `benchmark.result.tasks`, recurring substrings across `error` fields. (Bulk-reading attempt artifacts under `.evo/run_*/experiments/<exp>/attempts/<NNN>/` is the right tool for this — `evo show <id>` is for one-node introspection, not batch aggregation.)
+
+**Emit intersections explicitly.** After computing the per-pattern sets (call them A, B, ...), MUST emit each pairwise intersection `A ∩ B` as a distinct pattern entry whenever at least 2 experiments exhibit both. Intersections carry different strategic implications from their components (compound failures warrant different briefs than single-failure clusters) and do not reconstruct from sub-agent summaries -- this is a parent-level aggregation that must happen inline.
+
+**Improvers are a pattern too.** Enumerate the committed improvers (experiments with `outcome=committed` and `score > parent_score`) as a distinct pattern entry: they are candidate parent nodes for next-round branching and feed the brief's *Parent node* field.
+
+Hold all these findings; step 4's brief-writing combines them with the scan sub-agents' findings from step 3.
+
+### 3. Spawn scan sub-agents for cross-cutting free-text analysis
+
+**Hard rule (primary delegation).** The orchestrator MUST spawn at least one scan sub-agent via your host's parallel-subagent tool in every round before emitting any pattern. This applies to all scan input -- `outcome.json`, `traces/task_*.json`, annotations, and `error` fields alike -- regardless of file size, structure, or whether the orchestrator believes a script would be faster. An inline Python aggregation over `outcome.json` does NOT substitute for delegation; it may supplement sub-agent findings (step 2's structural pass still runs), but step 3's scan sub-agents MUST still run. If you reach step 4 without a completed scan sub-agent call in step 3, you have violated this rule -- stop and spawn one.
+
+**Narrow exception (verification).** After scan sub-agents have returned findings, the orchestrator MAY read individual trace files to: verify a specific finding before citing it in a brief, spot-check a pattern the orchestrator is unsure about, or pull a short quote for a brief's Objective or Pointer Traces field. These verification reads must be narrow (<=3 trace files per round, targeted at experiment IDs already surfaced by sub-agents). This exception does NOT let you skip the hard rule above -- it only governs what you may do after sub-agents have already run.
+
+Partition the evaluated experiments into batches small enough that each sub-agent can read its batch's traces in one pass. Spawn one scan sub-agent per batch in a **single batch** using your host's parallel-subagent tool (see "Host conventions"). They must execute in parallel, not sequentially.
+
+Pass this brief verbatim as the sub-agent's prompt:
+
+> You are a read-only evo scan sub-agent. Do not run experiments or edit code.
+>
+> Start by reading `.evo/project.md` to understand the optimization goal and metric. All your findings should be relevant to this goal.
+>
+> Your batch: `[exp_IDs]`.
+>
+> For each experiment, read `outcome.json` and `traces/task_*.json`. Also consider `hypothesis` and prose `error` text.
+>
+> Find patterns that will populate the next round's subagent briefs:
+> - **Shared failure causes** -- root-cause reasons recurring across 2+ experiments (the *why*, not the surface gate name). Feeds brief objectives.
+> - **Wall patterns** -- approaches or gates multiple experiments consistently fail on. Feeds brief boundaries / anti-patterns.
+> - **Compound-failure standouts** -- single experiments hitting multiple failure modes. Feeds brief pointer traces.
+>
+> Prioritize patterns tied to the goal's core failure modes or critical tasks. Deprioritize incidental observations. Skip: trace-shape statistics, fixture-structural facts, hypothesis-string-reuse, or anything the orchestrator can't act on in a brief.
+>
+> If your batch is still too heavy, partition further and spawn scan sub-agents recursively (same brief, smaller batch).
+>
+> Return JSON only: `{"findings": [{"description": "<short>", "experiment_ids": ["exp_XXXX", ...], "evidence": ["<short snippet>", ...]}]}`
+>
+> **Evidence must be verbatim quotes** from outcome.json fields, trace `messages`, or `error` text -- not paraphrases. Each description must be supported by the quoted evidence. **Do not speculate about causal chains** (e.g., "approach X regresses because it removes Y") unless a specific trace message or error field directly states that mechanism. If you cannot cite verbatim evidence for a finding, drop it -- err on under-reporting.
+>
+> Evidence: short quotes (<200 chars each), max 3 per finding.
+
+Wait for all scan sub-agents to return. Reconcile near-duplicate findings (`timeout_error` ≈ `error_timeout`) by judgment and combine with the structural-pass findings from step 2.
+
+**Verify every pattern before emitting it.** For each pattern in your final output, confirm that at least one reported experiment's outcome.json or trace content contains evidence that directly supports the pattern's description. If you cannot cite a specific field value or quoted message as evidence, drop the pattern. Do not emit speculative causal attributions ("approach X regresses because it removes Y") unless the trace or error text explicitly states that mechanism. This filter applies to both sub-agent findings and your own inline observations.
+
+These unified, verified cross-cutting findings feed step 4's brief-writing.
+
+### 4. Write subagent briefs
+
+Write **one brief per subagent** with these four fields:
+
+1. **Objective** -- one sentence describing the bottleneck to attack and the evidence for it. Should name *where in the system's behavior* the gain is hiding (e.g., "tool-use error recovery fails after the first bad call across tasks 2, 5, 7") but **must not name specific files, functions, or concrete edits** -- that's the subagent's job after it reads the code.
+2. **Parent node** -- which experiment to branch from.
+3. **Boundaries / anti-patterns** -- what this subagent should NOT try, explicitly called out with reasons. Include approaches already tried and discarded (from "What Not To Try"), gates it must not regress, and anything adjacent subagents in this round are doing (so it doesn't duplicate).
+4. **Pointer traces** -- task IDs the subagent should study first, with a one-line reason each.
+
+Be specific and bounded. Vague briefs like "improve accuracy" cause subagents to duplicate each other's work; structured briefs prevent it.
+
+**Diversity check (before spawning).** Re-read the N briefs side by side. If two briefs:
+- point at the same objective phrased differently, OR
+- cite overlapping pointer traces without meaningfully different framings, OR
+- attack the same area of the system,
+
+merge or re-scope one of them. The frontier/pruning logic handles tree-level exploration vs exploitation algorithmically -- the orchestrator's job is just to make sure the round's N briefs don't collapse onto each other.
+
+### 5. Spawn parallel optimization subagents
+
+Spawn all subagents in a **single batch** using your host's parallel-subagent tool. They must execute in parallel, not sequentially -- serial execution defeats the per-round width.
+
+Per host, the spawn shape matters because evo's loop depends on *completion notifications* arriving turn-by-turn (so the orchestrator can review each subagent's outcome and decide round 2):
+
+- **claude-code** — fire one `Bash(run_in_background=true)` call per brief. The bash invokes the subagent (the host's `Task` tool, or any equivalent that runs the brief to completion). Each backgrounded bash returns immediately and the runtime delivers a `<task-notification>` at a later turn when each subagent finishes. Do NOT wait on subagents inline; fan them out, then exit your current turn — notifications arrive in subsequent turns.
+- **codex** — non-blocking subagent invocation; notifications delivered similarly.
+- **hermes** — `terminal(background=true)`; notifications delivered similarly.
+- **openclaw** — `sessions_spawn deliver:false`; notifications delivered similarly.
+- **opencode** — *batch-parallel only* (no background notifications). Fire N `task` calls in ONE assistant message; all `tool_result`s return together when the slowest finishes. Plan all parallel work (including non-task tools) in that single message — opencode cannot interleave reasoning across turns while subagents run.
+- **pi** — *batch-parallel via extension*. Pi's default toolkit has no subagent primitive; `evo install pi` ensures the `pi-subagents` package is present, which registers a `subagent` tool. Fire N `subagent` calls in ONE assistant message; all results return together when the slowest finishes (same shape as opencode). If the `subagent` tool isn't available, fall back to running experiments sequentially in your own turn (`evo new` → `evo run` per attempt) and tell the user to `pi install npm:pi-subagents` for proper fanout.
+
+Respect the host's concurrency cap; batch if N exceeds it.
+
+Pick a faster model for straightforward briefs and a stronger model for harder ones requiring deeper trace analysis, if your host exposes per-call model selection.
+
+Each subagent prompt MUST start with the literal sentence:
+
+> "First, load and follow the **evo subagent skill** (named `subagent` under the evo plugin in your host's skill registry — use your host's skill loader, not a filesystem path). Allocate your experiment via `evo new --parent <id>`, edit inside the returned worktree, evaluate via `evo run <exp_id>`. Do not skip these steps even if the brief looks simple."
+
+Then append:
+- The four-field brief verbatim (objective, parent, boundaries/anti-patterns, pointer traces)
+- The iteration budget
+- A one-paragraph scratchpad summary (current best score, frontier nodes, recent failures) for context
+
+The opening sentence is non-negotiable — without it small models often skip the evo CLI and edit files directly, which produces no committed experiments and breaks the round.
+
+### 6. Collect results and update state
+
+After all subagents complete:
+
+- Review each subagent's summary
+- Record the round's best score and compare to the previous best
+- If no subagent improved the score, increment the stall counter
+- If any improved, reset the stall counter
+- Check if subagents added new gates -- note these in your state tracking
+- If multiple experiments failed the same gate, consider whether the gate is too restrictive or the briefs were aimed at the wrong surface
+
+**Cross-cut the round's evaluated nodes.** Before moving on, read `experiments/<id>/attempts/NNN/outcome.json` for each evaluated node from this round. The structured `gates[]` entries and `benchmark.result` let you spot shared failure modes the subagent summaries may have glossed over (e.g., three different subagents produced evaluated nodes whose gate_failures all included `refund_flow` -- that's a structural constraint the next round must confront, not three independent bad hypotheses).
+
+Prune dead branches where 3+ children all regressed:
+  ```bash
+  evo prune <exp_id> --reason "exhausted: N children all regressed"
+  ```
+
+`evo prune` accepts `committed` or `evaluated` nodes. Use it when you want
+to mark a lineage exhausted while preserving the result for later review or
+reference. Prune keeps the git commit alive (anchored at `refs/evo-anchor/<run>/<exp>`)
+so the node can be restored if needed. **Never `evo discard` a committed
+node** — it would orphan the branch ref and risk losing the commit.
+
+If a previously-pruned (or discarded-then-restored) node is worth revisiting:
+  ```bash
+  evo restore <exp_id>
+  ```
+Flips status back to committed; recreates the regular branch from the anchor
+ref so future `evo new --parent <id>` works. For discarded nodes whose commit
+is no longer reachable in git (rare; needs `git gc --prune=now` after the
+discard), restore errors and points at `experiments/<id>/attempts/NNN/diff.patch`
+for manual replay.
+
+Update notes with cross-cutting learnings:
+  ```bash
+  evo set <exp_id> --note "key insight from round N"
+  ```
+
+### 7. Continue or stop
+
+**Continue** if:
+- Stall counter < stall limit
+- User hasn't interrupted
+- Score hasn't reached the theoretical maximum
+
+**Stop** if:
+- Stall counter >= stall limit (N consecutive rounds with no improvement)
+- Score reached theoretical maximum (1.0 for max metric, 0.0 for min metric)
+- User interrupted
+
+On stop, print a final summary:
+- Best score achieved and experiment ID
+- Total experiments run across all rounds
+- The winning diff: `evo diff <best_exp_id>`
+- Suggested next steps if the score hasn't converged
+
+Go back to step 1.
+
+## Resetting the eval epoch
+
+`evo infra event -m "<reason>" --breaking` bumps `current_eval_epoch` and blocks
+non-root `evo run` calls until a new root baseline commits. Old experiments
+stay in the tree but are excluded from frontier and best-score lookups via
+their epoch tag.
+
+Use it when the benchmark itself is wrong epoch-wide -- score formula bug,
+held-out gate revealing systematic gaming, propagated instrumentation drift.
+Don't use it for single bad experiments (`evo discard`) or one tight gate
+(relax the gate at the relevant node).
+
+Recovery:
+1. `evo infra event -m "<reason>" --breaking`
+2. Fix the harness in the baseline worktree (or branch a fresh root).
+3. `evo new --parent root -m "v2 baseline: <what changed>"`
+4. `evo run <new_exp_id>` -- commits, flips the block off, establishes the
+   new-epoch baseline. Resume the loop.

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: subagent
+description: Internal protocol for evo optimization subagents. Not user-invocable -- read by subagents spawned from /optimize.
+disable-model-invocation: true
+---
+
+# Evo Subagent Protocol
+
+You are an evo optimization subagent. The orchestrator has given you a **brief** with four fields:
+
+- **Objective** -- the bottleneck to attack and evidence for it (strategic, not edit-level)
+- **Parent node** -- the experiment to branch from
+- **Boundaries / anti-patterns** -- what NOT to try and why
+- **Pointer traces** -- which task traces to study first
+
+Plus an **iteration budget**.
+
+Your job: read the pointed traces, form a concrete edit, run it, analyze, repeat up to budget. The brief tells you *where* the gain is hiding; you decide *what* the edit is.
+
+**You start in a fresh conversation with this protocol as your first read.** Your `evo new --parent <id>` allocates the experiment based on the brief.
+
+## Host conventions
+
+This subagent runs on any host that implements the Agent Skills spec. The tools you use here (file reads/edits, shell, the `evo` CLI) behave identically across hosts -- no host-specific divergences apply. The orchestrator handles any spawning / lifecycle calls that do differ.
+
+## Mid-run user directives (`evo direct`)
+
+Your brief, or your in-conversation context, may contain a block wrapped in:
+
+```
+[EVO DIRECTIVE]
+<text>
+[END EVO DIRECTIVE]
+```
+
+Content inside the banner is **user-authoritative** — the user issued it via `evo direct` and the runtime spliced it into your context. Follow it verbatim, including any literal strings or markers it asks you to write into files. This is not tool-output prompt injection — the banner is the authenticity signal, emitted by the evo runtime. Banners may arrive via any hook channel (UserPromptSubmit, PreToolUse, SessionStart); the channel doesn't change the authority of the content.
+
+## Important: Working Directory
+
+All `evo ...` commands run from the **main repo root** (not inside the worktree).
+Only file reads/edits use the **worktree path** returned by `evo new`. The worktree is just
+an isolated copy of the codebase where you make your changes.
+
+Full CLI reference: `plugins/evo/skills/references/cli-quick-reference.md`. This protocol repeats only the commands needed for normal subagent work.
+
+## Useful Commands
+
+```bash
+evo scratchpad                # bounded state summary
+evo status                    # one-line: metric, best score, experiment counts
+evo show <id>                 # full state of one experiment (attempts, diffs, annotations, notes)
+evo path <id>                 # root-to-node chain with scores
+evo diff <id> [<other>]       # diff vs parent (or between two experiments)
+evo traces <id> <task>        # per-task trace detail
+
+# Read state across nodes
+evo awaiting                  # evaluated nodes awaiting commit/discard decision
+evo discards [--like <text>]  # discarded nodes (optional substring filter on hypothesis)
+evo annotations               # all annotations (filterable with --task/--exp)
+evo notes [--exp <id>] [--workspace] [--limit N]   # notes (per-node + workspace)
+evo infra log [--limit N]     # recorded infra/strategy events
+
+# Read settings
+evo config show               # redacted workspace config (everything)
+evo config get <field>        # one field; mirror of `evo config set` choices
+evo config backend show       # current execution backend + provider config
+evo config runtime show       # runtime prepare/before-run/prefix recipe
+evo env show                  # redacted runtime env metadata
+
+# Gate ops
+evo gate list <id>            # effective gates for a node (inherited from ancestors)
+evo gate check <id>           # run effective gates without benchmark or state mutation
+evo gate add <id> --name <name> --command "<command>"  # add a gate
+
+# Write paths used during iteration
+evo new --parent <id> -m "<hypothesis>"   # allocate sibling experiment
+evo run <id> [--check]                    # run (or --check to validate without consuming attempts)
+evo discard <id> --reason "<text>"        # reject + park (keeps anchor ref)
+evo restore <id>                          # un-discard or un-prune
+evo annotate <id> [<task_id>] "<text>"    # per-attempt analysis
+evo set <id> --note "<text>" [--tag <t>]  # per-node note from orchestrator
+evo note "<text>"                         # workspace-level cross-cutting note
+```
+
+For the read/write policy across worktree files, `.evo/` artifacts, and config,
+see `references/cli-quick-reference.md` "Reading workspace state".
+
+## First Steps
+
+1. Read `.evo/project.md` to understand the target, what can be changed, and how to interpret results.
+2. Read the scratchpad for current state: `evo scratchpad`
+   It surfaces: best path (★-marked in the tree), frontier (strategy-ranked branchable nodes), evaluated nodes awaiting decision, gates, annotations, what not to try, infra events, and notes. The Drill-downs section at the bottom lists the read-only commands for going deeper on any section.
+3. Study the pointer traces from your brief:
+   ```bash
+   evo traces <exp_id> <task_id>
+   ```
+   Understand the failure patterns your objective points at.
+
+## Iteration Loop
+
+Repeat up to **budget** times:
+
+### 0. Re-read shared state (skip on first iteration)
+
+Before formulating your next edit, refresh your view of what other agents have done:
+
+```bash
+evo status
+evo scratchpad
+```
+
+Check for:
+- **Best score reached ceiling** (1.0 for max, 0.0 for min) -- if so, stop and report.
+- **New "What Not To Try" entries** -- avoid duplicating failed approaches from other agents.
+- **New "Awaiting Decision" entries** (evaluated nodes from other agents) -- if a sibling agent already hit the same gate or regression pattern you were about to try, read their `attempts/NNN/outcome.json` and diff before duplicating the attempt.
+- **New annotations** -- learn from others' findings on failing tasks.
+- **Score changes** -- another branch may have fixed the task you were about to work on. Adjust or stop.
+
+### 1. Formulate the edit
+
+Starting from the brief's objective and the traces you read, form a concrete edit hypothesis. It must name:
+- **Where** in the code: file, function, or behavior to change.
+- **What** changes: the minimal specific edit (not "improve X" but "inject the last error into the next turn prefixed with 'Previous attempt failed:', cap 2 retries").
+- **Predicted effect**: which task or behavior this should change and why.
+
+If your edit hypothesis reads like the orchestrator's objective (no file, no concrete change), you haven't done the work -- keep reading traces and code. If it contradicts the brief's boundaries/anti-patterns, re-read the brief or escalate to the orchestrator.
+
+### 2. Create experiment
+
+```bash
+evo new --parent <parent_id> -m "<your hypothesis>"
+```
+
+Parse the JSON output to get the experiment ID and worktree path.
+
+If you only need to validate benchmark/gate wiring before a real attempt, use `evo run <exp_id> --check`. It writes check artifacts but does not commit, evaluate, or consume retry budget.
+
+### 3. Edit the target
+
+How you edit depends on the workspace's execution backend (the `"worktree"` path returned by `evo new` tells you which case you're in):
+
+**Local backends (`--backend worktree` or `--backend pool`):** the worktree is a real path on this machine. Use your native `Read`/`Write`/`Edit` tools on that path directly. Example: `"target": "/path/to/.evo/run_0000/worktrees/exp_0005/src/agent.py"` -- read and edit that exact path.
+
+**Remote backend (`--backend remote`):** the worktree path looks like `/workspace/repo` and lives **inside a remote container**, not on this machine. Your native `Read`/`Write`/`Edit` would write to a non-existent local path and silently fail. Use `evo` workspace-op subcommands instead:
+
+```bash
+evo bash --exp-id <YOUR_EXP_ID> "<command>"
+evo read --exp-id <YOUR_EXP_ID> <path>
+evo write --exp-id <YOUR_EXP_ID> <path> --content "<text>"   # or pipe via stdin
+evo edit --exp-id <YOUR_EXP_ID> <path> --old "<s>" --new "<s>" [--replace-all]
+evo glob --exp-id <YOUR_EXP_ID> "<pattern>" [--path <dir>]
+evo grep --exp-id <YOUR_EXP_ID> "<pattern>" [--path <dir>]
+```
+
+`--exp-id` is **required** on every workspace op. The orchestrator gives you your exp_id at the start of the brief; pass it on every call. The check is strict by design: multiple subagents run concurrent experiments in different containers, and a silent default would let one subagent operate on another's container by accident.
+
+For multi-line edits, `evo edit --json-stdin` reads `{"old":...,"new":...,"replace_all":bool}` from stdin (avoids shell escaping for newlines / quotes).
+
+You may edit anything within the target scope. Do NOT modify benchmark, gate, or framework code.
+
+### 4. Run the experiment
+
+```bash
+evo run <exp_id>
+```
+
+This runs benchmark + gate and prints the result.
+
+In remote-backend workspaces, if a prior `evo run <exp_id>` was interrupted
+or the experiment is still `active`, run `evo run <exp_id>` again first. That
+is the recovery path: evo will try to attach to the existing remote process and
+finalize the same attempt instead of starting attempt 002. If the output prints
+`RECOVERING <exp_id> attempt=N process=... state=...`, wait for that command to
+finish. Do not discard the active experiment or create a replacement unless evo
+reports it is unrecoverable or the orchestrator explicitly tells you to.
+
+Benchmarks also receive `EVO_CHECKPOINT_DIR`. Expensive benchmarks should write
+portable progress files there. evo mirrors that directory back into
+`attempts/NNN/checkpoints/` during remote runs and records phase progress in
+`attempt_state.json`. This is the recovery boundary for container death: evo can
+restart from benchmark-owned checkpoint files, but it does not freeze/restore an
+arbitrary Linux process.
+
+**If the workspace was initialized with `commit_strategy=tracked-only` (the default for `--backend pool`):** `evo run` only commits modifications to *tracked* files. New files require an explicit `git add` from inside the worktree, then a shisa-kanko ack on the run command:
+
+```bash
+# inside the worktree -- only for new SOURCE files you want in the commit:
+cd <worktree_path> && git add path/to/new_file.py
+
+# then, from the main repo:
+evo run <exp_id> --i-staged-new-files yes
+```
+
+The ack flag is required when the worktree has any untracked, non-gitignored file. Without it, `evo run` errors closed and lists the files. For each file, decide: source (then `git add`) or warm state (leave untracked -- it persists in the slot for future experiments). Then re-run with `--i-staged-new-files yes`. The flag value must be exactly `yes`. In `commit_strategy=all` workspaces (default for `--backend worktree`) the flag is a silent no-op; safe to always pass.
+
+### 5. Analyze the result
+
+`evo run` prints one of three outcomes:
+
+- **`COMMITTED`** (score improved + gates passed): node locked in. Read failing task traces to find the next weakness. Use this experiment as the parent for your next iteration.
+
+- **`EVALUATED`** (score regressed or gate failed): ran cleanly but bad outcome. **You decide next step.** Read:
+  - `experiments/<id>/attempts/NNN/outcome.json` -- structured record: `score` vs `parent_score`, per-gate `passed`/`returncode`, benchmark result, error. Tells you *what* broke.
+  - `experiments/<id>/attempts/NNN/diff.patch` and `benchmark.log` -- tell you *why*.
+
+  Then either:
+  - Fixable edit-bug (off-by-one, wrong signature): edit the worktree and `evo run <id>` again. Bounded by `max_attempts` (default 3). Before retrying, compare your planned edit against the previous attempts' `outcome.json` on this same node -- if two earlier attempts hit the same gate, a small tweak won't fix it. When the cap is hit, run is refused -- you must discard.
+  - Hypothesis is wrong, no fix: `evo discard <id> --reason "..."` and branch a new experiment from the **original parent**.
+
+- **`FAILED`** (infra error, non-zero exit, timeout): couldn't evaluate. Doesn't consume the retry budget.
+  - Transient / fixable locally: retry.
+  - `remote_infra_failure:...`: remote container or agent infrastructure failed. Report it to the orchestrator unless your brief explicitly says to retry infra failures.
+  - Structural (benchmark broken, evo misconfigured): report to orchestrator and stop.
+  - Not worth fixing: `evo discard <id> --reason "..."`.
+
+### 6. Annotate
+
+```bash
+evo annotate <exp_id> "<what you changed, what happened, and why>"
+```
+
+Always annotate so other agents can learn from your experiments.
+
+### 6b. Add gates for fixed behaviors
+
+When you fix a critical, easy-to-regress behavior, lock it in as a gate so future experiments on this branch can't break it:
+
+```bash
+evo gate add <exp_id> --name "social_eng_resistance" --command "python3 {worktree}/benchmark.py --target {target} --task-ids 3 --min-score 0.9"
+```
+
+Good candidates: a specific benchmark task that was hard to fix, a test for a critical policy rule, a smoke test for a fragile behavior. The gate command must exit non-zero when the protected behavior regresses; a bare benchmark invocation that prints a low score but exits 0 is decorative and should not be registered. Do NOT gate every passing task -- that over-constrains the search.
+
+### 7. Decide: continue or stop
+
+Continue if budget remains AND (last outcome was committed, OR you have a meaningfully different idea after an evaluated/discarded outcome). When continuing after a committed experiment, update your parent to the newly committed ID.
+
+Stop if budget exhausted, infra failure, or you've exhausted variations with no improvement.
+
+## Enriching traces
+
+Check `.evo/meta.json` for `"instrumentation_mode"` (`"sdk"` or `"inline"`) to see which style the benchmark uses -- **stay consistent with that choice across iterations; do not flip styles mid-run.**
+
+Trace quality is part of the benchmark contract. After a failed baseline or failed task, the orchestrator should be able to reconstruct what happened using only `evo traces <exp_id> <task_id>`. If not, the trace logging is too thin.
+
+- **SDK mode** (`from evo_agent import Run`): read `plugins/evo/skills/references/agent-sdk-reference.md`, then enrich traces by adding `run.log(task_id, ...)` calls or extra fields to `run.report()`.
+- **Inline mode** (benchmark has local `log_task`/`logTask` helpers): add fields to the trace dict built inside `log_task()`.
+- **LLM / agent benchmarks**: log the task input, observation/frame summary, prompt or message summary, model/tool response, selected action, retries/errors, and final task outcome. If the project already has a separate recorder, decide whether evo traces mirror the important fields or whether the recorder artifact is explicitly linked from the evo trace.
+
+The trace format is forward-compatible -- extra fields are preserved. Do NOT change the score computation or gate logic -- only add observability.
+
+## Rules
+
+- Do NOT run `evo init` or `evo reset`
+- `evo discard <your_exp_id> --reason "..."` is your explicit "abandon" action — use it for any *non-committed* node you've decided not to pursue further (pre-run realization, evaluated with a bad hypothesis, or unfixable infra failure). Discard deletes the worktree and branch; the node and its per-attempt artifacts stay in `.evo/` as a record of what was tried.
+- If `evo discard` errors with **"cannot discard committed node ... use prune"** — the experiment cleared the gate and improved the score. You shouldn't be discarding it. Don't fight the error; the orchestrator owns committed-lineage decisions via `evo prune`.
+- If `evo discard` errors with **"cannot discard active node ... pass --force"** — the run is still in flight. Wait for it to finish; don't `--force` unless you know what you're doing (the running process can still write a final outcome that contradicts the discard).
+- If `evo discard` errors with **"cannot discard ... has non-discarded children"** — sibling/child experiments depend on this node's parent reference. Discard or commit-and-prune those first.
+- Do NOT copy `.env` files, bake secrets into source, or hard-code local runtime paths. Runtime setup/env is configured by the orchestrator (`evo config runtime ...`, `evo env ...`) and injected into benchmark/gate processes. If a missing dependency, setup step, or key blocks evaluation, report setup failure.
+- Always annotate your experiments, especially before discarding — the annotation is what persists after the worktree is gone.
+- Stay within your brief's objective and boundaries -- don't drift into unrelated changes
+
+## When Done
+
+Return a structured summary:
+
+```
+## Results
+- Experiments: <list of exp IDs with scores and status>
+- Best: <exp_id> with score <N>
+
+## Changes
+- <what you changed in each experiment, briefly>
+
+## Learnings
+- <what failure patterns you observed>
+- <what worked and what didn't>
+
+## Suggestions
+- <ideas for the next round that you didn't get to try>
+```

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.4.2-alpha.1"
+version = "0.4.2-alpha.2"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -164,12 +164,12 @@ build/
 ```bash
 evo init --name "<short project name>" \
   --target <file> --benchmark "<command using {worktree} and {target}>" --metric <max|min> \
-  --host <claude-code|codex|opencode|openclaw|hermes|generic> \
+  --host <claude-code|codex|opencode|openclaw|hermes|pi|generic> \
   --instrumentation-mode <sdk|inline> [--gate "<gate command>"] \
   [--commit-strategy <all|tracked-only>]
 ```
 
-**`--host` is required.** Pass the host runtime you (the orchestrator) are running under. Allowed values: `claude-code`, `codex`, `opencode`, `openclaw`, `hermes`, `generic`. This is recorded in `.evo/meta.json` so other commands can adapt to host-specific conventions. Pick the value matching the runtime you invoked `discover` from. Use `evo host set <value>` later if you change runtimes.
+**`--host` is required.** Pass the host runtime you (the orchestrator) are running under. Allowed values: `claude-code`, `codex`, `opencode`, `openclaw`, `hermes`, `pi`, `generic`. This is recorded in `.evo/meta.json` so other commands can adapt to host-specific conventions. Pick the value matching the runtime you invoked `discover` from. Use `evo host set <value>` later if you change runtimes.
 
 **`--name` should be a short human-readable project label** for dashboard display, chosen from the repository/product context. Existing workspaces without a name fall back to the repo directory name; do not hand-edit config just to migrate them.
 

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -10,7 +10,7 @@ Run the `evo` optimization loop. Each round, the orchestrator writes structured 
 
 This skill runs on any host that implements the Agent Skills spec. When the body uses generic phrases, apply the host's best-fit equivalent:
 
-- **"spawn N subagents in parallel"** -- use your host's parallel-subagent tool. See Step 5 below for the per-host spawn commands. Two broad shapes exist: *background+notify* (claude-code / codex / hermes / openclaw — fire-and-forget; the runtime delivers a `<task-notification>` at a later turn per subagent), and *batch parallel* (opencode — all spawns return together in one message).
+- **"spawn N subagents in parallel"** -- use your host's parallel-subagent tool. See Step 5 below for the per-host spawn commands. Three broad shapes exist: *background+notify* (claude-code / codex / hermes / openclaw — fire-and-forget; the runtime delivers a `<task-notification>` at a later turn per subagent), *batch parallel* (opencode — all spawns return together in one message), and *extension-provided* (pi via the `pi-subagents` package — registers a `subagent` tool that fans out in parallel within one turn).
 - **Slash commands shown in user-facing copy** (e.g. `/evo:optimize`) -- translate to your host's mention syntax when speaking to the user (e.g. `$evo optimize` on Codex -- plugin namespace then skill name, separated by a space).
 
 ## Mid-run user directives (`evo direct`)
@@ -101,7 +101,7 @@ Repeat until interrupted or stall limit reached:
 
 **Step 0 (always, before anything else): ensure you have read `.evo/project.md`.** Its contents define the optimization metric and goal; every pattern you report MUST be tied to a failure mode of that goal. If you haven't read it yet in this session, read it now -- before listing experiments, opening any `outcome.json`, or spawning sub-agents. If the file is missing, stop and tell the user.
 
-**Step 0.1 (one-time auto-migration): ensure the workspace knows what runtime you are.** Run `evo host show`. If it prints `<not set>`, the workspace pre-dates the host signature field — declare your runtime now: `evo host set <one of: claude-code, codex, opencode, openclaw, hermes, generic>`. You know what runtime you're operating in (your system prompt, env vars like `CLAUDECODE=1`, your own self-identity); pick the matching value. If genuinely unsure, use `generic`. Do not ask the user — this is a one-time silent migration. Subsequent rounds skip this step (`evo host show` returns the recorded value).
+**Step 0.1 (one-time auto-migration): ensure the workspace knows what runtime you are.** Run `evo host show`. If it prints `<not set>`, the workspace pre-dates the host signature field — declare your runtime now: `evo host set <one of: claude-code, codex, opencode, openclaw, hermes, pi, generic>`. You know what runtime you're operating in (your system prompt, env vars like `CLAUDECODE=1`, your own self-identity); pick the matching value. If genuinely unsure, use `generic`. Do not ask the user — this is a one-time silent migration. Subsequent rounds skip this step (`evo host show` returns the recorded value).
 
 ```bash
 evo scratchpad          # bounded state summary (tree, frontier, awaiting decision, gates, annotations, what-not-to-try, notes)
@@ -213,6 +213,7 @@ Per host, the spawn shape matters because evo's loop depends on *completion noti
 - **hermes** — `terminal(background=true)`; notifications delivered similarly.
 - **openclaw** — `sessions_spawn deliver:false`; notifications delivered similarly.
 - **opencode** — *batch-parallel only* (no background notifications). Fire N `task` calls in ONE assistant message; all `tool_result`s return together when the slowest finishes. Plan all parallel work (including non-task tools) in that single message — opencode cannot interleave reasoning across turns while subagents run.
+- **pi** — *batch-parallel via extension*. Pi's default toolkit has no subagent primitive; `evo install pi` ensures the `pi-subagents` package is present, which registers a `subagent` tool. Fire N `subagent` calls in ONE assistant message; all results return together when the slowest finishes (same shape as opencode). If the `subagent` tool isn't available, fall back to running experiments sequentially in your own turn (`evo new` → `evo run` per attempt) and tell the user to `pi install npm:pi-subagents` for proper fanout.
 
 Respect the host's concurrency cap; batch if N exceeds it.
 

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.4.2-alpha.1"
+__version__ = "0.4.2-alpha.2"

--- a/plugins/evo/src/evo/host_install/pi.py
+++ b/plugins/evo/src/evo/host_install/pi.py
@@ -25,6 +25,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -33,6 +34,19 @@ from pathlib import Path
 
 
 _SKILLS = ("discover", "optimize", "subagent", "infra-setup")
+
+# Pi extensions that register a parallel-subagent tool. Detected via the
+# substring appearing in ``pi list`` output OR in settings.json's
+# extensions[] paths. If none of these is present, `evo install pi`
+# auto-installs ``pi-subagents`` (the highest-traffic option) so the
+# optimize skill's parallel-fanout step works on pi out of the box.
+_KNOWN_SUBAGENT_PROVIDERS = (
+    "pi-subagents",
+    "pi-crew",
+    "taskplane",
+    "pi-collaborating-agents",
+)
+_DEFAULT_SUBAGENT_PROVIDER = "pi-subagents"
 
 # Same shape claude_code._RELEASE_VERSION_RE uses to decide whether to
 # auto-prefix with `v` for the GitHub tag URL. Branches/SHAs pass through.
@@ -161,6 +175,80 @@ def _fetch_skills_from_github(version: str | None) -> Path | None:
     return skills
 
 
+def _find_subagent_provider() -> str | None:
+    """Detect an installed pi extension that registers a parallel-subagent
+    tool. Returns the matched provider name or None.
+
+    Checks two sources:
+      1. ``pi list`` output (the canonical "what's installed" view).
+      2. settings.json#extensions[] paths (fallback when `pi` isn't on
+         PATH yet or `pi list` fails).
+    """
+    # Source 1: pi list.
+    pi_bin = shutil.which("pi")
+    if pi_bin is not None:
+        try:
+            result = subprocess.run(
+                [pi_bin, "list"],
+                capture_output=True, text=True, timeout=15, check=False,
+            )
+            haystack = (result.stdout or "") + (result.stderr or "")
+            for name in _KNOWN_SUBAGENT_PROVIDERS:
+                if name in haystack:
+                    return name
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Source 2: settings.json#extensions[] paths.
+    settings = _pi_settings_file()
+    if settings.exists():
+        try:
+            data = json.loads(settings.read_text())
+            paths_blob = " ".join(str(p) for p in data.get("extensions", []) or [])
+            for name in _KNOWN_SUBAGENT_PROVIDERS:
+                if name in paths_blob:
+                    return name
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def _ensure_subagent_provider() -> None:
+    """If no parallel-subagent extension is installed, install
+    ``pi-subagents`` (the default). Idempotent — no-ops when any known
+    provider (pi-subagents, pi-crew, taskplane, etc.) is already present.
+
+    The optimize skill needs a subagent tool to fan out round experiments
+    in parallel. Pi's default toolkit doesn't include one. We auto-install
+    so users don't have to do a second command.
+    """
+    existing = _find_subagent_provider()
+    if existing:
+        print(f"✓ subagent provider already installed: {existing}")
+        return
+
+    pi_bin = shutil.which("pi")
+    if pi_bin is None:
+        print(
+            "NOTE: `pi` binary not on PATH; skipping pi-subagents install.\n"
+            "  Install pi first (npm install -g @earendil-works/pi-coding-agent),\n"
+            "  then re-run `evo install pi` to get the parallel-subagent tool.",
+            file=sys.stderr,
+        )
+        return
+
+    print(f"installing {_DEFAULT_SUBAGENT_PROVIDER} (registers the `subagent` "
+          f"tool for parallel rounds)...")
+    cmd = [pi_bin, "install", f"npm:{_DEFAULT_SUBAGENT_PROVIDER}"]
+    print(f"$ {' '.join(cmd)}")
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        print(f"WARNING: `pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}` failed "
+              f"(rc={rc}); optimize will degrade to sequential execution.\n"
+              f"  Retry manually: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}",
+              file=sys.stderr)
+
+
 def _update_settings_extensions(settings: Path, target: str) -> bool:
     """Idempotent register: add `target` to settings.json#extensions[] if
     not already present. Returns True if file was modified.
@@ -249,6 +337,9 @@ def install(args: argparse.Namespace) -> int:
         getattr(args, "version", None),
     )
 
+    print("\nEnsuring a parallel-subagent provider is installed ...")
+    _ensure_subagent_provider()
+
     print("\nRestart any running pi session to load the extension and skills.")
     return 0
 
@@ -326,4 +417,12 @@ def doctor(args: argparse.Namespace) -> int:
 
     if shutil.which("pi") is None:
         print("? `pi` binary not on PATH (run `npm install -g @earendil-works/pi-coding-agent`)")
+
+    provider = _find_subagent_provider()
+    if provider:
+        print(f"✓ subagent provider present: {provider}")
+    else:
+        print("✗ no parallel-subagent provider installed")
+        print(f"  Run: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}")
+        rc = 1
     return rc

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -27,6 +27,7 @@ SOURCES = [
     ("sdk/python/pyproject.toml", "pyproject.toml (evo-hq-agent)"),
     ("sdk/python/src/evo_agent/__init__.py", "evo_agent/__init__.__version__"),
     ("sdk/node/package.json", "package.json (@evo-hq/evo-agent)"),
+    ("plugins/evo/npm/package.json", "package.json (@evo-hq/pi-evo)"),
 ]
 
 

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.4.2-alpha.1",
+  "version": "0.4.2-alpha.2",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.4.2-alpha.1"
+version = "0.4.2-alpha.2"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.4.2-alpha.1"
+__version__ = "0.4.2-alpha.2"


### PR DESCRIPTION
## Summary

0.4.2-alpha.1 added `pi` to the CLI's accepted `--host` values, but two related gaps surfaced in real use:

1. **Skill text was stale.** Agents reading `discover/SKILL.md` and `optimize/SKILL.md` saw the allowed-host enumeration without `pi`, mapped sessions to `--host generic`, and the optimize skill then refused to proceed ("no subagent support").
2. **Pi has no native subagent tool.** Default toolkit is `read, bash, edit, write`. Without a fanout extension installed, optimize degrades to sequential — slow + reduces evo's per-round width to 1.

This release closes both.

## Skill fix

`discover/SKILL.md` and `optimize/SKILL.md` now list `pi` in every host enumeration (3 spots in optimize, 2 in discover). The optimize skill's Step 5 documents pi's spawn shape as *batch-parallel via the `subagent` tool* (same shape as opencode), with a sequential fallback when the tool isn't available.

## pi-subagents auto-install

`host_install/pi.py` gains `_ensure_subagent_provider()`:
- Detects whether any known parallel-subagent extension is installed (`pi-subagents`, `pi-crew`, `taskplane`, `pi-collaborating-agents`)
- Detection sources: `pi list` first, fall back to scanning `settings.json#extensions[]` paths
- If none present, runs `pi install npm:pi-subagents` (89.7K/mo downloads; the canonical option)
- Idempotent — no-ops with a confirmation when a provider exists
- Doctor gains a matching `✓ subagent provider present` / `✗ no provider` line

Tested locally — `evo install pi` against a fresh `~/.pi/` installed pi-subagents successfully; doctor confirmed.

## Test plan

- [x] All 7 version-bearing files agree (`python3 scripts/check_versions.py`)
- [x] Local install in tmp `PI_HOME` → extension + skills + pi-subagents all land
- [x] Local doctor → all four checks pass
- [ ] e2b smoke (test_pi already validates the file-copy path; pi-subagents install path needs a separate smoke or in-line check)

## Follow-up (alpha.3, queued)

Publish `@evo-hq/pi-evo` to npm so users can `pi install npm:@evo-hq/pi-evo` directly. At that point `host_install/pi.py` collapses to a thin wrapper around pi's own package manager and pi-subagents moves into `bundledDependencies`. README docs the npm install path. Tracking in #15 (internal task).