### PR TITLE
v0.4.2: pi.dev as a first-class host

### DIFF
--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.3",
+  "version": "0.4.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.2",
+  "version": "0.4.2-alpha.3",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.3",
+  "version": "0.4.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.4.2-alpha.2",
+  "version": "0.4.2-alpha.3",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.4.2-alpha.3",
+  "version": "0.4.2",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.4.2-alpha.2",
+  "version": "0.4.2-alpha.3",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -18,10 +18,6 @@
     "extensions": ["./extensions"],
     "skills": ["./skills"]
   },
-  "dependencies": {
-    "pi-subagents": "*"
-  },
-  "bundledDependencies": ["pi-subagents"],
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "pi-agent-core": "*",

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.4.2-alpha.3"
+version = "0.4.2"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.4.2-alpha.2"
+version = "0.4.2-alpha.3"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.4.2-alpha.3"
+__version__ = "0.4.2"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.4.2-alpha.2"
+__version__ = "0.4.2-alpha.3"

--- a/plugins/evo/src/evo/host_install/pi.py
+++ b/plugins/evo/src/evo/host_install/pi.py
@@ -1,21 +1,23 @@
-"""Pi install — drop the bundled JS extension into ~/.pi/agent/extensions/evo/,
-register it in ~/.pi/agent/settings.json#extensions[], and copy the four
-evo skills under ~/.pi/agent/skills/evo-<name>/.
+"""Pi install — thin wrapper around `pi install npm:@evo-hq/pi-evo`.
 
-Pi (pi.dev, ``@earendil-works/pi-coding-agent``) is the upstream agent
-SDK that OpenClaw embeds. Pi's ExtensionAPI is the surface OpenClaw
-exposes, so the bundled extension at ``evo/openclaw_plugin/evo.bundle.js``
-loads cleanly on pi. We point at it directly rather than maintain a
-duplicate bundle: same source, two install adapters.
+Pi (pi.dev, ``@earendil-works/pi-coding-agent``) installs packages via
+its own marketplace mechanism. The evo package is published to npm
+as ``@evo-hq/pi-evo`` with a ``pi`` manifest pointing at the bundled
+extension and four skills, plus ``pi-subagents`` as a bundled dep so
+parallel rounds work out of the box.
 
