### PR TITLE
fix(windows): portable signals, pid-liveness, and supervisor shutdown

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -978,9 +978,37 @@ def _read_status(root: Path, exp_id: str) -> str:
     return p.read_text(encoding="utf-8").strip()
 
 
+def _win_pid_alive(pid: int) -> bool:
+    """Windows liveness probe. os.kill(pid, 0) is unusable here — signal 0
+    is CTRL_C_EVENT on Windows, not a "does this process exist" check — so
+    query the OS directly: open the process and ask whether its handle is
+    still un-signaled (WAIT_TIMEOUT) vs. signaled/exited (WAIT_OBJECT_0)."""
+    import ctypes
+
+    SYNCHRONIZE = 0x00100000
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    WAIT_TIMEOUT = 0x102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(
+        SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+    )
+    if not handle:
+        # Can't open: access-denied means the process exists but isn't ours
+        # (alive); anything else (e.g. invalid parameter) means no such pid.
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _is_pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+    if os.name == "nt":
+        return _win_pid_alive(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -990,8 +1018,6 @@ def _is_pid_alive(pid: int) -> bool:
         # pid exists but isn't ours — treat as alive
         return True
     except OSError:
-        # Windows: os.kill(pid, 0) on a dead pid raises generic OSError
-        # (errno EINVAL from OpenProcess), not ProcessLookupError.
         return False
 
 
@@ -1339,7 +1365,10 @@ def cmd_abort(args: argparse.Namespace) -> int:
     if not _is_pid_alive(pid):
         print(f"{args.exp_id}: driver PID {pid} already not alive")
         return 0
-    sig = signal.SIGKILL if args.force else signal.SIGTERM
+    # Windows has no SIGKILL; there os.kill(pid, SIGTERM) already maps to
+    # TerminateProcess (a hard kill), so SIGTERM is the forceful signal.
+    sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+    sig = sigkill if args.force else signal.SIGTERM
     try:
         os.kill(pid, sig)
     except ProcessLookupError:
@@ -1362,7 +1391,7 @@ def cmd_abort(args: argparse.Namespace) -> int:
             return 0
         _time.sleep(0.25)
     try:
-        os.kill(pid, signal.SIGKILL)
+        os.kill(pid, sigkill)
         print(
             f"{args.exp_id}: driver PID {pid} did not exit in {args.timeout}s; "
             f"escalated to SIGKILL"
@@ -3272,28 +3301,60 @@ def cmd_gc(args: argparse.Namespace) -> int:
 def _stop_dashboard(root: Path) -> None:
     """Stop the background dashboard if running.
 
-    Signals the supervisor first so it doesn't respawn the dashboard
-    mid-stop, then SIGTERMs the dashboard directly as a fallback (in
-    case the supervisor crashed but the dashboard is still up — e.g.
-    older install without a supervisor).
+    Asks the supervisor to shut down via the shutdown sentinel first — the
+    only portable mechanism, since on Windows an external SIGTERM is an
+    uncatchable hard kill that would orphan the dashboard child. On POSIX
+    also sends SIGTERM as a fast path. Falls back to signalling the
+    dashboard directly if the supervisor already died (older installs).
     """
     import signal as _signal
+    import time as _time
+    from .dashboard_supervisor import SHUTDOWN_SENTINEL_NAME
+
     edir = evo_dir(root)
     supervisor_pid_file = edir / "supervisor.pid"
     pid_file = edir / "dashboard.pid"
     port_file = edir / "dashboard.port"
     dead_sentinel = edir / "dashboard.dead"
-    for pidfile in (supervisor_pid_file, pid_file):
-        if not pidfile.exists():
-            continue
+    shutdown_sentinel = edir / SHUTDOWN_SENTINEL_NAME
+
+    sup_pid = None
+    if supervisor_pid_file.exists():
         try:
-            pid = int(pidfile.read_text().strip())
-            os.kill(pid, _signal.SIGTERM)
+            sup_pid = int(supervisor_pid_file.read_text().strip())
+        except (OSError, ValueError):
+            sup_pid = None
+
+    if sup_pid:
+        # Clean shutdown: the supervisor watches this file, kills its child,
+        # and removes its own pid files — same path on every OS.
+        try:
+            shutdown_sentinel.write_text("stop\n", encoding="utf-8")
+        except OSError:
+            pass
+        if os.name != "nt":
+            try:
+                os.kill(sup_pid, _signal.SIGTERM)
+            except OSError:
+                pass
+        deadline = _time.time() + 6.0
+        while _time.time() < deadline and _is_pid_alive(sup_pid):
+            _time.sleep(0.1)
+        if _is_pid_alive(sup_pid):
+            try:  # last resort so it can't keep respawning the dashboard
+                os.kill(sup_pid, getattr(_signal, "SIGKILL", _signal.SIGTERM))
+            except OSError:
+                pass
+
+    if pid_file.exists():
+        try:
+            os.kill(int(pid_file.read_text().strip()), _signal.SIGTERM)
         except (OSError, ValueError):
             pass
-        pidfile.unlink(missing_ok=True)
-    port_file.unlink(missing_ok=True)
-    dead_sentinel.unlink(missing_ok=True)
+
+    for f in (supervisor_pid_file, pid_file, port_file, dead_sentinel,
+              shutdown_sentinel):
+        f.unlink(missing_ok=True)
 
 
 def cmd_reset(args: argparse.Namespace) -> int:

--- a/plugins/evo/src/evo/dashboard_supervisor.py
+++ b/plugins/evo/src/evo/dashboard_supervisor.py
@@ -61,6 +61,14 @@ HEALTHY_UPTIME_SECONDS = 120
 # Wait this long for the child to exit after SIGTERM before SIGKILL.
 SHUTDOWN_GRACE_SECONDS = 5.0
 
+# Portable stop signal. A caller drops this file under <root>/.evo/ to ask
+# the supervisor to shut down cleanly. Needed because on Windows an external
+# signal is an uncatchable hard kill (TerminateProcess) — the SIGTERM handler
+# never runs, so without the sentinel the supervisor can't tear its child
+# down and remove its pid files on Windows.
+SHUTDOWN_SENTINEL_NAME = "supervisor.shutdown"
+SHUTDOWN_POLL_SECONDS = 0.25
+
 
 _shutdown_requested = threading.Event()
 
@@ -126,6 +134,21 @@ def _handle_shutdown_signal(_signum, _frame) -> None:
             pass
 
 
+def _watch_shutdown_sentinel(sentinel: Path) -> None:
+    """Trigger a clean shutdown when the sentinel file appears.
+
+    This is the cross-platform stop path. On POSIX the SIGTERM/SIGINT
+    handlers already cover it; on Windows they can't (an external signal is
+    a hard TerminateProcess that bypasses Python handlers), so this watcher
+    is what lets the supervisor run its cleanup and exit 0 on Windows.
+    """
+    while not _shutdown_requested.is_set():
+        if sentinel.exists():
+            _handle_shutdown_signal(None, None)
+            return
+        time.sleep(SHUTDOWN_POLL_SECONDS)
+
+
 def _resolve_root() -> Path:
     raw = os.environ.get("EVO_SUPERVISOR_ROOT") or os.getcwd()
     return Path(raw).resolve()
@@ -153,6 +176,7 @@ def main() -> int:
     dashboard_dead = edir / "dashboard.dead"
     dashboard_log = edir / "dashboard.log"
     supervisor_log = edir / "supervisor.log"
+    shutdown_sentinel = edir / SHUTDOWN_SENTINEL_NAME
 
     # Single-supervisor guard via the workspace's existing lock pattern.
     # If acquisition times out, another supervisor is already running.
@@ -178,10 +202,18 @@ def main() -> int:
             sup_logger.info(f"supervisor starting pid={os.getpid()} root={root}")
             supervisor_pid_file.write_text(str(os.getpid()), encoding="utf-8")
             dashboard_dead.unlink(missing_ok=True)
+            # Clear any stale sentinel from a previous run so the watcher
+            # below doesn't shut us down the instant we start.
+            shutdown_sentinel.unlink(missing_ok=True)
 
             signal.signal(signal.SIGTERM, _handle_shutdown_signal)
             if os.name != "nt":
                 signal.signal(signal.SIGINT, _handle_shutdown_signal)
+            threading.Thread(
+                target=_watch_shutdown_sentinel,
+                args=(shutdown_sentinel,),
+                daemon=True,
+            ).start()
 
             failure_count = 0
             first_failure_at = 0.0
@@ -290,6 +322,7 @@ def main() -> int:
                         sup_logger.error(f"error stopping dashboard: {exc}")
                 dashboard_pid_file.unlink(missing_ok=True)
                 supervisor_pid_file.unlink(missing_ok=True)
+                shutdown_sentinel.unlink(missing_ok=True)
                 sup_logger.info("supervisor exiting")
             return 0
     except LockTimeoutError:

--- a/tests/unit/test_concurrent_run_guard.py
+++ b/tests/unit/test_concurrent_run_guard.py
@@ -134,7 +134,9 @@ class TestCmdAbort(unittest.TestCase):
         Whether it exits on SIGTERM or gets escalated to SIGKILL after
         the grace period depends on macOS zombie reaping timing; both
         outcomes mean the abort succeeded."""
-        child = subprocess.Popen(["sleep", "30"])
+        # Portable long-lived child (no dependency on a `sleep` binary,
+        # which Windows lacks).
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
         try:
             _make_active_node_with_pid(self.root, "exp_0001", 1, child.pid)
             rc, out, _ = self._run_abort("exp_0001", timeout=2.0)
@@ -171,14 +173,36 @@ class TestCmdAbort(unittest.TestCase):
 
     def test_abort_clean_when_pid_already_dead(self):
         """A pre-dead PID — abort reports it and exits 0 (no signal sent)."""
-        # Spawn and kill to get a guaranteed-dead PID.
-        child = subprocess.Popen(["true"])
+        # Spawn a process that exits immediately to get a guaranteed-dead PID
+        # (portable; no dependency on a `true` binary).
+        child = subprocess.Popen([sys.executable, "-c", ""])
         child.wait()
         dead_pid = child.pid
         _make_active_node_with_pid(self.root, "exp_0004", 1, dead_pid)
         rc, out, _ = self._run_abort("exp_0004")
         self.assertEqual(rc, 0)
         self.assertIn("already not alive", out)
+
+
+class TestIsPidAlive(unittest.TestCase):
+    """_is_pid_alive must be correct on every OS. On Windows os.kill(pid, 0)
+    is CTRL_C_EVENT, not a liveness probe, so the helper has a dedicated
+    native path — exercise both live and dead PIDs here on whatever OS runs."""
+
+    def test_live_process_reports_alive(self):
+        from evo.cli import _is_pid_alive
+        self.assertTrue(_is_pid_alive(os.getpid()))
+
+    def test_dead_process_reports_not_alive(self):
+        from evo.cli import _is_pid_alive
+        child = subprocess.Popen([sys.executable, "-c", ""])
+        child.wait()
+        self.assertFalse(_is_pid_alive(child.pid))
+
+    def test_nonpositive_pid_is_not_alive(self):
+        from evo.cli import _is_pid_alive
+        self.assertFalse(_is_pid_alive(0))
+        self.assertFalse(_is_pid_alive(-1))
 
 
 class TestSdkActiveRunsRegistry(unittest.TestCase):

--- a/tests/unit/test_dashboard_supervisor.py
+++ b/tests/unit/test_dashboard_supervisor.py
@@ -73,13 +73,37 @@ def _wait_for(predicate, timeout: float = 5.0) -> bool:
     return False
 
 
+def _kill_tree(proc: subprocess.Popen) -> None:
+    """Hard-kill a process and its children — last-resort teardown. On
+    Windows terminating a parent doesn't kill its children, so use
+    `taskkill /T` to take down the whole tree (otherwise the dashboard
+    grandchild keeps the temp dir's log file open and rmtree fails)."""
+    if proc.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    else:
+        proc.kill()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 class TestSupervisorLifecycle(unittest.TestCase):
     """Spawn supervisor, verify it spawns dashboard + writes logs + cleans
     up on SIGTERM. Each test gets a fresh workspace + port so they can
     run in parallel."""
 
     def setUp(self):
-        self._tmp = tempfile.TemporaryDirectory()
+        # ignore_cleanup_errors: belt-and-suspenders on Windows, where a
+        # lingering child handle would otherwise make rmtree raise at
+        # teardown. _shutdown() should release handles first; this keeps a
+        # stray one from failing an otherwise-passing test.
+        self._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.root = Path(self._tmp.name).resolve()
         _make_workspace(self.root)
         self.port = _pick_free_port()
@@ -87,12 +111,26 @@ class TestSupervisorLifecycle(unittest.TestCase):
 
     def tearDown(self):
         if self._sup_proc and self._sup_proc.poll() is None:
-            self._sup_proc.terminate()
-            try:
-                self._sup_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._sup_proc.kill()
+            self._shutdown(self._sup_proc)
         self._tmp.cleanup()
+
+    def _shutdown(self, proc: subprocess.Popen, timeout: float = 10.0) -> int | None:
+        """Clean cross-platform stop: drop the shutdown sentinel so the
+        supervisor tears down its child dashboard and exits 0. Falls back to
+        a process-tree kill if it doesn't exit in time. Returns the exit
+        code (or None if it had to be force-killed)."""
+        from evo.dashboard_supervisor import SHUTDOWN_SENTINEL_NAME
+        try:
+            (self.root / ".evo" / SHUTDOWN_SENTINEL_NAME).write_text(
+                "stop\n", encoding="utf-8"
+            )
+        except OSError:
+            pass
+        try:
+            return proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_tree(proc)
+            return proc.poll()
 
     def _start_supervisor(self) -> subprocess.Popen:
         env = {
@@ -123,13 +161,34 @@ class TestSupervisorLifecycle(unittest.TestCase):
         self.assertTrue(_wait_for(
             lambda: (edir / "dashboard.log").stat().st_size > 0
         ))
-        sup.terminate()
-        sup.wait(timeout=5)
+        self._shutdown(sup)
 
+    def test_shutdown_sentinel_cleans_up_pid_files(self):
+        """Dropping the shutdown sentinel → child terminated → finally block
+        runs → pid files removed, exit 0. This is the portable stop path —
+        the only one that works on Windows, where an external signal is an
+        uncatchable hard kill (TerminateProcess)."""
+        sup = self._start_supervisor()
+        edir = self.root / ".evo"
+        self.assertTrue(_wait_for_file(edir / "supervisor.pid"))
+        self.assertTrue(_wait_for_file(edir / "dashboard.pid"))
+        rc = self._shutdown(sup)
+        self.assertEqual(rc, 0)
+        self.assertFalse((edir / "supervisor.pid").exists(),
+                         "supervisor.pid must be removed on clean shutdown")
+        self.assertFalse((edir / "dashboard.pid").exists(),
+                         "dashboard.pid must be removed on clean shutdown")
+
+    @unittest.skipIf(
+        os.name == "nt",
+        "Windows can't deliver a catchable SIGTERM to another process "
+        "(TerminateProcess is a hard kill); the sentinel path above covers "
+        "clean shutdown cross-platform.",
+    )
     def test_sigterm_cleans_up_pid_files(self):
-        """SIGTERM to supervisor → child terminated → finally block runs
-        → pid files removed. The lock file stays (it's the file the
-        portalocker context manager held; flock auto-released)."""
+        """POSIX: SIGTERM → handler sets the flag + terminates the child →
+        finally block runs → pid files removed, exit 0. The lock file stays
+        (the portalocker context manager held it; flock auto-released)."""
         sup = self._start_supervisor()
         edir = self.root / ".evo"
         self.assertTrue(_wait_for_file(edir / "supervisor.pid"))
@@ -167,8 +226,7 @@ class TestSupervisorLifecycle(unittest.TestCase):
 
         # First supervisor unaffected.
         self.assertIsNone(sup1.poll(), "first supervisor must keep running")
-        sup1.terminate()
-        sup1.wait(timeout=5)
+        self._shutdown(sup1)
 
 
 class TestSupervisorBackoffOnCrashLoop(unittest.TestCase):


### PR DESCRIPTION
Fixes the 5 Windows-only failures in the unit matrix on `v0.4.4`, all real portability gaps (none reproduce on macOS/Linux, where POSIX hides them).

## Changes
- **`signal.SIGKILL`** — `cmd_abort` (cli.py) referenced `signal.SIGKILL`, absent on Windows. Falls back to `SIGTERM`, which `os.kill` maps to `TerminateProcess` (a hard kill) on Windows.
- **`_is_pid_alive`** — probed with `os.kill(pid, 0)`, but signal `0` is `CTRL_C_EVENT` on Windows, not a liveness check. Adds a native `OpenProcess` + `WaitForSingleObject` probe for `nt`.
- **Supervisor shutdown** — cleanup ran only from a `SIGTERM` handler, which Windows can't deliver to another process (`TerminateProcess` bypasses Python handlers): pid files leaked, exit code was 1, and the orphaned dashboard child kept the temp log open (`rmtree` `WinError 32`). Adds a shutdown-sentinel file watched by a daemon thread; `_stop_dashboard` drops it for a clean cross-platform stop.

## Tests
- Abort tests no longer depend on `sleep`/`true` binaries.
- The `SIGTERM` supervisor test is POSIX-only, with a cross-platform sentinel test beside it.
- Teardown shuts down via the sentinel and tree-kills as a fallback; `TemporaryDirectory(ignore_cleanup_errors=True)`.
- Added direct `_is_pid_alive` coverage (live/dead/non-positive).

Full unit suite green on macOS (558 passed). Draft until the Windows CI matrix confirms.

## Test plan
- [ ] Windows `unit-tests` matrix (3.10–3.14) green
- [ ] Ubuntu/macOS matrix still green