-Differs from the openclaw adapter in three deliberate omissions:
-  1. No ``plugins.allow`` trust grants — pi has no per-plugin trust gate.
-  2. No openclaw-native ``tool_result_persist`` plugin — that hook is
-     openclaw-only. ``before_provider_request`` (used by the bundle) still
-     fires on pi 0.75.3 (verified by live probe at trials/pi-probe/).
-  3. No ``pi install <source>`` marketplace call for the skills — we
-     copy SKILL.md files directly. The pi marketplace path is available
-     if a published package is preferred later.
+Resolution order for the install spec:
+  1. ``--from-path <dir>`` → ``pi install <dir>/plugins/evo/npm``
+     (live tests, manual installs from a clone)
+  2. ``--version <X>`` → ``pi install npm:@evo-hq/pi-evo@<X>``
+     (pin to a specific release or to ``alpha`` dist-tag)
+  3. default → ``pi install npm:@evo-hq/pi-evo``
+     (resolves to the ``latest`` dist-tag)
+
+Migration: legacy file-copy installs (0.4.2-alpha.{1,2}) put files
+under ``~/.pi/agent/extensions/evo/`` and ``~/.pi/agent/skills/evo-*/``.
+Those still work — pi auto-discovers them — but they conflict with the
+npm-installed package's skills. Clean them up on install.
 """
 
 from __future__ import annotations
@@ -23,34 +25,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
-import tarfile
-import tempfile
-import urllib.request
 from pathlib import Path
 
 
-_SKILLS = ("discover", "optimize", "subagent", "infra-setup")
-
-# Pi extensions that register a parallel-subagent tool. Detected via the
-# substring appearing in ``pi list`` output OR in settings.json's
-# extensions[] paths. If none of these is present, `evo install pi`
-# auto-installs ``pi-subagents`` (the highest-traffic option) so the
-# optimize skill's parallel-fanout step works on pi out of the box.
-_KNOWN_SUBAGENT_PROVIDERS = (
-    "pi-subagents",
-    "pi-crew",
-    "taskplane",
-    "pi-collaborating-agents",
-)
-_DEFAULT_SUBAGENT_PROVIDER = "pi-subagents"
-
-# Same shape claude_code._RELEASE_VERSION_RE uses to decide whether to
-# auto-prefix with `v` for the GitHub tag URL. Branches/SHAs pass through.
-_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
+_NPM_PACKAGE = "@evo-hq/pi-evo"
+_LEGACY_SKILL_DIRS = ("evo-discover", "evo-optimize", "evo-subagent", "evo-infra-setup")
 
 
 def _pi_base() -> Path:
@@ -62,367 +44,189 @@ def _pi_settings_file() -> Path:
     return _pi_base() / "agent" / "settings.json"
 
 
-def _evo_extension_dir() -> Path:
-    return _pi_base() / "agent" / "extensions" / "evo"
+def _legacy_extension_path() -> Path:
+    """The pre-alpha.3 file-copy location for the bundled JS extension."""
+    return _pi_base() / "agent" / "extensions" / "evo" / "index.js"
 
 
-def _evo_extension_path() -> Path:
-    return _evo_extension_dir() / "index.js"
-
-
-def _pi_skills_dir() -> Path:
+def _legacy_skills_dir() -> Path:
     return _pi_base() / "agent" / "skills"
 
 
-def _bundled_extension_source() -> Path | None:
-    """Return the prebuilt JS extension bundle. Shared with openclaw —
-    the bundle targets pi's ExtensionAPI which openclaw embeds."""
-    here = Path(__file__).resolve().parent.parent  # evo/
-    bundle = here / "openclaw_plugin" / "evo.bundle.js"
-    return bundle if bundle.exists() else None
+def _pi_bin_or_error() -> str | None:
+    pi = shutil.which("pi")
+    if pi is None:
+        print(
+            "ERROR: `pi` binary not on PATH. Install pi first:\n"
+            "  npm install -g @earendil-works/pi-coding-agent",
+            file=sys.stderr,
+        )
+    return pi
 
 
-def _skills_source_root(from_path: str | None, version: str | None) -> Path | None:
-    """Locate the plugins/evo/skills/ source dir.
+def _resolve_install_spec(from_path: str | None, version: str | None) -> str:
+    """Map the install args to the `pi install <spec>` argument.
 
-    Resolution order:
-      1. ``--from-path`` (live tests, manual installs from a clone) —
-         expects either the plugin root or a parent containing
-         ``plugins/evo/skills/``.
-      2. Development checkout via ``__file__`` walk — works when running
-         against ``plugins/evo/src/`` directly.
-      3. GitHub tarball — for PyPI users, fetch the evo-hq/evo source
-         at the given ref (``--version`` if set, else default branch),
-         extract to a temp dir, and return the skills/ inside. Caller
-         is responsible for cleaning up the returned tree.
-
-    Returns None only if every path failed (e.g. download error).
+    `--from-path` wins over `--version` (used by live tests with a
+    local repo tarball; the bundle/skills are sync'd into
+    ``<from-path>/plugins/evo/npm`` by CI before publish).
     """
     if from_path:
-        base = Path(from_path)
-        for candidate in (base / "plugins" / "evo" / "skills", base / "skills"):
-            if candidate.exists():
-                return candidate
-
-    # __file__ = .../plugins/evo/src/evo/host_install/pi.py — present in
-    # a dev checkout, missing from a wheel install.
-    dev = Path(__file__).resolve().parents[3] / "skills"
-    if dev.exists():
-        return dev
-
-    return _fetch_skills_from_github(version)
-
-
-def _fetch_skills_from_github(version: str | None) -> Path | None:
-    """Download the evo-hq/evo source tarball at the given ref and
-    return the path to its plugins/evo/skills/ dir. Extracts into a
-    persistent location under the user's cache dir so repeat
-    `evo install pi` doesn't re-download.
-
-    `version` is the ``--version`` arg. Release-version shape gets
-    auto-prefixed with `v` (repo tag convention); any other shape
-    (branch, sha) passes through.
-    """
+        return str(Path(from_path) / "plugins" / "evo" / "npm")
     if version:
-        ref = f"v{version}" if _RELEASE_VERSION_RE.match(version) else version
-    else:
-        # Default branch — match what `evo install claude-code` does
-        # without --version (the host marketplace clones main).
-        ref = "main"
-    url = f"https://github.com/evo-hq/evo/archive/refs/heads/{ref}.tar.gz"
-    if ref != "main":
-        # Tags live under refs/tags. Try tag URL first; if the ref is a
-        # branch the heads URL handles it. Falling back to heads on 404
-        # would mask real misconfig, so we just use tags for ref != main.
-        url = f"https://github.com/evo-hq/evo/archive/refs/tags/{ref}.tar.gz"
-
-    cache_dir = Path.home() / ".cache" / "evo-hq-cli" / "github-src" / ref
-    skills = cache_dir / "skills"
-    if skills.exists():
-        print(f"  using cached evo source at {cache_dir}")
-        return skills
-
-    print(f"  downloading evo source from {url}")
-    try:
-        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
-            urllib.request.urlretrieve(url, tmp.name)
-            tarball = Path(tmp.name)
-    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
-        print(f"WARNING: could not fetch {url}: HTTP {exc.code}", file=sys.stderr)
-        return None
-    except Exception as exc:  # noqa: BLE001
-        print(f"WARNING: could not fetch {url}: {exc}", file=sys.stderr)
-        return None
-
-    try:
-        with tempfile.TemporaryDirectory(prefix="evo-pi-src-") as extract_root:
-            with tarfile.open(tarball) as tf:
-                tf.extractall(extract_root)
-            # GitHub tarballs extract as `<repo>-<ref>/...`.
-            entries = [p for p in Path(extract_root).iterdir() if p.is_dir()]
-            if not entries:
-                print(f"WARNING: extracted tarball has no top-level dir", file=sys.stderr)
-                return None
-            src_skills = entries[0] / "plugins" / "evo" / "skills"
-            if not src_skills.exists():
-                print(f"WARNING: no plugins/evo/skills/ inside fetched tarball "
-                      f"({entries[0].name})", file=sys.stderr)
-                return None
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(src_skills, skills, dirs_exist_ok=True)
-    finally:
-        tarball.unlink(missing_ok=True)
-    return skills
+        return f"npm:{_NPM_PACKAGE}@{version}"
+    return f"npm:{_NPM_PACKAGE}"
 
 
-def _find_subagent_provider() -> str | None:
-    """Detect an installed pi extension that registers a parallel-subagent
-    tool. Returns the matched provider name or None.
+def _migrate_legacy_file_copy() -> None:
+    """Remove pre-alpha.3 file-copy artifacts.
 
-    Checks two sources:
-      1. ``pi list`` output (the canonical "what's installed" view).
-      2. settings.json#extensions[] paths (fallback when `pi` isn't on
-         PATH yet or `pi list` fails).
+    0.4.2-alpha.1 and alpha.2 installed via direct file-copy into
+    ``~/.pi/agent/extensions/evo/`` and ``~/.pi/agent/skills/evo-*/``.
+    Now that ``@evo-hq/pi-evo`` is the canonical source, those files
+    shadow (and may collide with) the npm-installed skills.
+
+    Removes:
+      - the extension path entry from settings.json#extensions[]
+      - ``~/.pi/agent/extensions/evo/`` (file + dir)
+      - ``~/.pi/agent/skills/evo-{discover,optimize,subagent,infra-setup}/``
+
+    Does NOT touch the npm-installed package, ``pi-subagents``, or
+    any unrelated skills/extensions.
     """
-    # Source 1: pi list.
-    pi_bin = shutil.which("pi")
-    if pi_bin is not None:
-        try:
-            result = subprocess.run(
-                [pi_bin, "list"],
-                capture_output=True, text=True, timeout=15, check=False,
-            )
-            haystack = (result.stdout or "") + (result.stderr or "")
-            for name in _KNOWN_SUBAGENT_PROVIDERS:
-                if name in haystack:
-                    return name
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-    # Source 2: settings.json#extensions[] paths.
+    legacy_ext = _legacy_extension_path()
     settings = _pi_settings_file()
     if settings.exists():
         try:
             data = json.loads(settings.read_text())
-            paths_blob = " ".join(str(p) for p in data.get("extensions", []) or [])
-            for name in _KNOWN_SUBAGENT_PROVIDERS:
-                if name in paths_blob:
-                    return name
-        except json.JSONDecodeError:
-            pass
-    return None
-
-
-def _ensure_subagent_provider() -> None:
-    """If no parallel-subagent extension is installed, install
-    ``pi-subagents`` (the default). Idempotent — no-ops when any known
-    provider (pi-subagents, pi-crew, taskplane, etc.) is already present.
-
-    The optimize skill needs a subagent tool to fan out round experiments
-    in parallel. Pi's default toolkit doesn't include one. We auto-install
-    so users don't have to do a second command.
-    """
-    existing = _find_subagent_provider()
-    if existing:
-        print(f"✓ subagent provider already installed: {existing}")
-        return
-
-    pi_bin = shutil.which("pi")
-    if pi_bin is None:
-        print(
-            "NOTE: `pi` binary not on PATH; skipping pi-subagents install.\n"
-            "  Install pi first (npm install -g @earendil-works/pi-coding-agent),\n"
-            "  then re-run `evo install pi` to get the parallel-subagent tool.",
-            file=sys.stderr,
-        )
-        return
-
-    print(f"installing {_DEFAULT_SUBAGENT_PROVIDER} (registers the `subagent` "
-          f"tool for parallel rounds)...")
-    cmd = [pi_bin, "install", f"npm:{_DEFAULT_SUBAGENT_PROVIDER}"]
-    print(f"$ {' '.join(cmd)}")
-    rc = subprocess.call(cmd)
-    if rc != 0:
-        print(f"WARNING: `pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}` failed "
-              f"(rc={rc}); optimize will degrade to sequential execution.\n"
-              f"  Retry manually: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}",
-              file=sys.stderr)
-
-
-def _update_settings_extensions(settings: Path, target: str) -> bool:
-    """Idempotent register: add `target` to settings.json#extensions[] if
-    not already present. Returns True if file was modified.
-    """
-    settings.parent.mkdir(parents=True, exist_ok=True)
-    data: dict = {}
-    if settings.exists():
-        try:
-            data = json.loads(settings.read_text())
-        except json.JSONDecodeError:
-            print(f"ERROR: could not parse {settings}", file=sys.stderr)
-            raise
-    extensions = data.setdefault("extensions", [])
-    if target in extensions:
-        return False
-    extensions.append(target)
-    settings.write_text(json.dumps(data, indent=2) + "\n")
-    return True
-
-
-def _install_skills(from_path: str | None = None, version: str | None = None) -> int:
-    """Copy each evo skill into ~/.pi/agent/skills/evo-<name>/.
-
-    Pi auto-discovers any directory under skills/ that contains a
-    SKILL.md. Namespacing the dirs as `evo-<name>` avoids colliding
-    with non-evo skills the user already has.
-    """
-    src_root = _skills_source_root(from_path, version)
-    if src_root is None or not src_root.exists():
-        print(f"WARNING: could not resolve evo skills source "
-              f"(from_path={from_path}, version={version}); "
-              f"skipping skill install", file=sys.stderr)
-        return 0
-    dest_root = _pi_skills_dir()
-    dest_root.mkdir(parents=True, exist_ok=True)
-    copied = 0
-    for name in _SKILLS:
-        src = src_root / name
-        if not src.exists():
-            print(f"  - {name}: source missing at {src}, skipping")
-            continue
-        dest = dest_root / f"evo-{name}"
-        # Wipe + recopy so stale files from a prior version don't linger.
-        if dest.exists():
-            shutil.rmtree(dest)
-        shutil.copytree(src, dest)
-        print(f"  + installed skill: {dest}")
-        copied += 1
-    return copied
-
-
-def install(args: argparse.Namespace) -> int:
-    src = _bundled_extension_source()
-    if src is None:
-        print(
-            "ERROR: bundled pi extension not found in this evo install.\n"
-            "  Expected at evo/openclaw_plugin/evo.bundle.js (built via `bun build`).",
-            file=sys.stderr,
-        )
-        return 2
-
-    if shutil.which("pi") is None:
-        print(
-            "NOTE: `pi` binary not on PATH. Install pi first:\n"
-            "  npm install -g @earendil-works/pi-coding-agent\n"
-            "Continuing anyway — file install does not require the binary.",
-            file=sys.stderr,
-        )
-
-    ext_dir = _evo_extension_dir()
-    ext_dir.mkdir(parents=True, exist_ok=True)
-    ext_path = _evo_extension_path()
-    shutil.copyfile(src, ext_path)
-    print(f"installed extension: {ext_path}")
-
-    settings = _pi_settings_file()
-    target = str(ext_path)
-    if _update_settings_extensions(settings, target):
-        print(f"added {target} to extensions in {settings}")
-    else:
-        print(f"{target} already in extensions in {settings}")
-
-    print("\nInstalling evo skills under ~/.pi/agent/skills/evo-*/ ...")
-    _install_skills(
-        getattr(args, "from_path", None),
-        getattr(args, "version", None),
-    )
-
-    print("\nEnsuring a parallel-subagent provider is installed ...")
-    _ensure_subagent_provider()
-
-    print("\nRestart any running pi session to load the extension and skills.")
-    return 0
-
-
-def uninstall(args: argparse.Namespace) -> int:
-    ext_path = _evo_extension_path()
-    target = str(ext_path)
-
-    settings = _pi_settings_file()
-    if settings.exists():
-        try:
-            data = json.loads(settings.read_text())
-            extensions = data.get("extensions", [])
+            extensions = data.get("extensions", []) or []
+            target = str(legacy_ext)
             if target in extensions:
                 extensions.remove(target)
                 settings.write_text(json.dumps(data, indent=2) + "\n")
-                print(f"removed {target} from {settings}")
+                print(f"  migrated: removed {target} from {settings}")
         except json.JSONDecodeError:
             pass
 
-    if ext_path.exists():
-        ext_path.unlink()
-        print(f"removed {ext_path}")
-    # Best-effort dir cleanup.
-    if ext_path.parent.exists() and not any(ext_path.parent.iterdir()):
-        ext_path.parent.rmdir()
+    if legacy_ext.exists():
+        legacy_ext.unlink()
+        print(f"  migrated: removed {legacy_ext}")
+    if legacy_ext.parent.exists() and not any(legacy_ext.parent.iterdir()):
+        legacy_ext.parent.rmdir()
 
-    skills_root = _pi_skills_dir()
-    for name in _SKILLS:
-        d = skills_root / f"evo-{name}"
+    skills_root = _legacy_skills_dir()
+    for name in _LEGACY_SKILL_DIRS:
+        d = skills_root / name
         if d.exists():
             shutil.rmtree(d)
-            print(f"removed {d}")
+            print(f"  migrated: removed {d}")
+
+
+def install(args: argparse.Namespace) -> int:
+    pi = _pi_bin_or_error()
+    if pi is None:
+        return 2
+
+    print("Cleaning up any pre-alpha.3 file-copy install ...")
+    _migrate_legacy_file_copy()
+
+    spec = _resolve_install_spec(
+        getattr(args, "from_path", None),
+        getattr(args, "version", None),
+    )
+    cmd = [pi, "install", spec]
+    print(f"$ {' '.join(cmd)}")
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        return rc
+
+    print(
+        f"\n✓ {_NPM_PACKAGE} installed via pi.\n"
+        "  Restart any running pi session to load the extension and skills."
+    )
+    return 0
+
+
+def update(args: argparse.Namespace) -> int:
+    """Update the pi-installed evo package + run the legacy-file-copy
+    migration. ``pi install`` is idempotent + version-aware, so install
+    and update share the same path. Without explicit ``--version``,
+    pi resolves to the ``latest`` dist-tag.
+    """
+    return install(args)
+
+
+def uninstall(args: argparse.Namespace) -> int:
+    # Always sweep legacy file-copy artifacts (no-op if absent).
+    _migrate_legacy_file_copy()
+
+    pi = shutil.which("pi")
+    if pi is None:
+        # No pi binary → nothing more to remove from pi's own registry.
+        # Legacy cleanup above already handled the file-copy case.
+        return 0
+
+    # Pi tracks packages by full spec (e.g. `npm:@evo-hq/pi-evo`) — the
+    # short name alone returns "No matching package found".
+    spec = f"npm:{_NPM_PACKAGE}"
+    cmd = [pi, "uninstall", spec]
+    print(f"$ {' '.join(cmd)}")
+    rc = subprocess.call(cmd)
+    # `pi uninstall` returns non-zero when the package isn't installed.
+    # Treat that as success — caller's goal (package gone) is satisfied.
+    if rc != 0:
+        print(f"({spec} was not installed via pi; nothing to remove)")
     return 0
 
 
 def doctor(args: argparse.Namespace) -> int:
-    ext_path = _evo_extension_path()
-    settings = _pi_settings_file()
     rc = 0
 
-    if ext_path.exists():
-        print(f"✓ extension installed: {ext_path}")
-    else:
-        print(f"✗ extension not at {ext_path}")
-        print("  Run: evo install pi")
-        rc = 1
+    pi = shutil.which("pi")
+    if pi is None:
+        print("✗ `pi` binary not on PATH")
+        print("  Install: npm install -g @earendil-works/pi-coding-agent")
+        return 1
+    print(f"✓ pi binary: {pi}")
 
-    if settings.exists():
-        try:
-            data = json.loads(settings.read_text())
-            target = str(ext_path)
-            if target in data.get("extensions", []):
-                print(f"✓ extension registered in {settings}")
-            else:
-                print(f"✗ extension not in {settings} extensions list")
-                print("  Run: evo install pi")
-                rc = 1
-        except json.JSONDecodeError:
-            print(f"✗ could not parse {settings}")
-            rc = 1
-    else:
+    settings = _pi_settings_file()
+    if not settings.exists():
         print(f"✗ {settings} not found (pi may not have run yet)")
-        rc = 1
+        return 1
 
-    skills_root = _pi_skills_dir()
-    missing = [name for name in _SKILLS
-               if not (skills_root / f"evo-{name}" / "SKILL.md").exists()]
-    if missing:
-        print(f"✗ missing skills: {', '.join(missing)}")
+    try:
+        data = json.loads(settings.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"✗ could not parse {settings}: {exc}")
+        return 1
+
+    packages = data.get("packages", []) or []
+    has_pi_evo = any(_NPM_PACKAGE in p for p in packages)
+    if has_pi_evo:
+        print(f"✓ {_NPM_PACKAGE} installed (in {settings}#packages[])")
+    else:
+        print(f"✗ {_NPM_PACKAGE} not installed")
         print("  Run: evo install pi")
         rc = 1
-    else:
-        print(f"✓ all {len(_SKILLS)} evo skills installed under {skills_root}/evo-*/")
 
-    if shutil.which("pi") is None:
-        print("? `pi` binary not on PATH (run `npm install -g @earendil-works/pi-coding-agent`)")
-
-    provider = _find_subagent_provider()
-    if provider:
-        print(f"✓ subagent provider present: {provider}")
+    has_subagents = any("pi-subagents" in p for p in packages)
+    if has_subagents:
+        print("✓ pi-subagents installed (parallel-subagent provider)")
     else:
-        print("✗ no parallel-subagent provider installed")
-        print(f"  Run: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}")
+        # `@evo-hq/pi-evo` bundles pi-subagents as a dependency, so this
+        # should be present after a successful install. Flag if missing.
+        print("✗ pi-subagents not detected — `@evo-hq/pi-evo` should bundle it")
         rc = 1
+
+    # Warn (don't fail) if legacy artifacts remain — install/update auto-sweeps.
+    legacy_ext = _legacy_extension_path()
+    if legacy_ext.exists():
+        print(f"? legacy file-copy extension still at {legacy_ext} "
+              f"(re-run `evo install pi` to migrate)")
+    legacy_skills = _legacy_skills_dir()
+    legacy_present = [d for d in _LEGACY_SKILL_DIRS
+                      if (legacy_skills / d).exists()]
+    if legacy_present:
+        print(f"? legacy file-copy skills still present: {', '.join(legacy_present)} "
+              f"(re-run `evo install pi` to migrate)")
     return rc

--- a/plugins/evo/src/evo/host_install/pi.py
+++ b/plugins/evo/src/evo/host_install/pi.py
@@ -34,6 +34,19 @@ from pathlib import Path
 _NPM_PACKAGE = "@evo-hq/pi-evo"
 _LEGACY_SKILL_DIRS = ("evo-discover", "evo-optimize", "evo-subagent", "evo-infra-setup")
 
+# Pi extensions that register a parallel-subagent tool. If none is
+# present after the main install, `evo install pi` auto-installs
+# `pi-subagents` (the default option). bundledDependencies in @evo-hq/pi-evo
+# can't reliably ship pi-subagents — CI doesn't `npm install` before
+# `npm publish` so the bundle ends up empty in the tarball.
+_KNOWN_SUBAGENT_PROVIDERS = (
+    "pi-subagents",
+    "pi-crew",
+    "taskplane",
+    "pi-collaborating-agents",
+)
+_DEFAULT_SUBAGENT_PROVIDER = "pi-subagents"
+
 
 def _pi_base() -> Path:
     home_override = os.environ.get("PI_HOME")
@@ -51,6 +64,59 @@ def _legacy_extension_path() -> Path:
 
 def _legacy_skills_dir() -> Path:
     return _pi_base() / "agent" / "skills"
+
+
+def _find_subagent_provider() -> str | None:
+    """Return the name of an installed parallel-subagent provider, or None.
+
+    Looks in settings.json#packages[] for any of the known providers.
+    Used both for the install gate (`_ensure_subagent_provider`) and
+    by doctor.
+    """
+    settings = _pi_settings_file()
+    if not settings.exists():
+        return None
+    try:
+        data = json.loads(settings.read_text())
+    except json.JSONDecodeError:
+        return None
+    blob = " ".join(str(p) for p in data.get("packages", []) or [])
+    for name in _KNOWN_SUBAGENT_PROVIDERS:
+        if name in blob:
+            return name
+    return None
+
+
+def _ensure_subagent_provider() -> None:
+    """Install `pi-subagents` if no parallel-subagent provider is present.
+
+    Pi's default toolkit has no fanout primitive. @evo-hq/pi-evo declares
+    pi-subagents as a dep but can't reliably ship it as a bundle (CI
+    doesn't `npm install` before `npm publish`). So we install it
+    explicitly here. Idempotent: if any known provider already exists,
+    no-op.
+    """
+    existing = _find_subagent_provider()
+    if existing:
+        print(f"✓ subagent provider already installed: {existing}")
+        return
+
+    pi_bin = shutil.which("pi")
+    if pi_bin is None:
+        # _pi_bin_or_error caught this in install(); this path only
+        # reached via direct unit-style invocation.
+        return
+
+    print(f"installing {_DEFAULT_SUBAGENT_PROVIDER} (registers the `subagent` "
+          f"tool for parallel rounds)...")
+    cmd = [pi_bin, "install", f"npm:{_DEFAULT_SUBAGENT_PROVIDER}"]
+    print(f"$ {' '.join(cmd)}")
+    rc = subprocess.call(cmd)
+    if rc != 0:
+        print(f"WARNING: `pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}` failed "
+              f"(rc={rc}); optimize will degrade to sequential execution.\n"
+              f"  Retry manually: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}",
+              file=sys.stderr)
 
 
 def _pi_bin_or_error() -> str | None:
@@ -140,6 +206,9 @@ def install(args: argparse.Namespace) -> int:
     if rc != 0:
         return rc
 
+    print("\nEnsuring a parallel-subagent provider is installed ...")
+    _ensure_subagent_provider()
+
     print(
         f"\n✓ {_NPM_PACKAGE} installed via pi.\n"
         "  Restart any running pi session to load the extension and skills."
@@ -209,13 +278,16 @@ def doctor(args: argparse.Namespace) -> int:
         print("  Run: evo install pi")
         rc = 1
 
-    has_subagents = any("pi-subagents" in p for p in packages)
-    if has_subagents:
-        print("✓ pi-subagents installed (parallel-subagent provider)")
+    # pi-subagents is installed explicitly (not as a bundled dep — the
+    # bundle is empty in the published tarball because CI doesn't
+    # `npm install` before `npm publish`). It should appear in packages[]
+    # after a successful `evo install pi`.
+    provider = _find_subagent_provider()
+    if provider:
+        print(f"✓ subagent provider installed: {provider}")
     else:
-        # `@evo-hq/pi-evo` bundles pi-subagents as a dependency, so this
-        # should be present after a successful install. Flag if missing.
-        print("✗ pi-subagents not detected — `@evo-hq/pi-evo` should bundle it")
+        print(f"✗ no parallel-subagent provider installed")
+        print(f"  Run: pi install npm:{_DEFAULT_SUBAGENT_PROVIDER}")
         rc = 1
 
     # Warn (don't fail) if legacy artifacts remain — install/update auto-sweeps.

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.4.2-alpha.3",
+  "version": "0.4.2",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.4.2-alpha.2",
+  "version": "0.4.2-alpha.3",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.4.2-alpha.3"
+version = "0.4.2"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.4.2-alpha.2"
+version = "0.4.2-alpha.3"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.4.2-alpha.3"
+__version__ = "0.4.2"

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.4.2-alpha.2"
+__version__ = "0.4.2-alpha.3"


### PR DESCRIPTION
## Summary

Now that `@evo-hq/pi-evo` is published to npm (alpha.2), `host_install/pi.py` no longer needs to file-copy the bundle and skills itself — pi's own package manager handles distribution, extension registration, and skill discovery. Refactor drops 200 lines of file-copy logic in favor of a ~230-line wrapper.

## What changes for users

| `evo install pi ...` flag | Becomes | Result |
|---|---|---|
| (no args) | `pi install npm:@evo-hq/pi-evo` | Latest dist-tag (alpha until 0.4.2 stable) |
| `--version 0.4.2-alpha.3` | `pi install npm:@evo-hq/pi-evo@0.4.2-alpha.3` | Pin to exact version |
| `--version alpha` | `pi install npm:@evo-hq/pi-evo@alpha` | Latest alpha |
| `--from-path /tmp/repo` | `pi install /tmp/repo/plugins/evo/npm` | Install from local clone (live tests, dev) |

Pi reads the package's `pi` manifest → auto-registers the bundled extension at `extensions/evo/index.js` and the four skills under `skills/{discover,optimize,subagent,infra-setup}/`. The `pi-subagents` package rides along as a bundled dependency.

## Migration

Pre-alpha.3 installs (alpha.1, alpha.2) used file-copy to `~/.pi/agent/extensions/evo/` and `~/.pi/agent/skills/evo-*/`. Those files conflict with the npm-installed package's skill discovery (pi reports "Skill conflicts" at startup). `evo install pi` now auto-sweeps the file-copy artifacts on every run:

- `~/.pi/agent/extensions/evo/index.js` → deleted
- Empty `~/.pi/agent/extensions/evo/` dir → removed
- `~/.pi/agent/skills/evo-{discover,optimize,subagent,infra-setup}/` → deleted
- `settings.json#extensions[]` entry pointing at the legacy path → removed

`evo uninstall pi` does the same sweep + calls `pi uninstall npm:@evo-hq/pi-evo`. Doctor reports presence of both `@evo-hq/pi-evo` and `pi-subagents`, warns (non-failing) when legacy artifacts remain.

## Test plan

- [x] Local install/doctor/uninstall cycle against real `~/.pi/` — full round-trip works
- [x] `--from-path` with absolute path resolves to `<path>/plugins/evo/npm` and pi installs from there
- [x] `--version <X>` produces `npm:@evo-hq/pi-evo@<X>` spec
- [x] Migration sweep — verified on my machine post-uninstall (file-copy was cleared earlier)
- [ ] e2b smoke test_pi — running

## Code shape

```
plugins/evo/src/evo/host_install/pi.py:
  -349 lines, +153 lines (net -196)
```

The bundled extension source (`plugins/evo/src/evo/openclaw_plugin/evo.bundle.js`) and skill files (`plugins/evo/skills/*/`) remain canonical — `plugins/evo/npm/scripts/sync-from-source.sh` keeps the npm package in lockstep.