### PR TITLE
fix(inject): engage orchestrator at SessionStart so evo direct reaches hook hosts

### DIFF
--- a/plugins/evo/bin/evo-hook-drain-rs/src/main.rs
+++ b/plugins/evo/bin/evo-hook-drain-rs/src/main.rs
@@ -176,7 +176,7 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (y, m, d)
 }
 
-fn register_session(run_dir: &Path, sid: &str, host: &str) -> io::Result<()> {
+fn register_session(run_dir: &Path, sid: &str, host: &str, engage: bool) -> io::Result<()> {
     let sessions_dir = run_dir.join("inject").join("sessions");
     fs::create_dir_all(&sessions_dir)?;
     let now = iso8601_utc_now();
@@ -185,18 +185,39 @@ fn register_session(run_dir: &Path, sid: &str, host: &str) -> io::Result<()> {
     // chooses workspace-vs-exp based on `sess.exp_id`). Without this,
     // a directive queued by `evo direct --to exp_id` BEFORE the Python
     // `auto_register_from_env` merge can be missed.
-    let exp_id_json = match env::var("EVO_EXP_ID") {
-        Ok(v) if !v.is_empty() => format!(r#""{}""#, escape_json_str(&v)),
-        _ => "null".to_string(),
+    let exp_id = match env::var("EVO_EXP_ID") {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    };
+    let exp_id_json = match &exp_id {
+        Some(v) => format!(r#""{}""#, escape_json_str(v)),
+        None => "null".to_string(),
+    };
+    // Engage the orchestrator at SessionStart. The hook-host process that
+    // fired SessionStart IS the orchestrator, so SessionStart is its
+    // engagement signal — same as the in-process JS plugins (pi/openclaw)
+    // marking engaged at session_start. Under /optimize the orchestrator
+    // dispatches every `evo` command to subagents, so it never runs `evo`
+    // itself; without engaging here, the Python `evo direct` broadcast
+    // filters it out (skipped_unengaged) and mid-run directives never
+    // land. NEVER engage a subagent registration (EVO_EXP_ID set) — a
+    // subagent must not engage the workspace loop on its own.
+    let engaged = engage && exp_id.is_none();
+    let (engaged_json, engaged_at_json) = if engaged {
+        ("true".to_string(), format!(r#""{}""#, now))
+    } else {
+        ("false".to_string(), "null".to_string())
     };
     let payload = format!(
-        r#"{{"schema_version":1,"session_id":"{}","host":"{}","pid":{},"registered_at":"{}","last_seen_at":"{}","exp_id":{},"parent_session_id":null}}"#,
+        r#"{{"schema_version":1,"session_id":"{}","host":"{}","pid":{},"registered_at":"{}","last_seen_at":"{}","exp_id":{},"parent_session_id":null,"has_evo_engaged":{},"engaged_at":{},"optimize_mode":false,"optimize_mode_at":null}}"#,
         sid,
         host,
         process::id(),
         now,
         now,
         exp_id_json,
+        engaged_json,
+        engaged_at_json,
     );
     fs::write(sessions_dir.join(format!("{}.json", sid)), payload)
 }
@@ -409,7 +430,10 @@ fn main() {
 
     if hook_event == "SessionStart" {
         if !sessions_file.is_file() {
-            let _ = register_session(&run_dir, &sid, host);
+            // engage=true: SessionStart on the hook host IS the orchestrator
+            // engagement signal. register_session refuses to engage if
+            // EVO_EXP_ID is set (subagent context).
+            let _ = register_session(&run_dir, &sid, host, true);
         }
         // Plugin root = parent of the directory containing this executable.
         let exe = env::current_exe().ok();
@@ -432,7 +456,12 @@ fn main() {
     // /optimize matcher in Python actually has a session record to flip.
     if !sessions_file.is_file() {
         if hook_event == "UserPromptSubmit" {
-            let _ = register_session(&run_dir, &sid, host);
+            // A resumed orchestrator's first prompt. Engage unless this is
+            // a subagent-originated prompt (agent_id present) — a subagent
+            // must not engage the workspace loop on its own. register_session
+            // additionally refuses to engage when EVO_EXP_ID is set.
+            let engage = !is_subagent_context(&stdin_buf);
+            let _ = register_session(&run_dir, &sid, host, engage);
         } else {
             emit_ok();
         }

--- a/plugins/evo/src/evo/hermes_plugin/__init__.py
+++ b/plugins/evo/src/evo/hermes_plugin/__init__.py
@@ -40,7 +40,7 @@ from evo.core import repo_root
 from evo.inject import marker
 from evo.inject.paths import inject_root, exp_events_path, workspace_events_path
 from evo.inject.queue import read_events_after, read_offset, write_offset
-from evo.inject.registry import get_session, register_session
+from evo.inject.registry import get_session, mark_engaged, register_session
 from evo.inject.drain import (
     _POLICY_NUDGE_TEMPLATE,
     _STOP_NUDGE_TEMPLATE,
@@ -66,9 +66,26 @@ def _resolve_root() -> Path | None:
 
 
 def _ensure_registered(root: Path, session_id: str) -> None:
-    """Register the hermes session if not already in the registry."""
+    """Register the hermes session if not already in the registry, and
+    mark it as evo-engaged.
+
+    The hermes plugin process IS the orchestrator — there is no separate
+    `evo`-command engagement signal (under /optimize the orchestrator
+    dispatches every evo command to subagents, so `auto_register_from_env`
+    never flips engagement). Without engaging here, `evo direct` filters
+    this session out (skipped_unengaged) and mid-run directives never
+    reach hermes. Hermes uses no Rust binary, so this is its only
+    engagement path. `register_session(engage=True)` engages a fresh
+    record; `mark_engaged` covers an existing record that registered
+    before this fix. Both refuse to engage a subagent (exp_id-bearing)
+    record. On the false→true transition the offset is seeded to the
+    queue tail so pre-engagement directives don't replay."""
     if get_session(root, session_id) is None:
-        register_session(root, session_id, "hermes")
+        register_session(root, session_id, "hermes", engage=True)
+        return
+    from evo.inject.queue import init_offset_to_latest
+    if mark_engaged(root, session_id):
+        init_offset_to_latest(root, session_id)
 
 
 def _compute_drain_text(root: Path, session_id: str) -> str | None:

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -123,6 +123,20 @@ def _hook_event_from_payload(payload: dict) -> str | None:
     return payload.get("hook_event_name") or payload.get("hookEventName")
 
 
+def _payload_is_subagent(payload: dict | None) -> bool:
+    """Mirror the Rust binary's `is_subagent_context`: claude-code (and
+    codex) include a non-empty `agent_id` in hook payloads triggered by
+    subagent (Task tool) activity; the orchestrator's own events omit it.
+    Used to refuse engaging the parent when a SessionStart-class event
+    actually originates from a subagent. Defensive — the Rust binary
+    already fast-exits on subagent PreToolUse before handoff, but the
+    Python drain may run SessionStart registration directly."""
+    if not payload:
+        return False
+    aid = payload.get("agent_id") or payload.get("agentId")
+    return bool(aid)
+
+
 def _resolve_root_from_payload(payload: dict) -> Path | None:
     """Locate the workspace root (dir containing `.evo/`) for hosts whose
     hook command runs from outside the project. Cursor's user-level
@@ -540,6 +554,27 @@ def drain_session(root: Path, session_id: str, host: str | None = None, hook_eve
     if host == "unknown":
         host = "claude-code"
     exp_id = sess.get("exp_id")
+
+    # Orchestrator engagement on SessionStart. For hook hosts
+    # (claude-code/codex) the host process that fired SessionStart IS the
+    # orchestrator, so SessionStart is the engagement signal — same as the
+    # in-process JS plugins (pi/openclaw) marking engaged at session_start.
+    # Under /optimize the orchestrator dispatches every `evo` command to
+    # subagents, so it never runs `evo` itself and `auto_register_from_env`
+    # never flips engagement; without this, `evo direct` filters the
+    # orchestrator out (skipped_unengaged) and the directive never lands.
+    # Guarded: never engage a subagent-originated event, never engage a
+    # record carrying an exp_id. This handles the case where the published
+    # Rust binary predates the SessionStart-engage fix.
+    if (
+        hook_event in _SESSION_START_EVENTS
+        and not exp_id
+        and not _payload_is_subagent(payload)
+    ):
+        from .registry import mark_engaged
+        if mark_engaged(root, session_id):
+            queue.init_offset_to_latest(root, session_id)
+            sess = get_session(root, session_id) or sess
 
     # Seed offset to the current queue tail for sessions that don't yet
     # have an offset file. Closes the SessionStart-unconditional-drain

--- a/plugins/evo/src/evo/inject/registry.py
+++ b/plugins/evo/src/evo/inject/registry.py
@@ -66,15 +66,31 @@ def register_session(
     *,
     exp_id: str | None = None,
     parent_session_id: str | None = None,
+    engage: bool = False,
 ) -> None:
     """Idempotent: write `<inject>/sessions/<sid>.json` if absent;
     update `last_seen_at` if present.
 
-    Merges non-null `exp_id` / `parent_session_id` into an existing
-    record when those fields are currently empty — covers the case
-    where the Rust binary registered at SessionStart with `exp_id=null`
-    and a later Python `auto_register_from_env` call sees `EVO_EXP_ID`
-    set (subagent dispatched into an experiment after registration).
+    Merges non-null `parent_session_id` into an existing record when
+    that field is currently empty.
+
+    `exp_id` merge is restricted: a non-null `exp_id` is only merged
+    onto a record that is NOT an engaged orchestrator. claude-code and
+    codex inherit the parent's CLAUDE_CODE_SESSION_ID / CODEX_THREAD_ID
+    when spawning subagents, so a subagent's `auto_register_from_env`
+    resolves to the orchestrator's sid and would otherwise stamp
+    `EVO_EXP_ID` onto the orchestrator record — re-classifying it as a
+    subagent and making `evo direct` skip it (cli.py skipped_subagent).
+    Only stamp `exp_id` when the existing record never engaged (so it's
+    a genuine subagent-first registration), never onto an engaged
+    orchestrator.
+
+    `engage=True` marks the session as evo-engaged at registration — used
+    by the SessionStart / orchestrator-process registration paths (Rust
+    binary, hermes plugin) where the registering process IS the
+    orchestrator. Engagement is refused for subagent registrations
+    (non-null `exp_id`): a subagent must never engage the loop on its own.
+
     Never clobbers a non-null existing value.
 
     Caller is responsible for only calling this when there's an active
@@ -83,6 +99,7 @@ def register_session(
     ensure_dirs(root)
     path = session_file(root, session_id)
     now = _now_iso()
+    is_subagent = exp_id is not None
     if path.exists():
         try:
             data = json.loads(path.read_text())
@@ -90,20 +107,48 @@ def register_session(
             data = None
         if data is not None:
             data["last_seen_at"] = now
-            # Merge-only: fill in fields that are currently null.
-            if exp_id is not None and not data.get("exp_id"):
-                data["exp_id"] = exp_id
-            if parent_session_id is not None and not data.get("parent_session_id"):
-                data["parent_session_id"] = parent_session_id
             # Ensure engagement + optimize_mode fields exist on records
             # written by older code paths (e.g. the Rust binary's v1
-            # schema without these fields).
+            # schema without these fields). Do this BEFORE the exp_id
+            # merge so the engaged-orchestrator guard below sees the
+            # real value.
             data.setdefault("has_evo_engaged", False)
             data.setdefault("engaged_at", None)
             data.setdefault("optimize_mode", False)
             data.setdefault("optimize_mode_at", None)
+            # Merge-only: fill in fields that are currently null.
+            # exp_id is special: never stamp a subagent's exp_id onto an
+            # already-engaged orchestrator record (the inherited-session-id
+            # case). That would mis-classify the orchestrator as a
+            # subagent and make `evo direct` skip it.
+            if (
+                exp_id is not None
+                and not data.get("exp_id")
+                and not data.get("has_evo_engaged")
+            ):
+                data["exp_id"] = exp_id
+            if parent_session_id is not None and not data.get("parent_session_id"):
+                data["parent_session_id"] = parent_session_id
+            # Orchestrator engagement on a re-registration (e.g. a resumed
+            # chat whose SessionStart re-fires). Only engage genuine
+            # orchestrators — never a record carrying an exp_id, and never
+            # the incoming subagent registration.
+            transitioned = False
+            if (
+                engage
+                and not is_subagent
+                and not data.get("exp_id")
+                and not data.get("has_evo_engaged")
+            ):
+                data["has_evo_engaged"] = True
+                data["engaged_at"] = now
+                transitioned = True
             atomic_write_json(path, data)
+            if transitioned:
+                from .queue import init_offset_to_latest
+                init_offset_to_latest(root, session_id)
             return
+    engaged = bool(engage and not is_subagent)
     data = {
         "schema_version": REGISTRY_SCHEMA_VERSION,
         "session_id": session_id,
@@ -113,8 +158,8 @@ def register_session(
         "last_seen_at": now,
         "exp_id": exp_id,
         "parent_session_id": parent_session_id,
-        "has_evo_engaged": False,
-        "engaged_at": None,
+        "has_evo_engaged": engaged,
+        "engaged_at": now if engaged else None,
         # v0.4.5+: optimize_mode tags a session as the orchestrator
         # currently driving /evo:optimize. Set automatically when the
         # user invokes /optimize (UserPromptSubmit pattern-match in
@@ -247,6 +292,8 @@ def mark_engaged(root: Path, session_id: str) -> bool:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
         return False
+    if data.get("exp_id"):
+        return False  # subagent — never engage the loop on its own
     if data.get("has_evo_engaged"):
         return False
     data["has_evo_engaged"] = True

--- a/tests/live/test_release_smoke.py
+++ b/tests/live/test_release_smoke.py
@@ -448,6 +448,19 @@ def _parse_directive_id(direct_output: str) -> str:
     return m.group(1)
 
 
+def _parse_fanout(direct_output: str) -> tuple[int, int]:
+    """Parse `fanout=N sessions, skipped_unengaged=M` from the workspace
+    `evo direct` line. Returns (fanout, skipped_unengaged). Returns
+    (-1, -1) if the line isn't the workspace broadcast form (e.g. an
+    exp-targeted `directive queued (exp=..., woken=N)` form, which has
+    no fanout field)."""
+    fm = re.search(r"fanout=(\d+)", direct_output)
+    sm = re.search(r"skipped_unengaged=(\d+)", direct_output)
+    if not fm or not sm:
+        return (-1, -1)
+    return (int(fm.group(1)), int(sm.group(1)))
+
+
 def _verify_directive_consumed(h: _Harness, ws_root: str, directive_id: str) -> int:
     """Count sessions (across ALL run_* dirs) whose offset file matches
     the directive id. Cross-run because the agent can re-`evo init`
@@ -609,6 +622,29 @@ def _drive_smoke(
         f"evo direct {_shell_quote(directive_text)}"
     )
     directive_id = _parse_directive_id(direct_out)
+
+    # Engagement-regression early-catch. The orchestrator session must be
+    # engaged at SessionStart (hook hosts via the Rust binary / Python
+    # drain; hermes via on_session_start; pi/openclaw via their JS
+    # plugins) so `evo direct` fans the directive out to it. Under
+    # /optimize the orchestrator dispatches every `evo` command to
+    # subagents and never runs `evo` itself, so the env-var engagement
+    # path never fires — SessionStart is the only signal. If fanout=0 /
+    # skipped_unengaged>=1 here, the directive was filtered out and
+    # consumed_by would be 0 after a 15-minute poll. Fail fast instead.
+    fanout, skipped_unengaged = _parse_fanout(direct_out)
+    if fanout >= 0:  # workspace broadcast form (not exp-targeted)
+        assert fanout >= 1, (
+            f"[{host}] evo direct fanout={fanout} skipped_unengaged="
+            f"{skipped_unengaged}: orchestrator session not engaged — "
+            f"mid-run directive filtered out before delivery. "
+            f"direct output: {direct_out!r}"
+        )
+        assert skipped_unengaged == 0, (
+            f"[{host}] evo direct skipped_unengaged={skipped_unengaged}: "
+            f"an orchestrator session registered but was not engaged at "
+            f"SessionStart. direct output: {direct_out!r}"
+        )
 
     # Harness-side poll with hard ceilings. e2b kills long-lived HTTP/2
     # streams server-side regardless of heartbeat output (verified v17/v18),

--- a/tests/unit/test_engagement_filter.py
+++ b/tests/unit/test_engagement_filter.py
@@ -563,5 +563,194 @@ class TestSessionStartDoesNotBackfill(unittest.TestCase):
         assert offset == post_id
 
 
+# ---------------------------------------------------------------------------
+# SessionStart engages the orchestrator (hook hosts + hermes)
+#
+# Regression for the release-smoke failure: claude-code/codex/hermes
+# delivered fanout=0 / skipped_unengaged=1 under /optimize because the
+# orchestrator dispatches every `evo` command to subagents, so its own
+# session never ran `evo` and `auto_register_from_env` never engaged it.
+# SessionStart (the hook host) / on_session_start (hermes) IS the
+# orchestrator's engagement signal and must flip has_evo_engaged true.
+# ---------------------------------------------------------------------------
+
+class TestSessionStartEngagesOrchestrator(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _make_workspace(self.root)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_register_session_engage_flag_marks_engaged(self):
+        register_session(self.root, "orch", "claude-code", engage=True)
+        rec = _read_record(self.root, "orch")
+        assert rec["has_evo_engaged"] is True
+        assert rec.get("engaged_at") is not None
+
+    def test_register_session_engage_refused_for_subagent(self):
+        # A subagent registration (exp_id set) must never engage even if
+        # the engage flag is passed.
+        register_session(self.root, "sub", "claude-code", exp_id="exp_0001", engage=True)
+        rec = _read_record(self.root, "sub")
+        assert rec["has_evo_engaged"] is False
+
+    def test_drain_session_sessionstart_engages_orchestrator(self):
+        # Rust binary registered at SessionStart (unengaged, e.g. a
+        # published binary predating the engage fix), then handed off to
+        # the Python drain on the SessionStart event. The Python drain
+        # must engage the orchestrator.
+        register_session(self.root, "orch2", "claude-code")
+        assert _read_record(self.root, "orch2")["has_evo_engaged"] is False
+        from evo.inject.drain import drain_session
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            drain_session(
+                self.root, "orch2",
+                host="claude-code", hook_event="SessionStart",
+                payload={"hook_event_name": "SessionStart", "session_id": "orch2"},
+            )
+        rec = _read_record(self.root, "orch2")
+        assert rec["has_evo_engaged"] is True, (
+            "SessionStart drain must engage the orchestrator so `evo direct` "
+            "fanout reaches it"
+        )
+
+    def test_drain_session_sessionstart_does_not_engage_subagent(self):
+        # A SessionStart-class event carrying agent_id originates from a
+        # subagent — must not engage.
+        register_session(self.root, "orch3", "claude-code")
+        from evo.inject.drain import drain_session
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            drain_session(
+                self.root, "orch3",
+                host="claude-code", hook_event="SessionStart",
+                payload={
+                    "hook_event_name": "SessionStart",
+                    "session_id": "orch3",
+                    "agent_id": "subagent-xyz",
+                },
+            )
+        assert _read_record(self.root, "orch3")["has_evo_engaged"] is False
+
+    def test_engaged_orchestrator_receives_direct_fanout(self):
+        # End-to-end: SessionStart engagement makes `evo direct` deliver.
+        register_session(self.root, "orch4", "claude-code")
+        from evo.inject.drain import drain_session
+        with patch("sys.stdout", io.StringIO()):
+            drain_session(
+                self.root, "orch4",
+                host="claude-code", hook_event="SessionStart",
+                payload={"hook_event_name": "SessionStart", "session_id": "orch4"},
+            )
+        old_cwd = Path.cwd()
+        os.chdir(self.root)
+        try:
+            from evo.cli import cmd_direct
+            buf = io.StringIO()
+            with patch("sys.stdout", buf):
+                cmd_direct(_build_args("mid-run directive"))
+            out = buf.getvalue()
+        finally:
+            os.chdir(old_cwd)
+        assert marker.exists(self.root, "orch4"), (
+            "engaged orchestrator must receive the directive marker"
+        )
+        assert "fanout=1" in out
+        assert "skipped_unengaged=0" in out
+
+
+class TestHermesEngagesOnSessionStart(unittest.TestCase):
+    """The hermes plugin process IS the orchestrator; on_session_start /
+    pre_llm_call must engage it (hermes uses no Rust binary)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _make_workspace(self.root)
+        self._old_cwd = Path.cwd()
+        os.chdir(self.root)
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        self._tmp.cleanup()
+
+    def test_on_session_start_marks_engaged(self):
+        from evo.hermes_plugin import _on_session_start
+        _on_session_start(session_id="hermes_sid")
+        rec = _read_record(self.root, "hermes_sid")
+        assert rec is not None, "on_session_start must register the hermes session"
+        assert rec["has_evo_engaged"] is True, (
+            "hermes orchestrator must be engaged at session start"
+        )
+
+    def test_engaged_hermes_session_receives_direct_fanout(self):
+        from evo.hermes_plugin import _on_session_start
+        _on_session_start(session_id="hermes_sid2")
+        from evo.cli import cmd_direct
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            cmd_direct(_build_args("hermes directive"))
+        out = buf.getvalue()
+        assert marker.exists(self.root, "hermes_sid2")
+        assert "fanout=1" in out
+
+
+class TestInheritedSessionIdNotMisclassified(unittest.TestCase):
+    """claude-code/codex inherit the parent's session-id env var when
+    spawning subagents. A subagent's auto_register_from_env then resolves
+    to the ORCHESTRATOR's sid with EVO_EXP_ID set — register_session must
+    NOT stamp that exp_id onto the engaged orchestrator record (which would
+    make `evo direct` skip it as skipped_subagent)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _make_workspace(self.root)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_exp_id_not_stamped_onto_engaged_orchestrator(self):
+        # Orchestrator registered + engaged at SessionStart.
+        register_session(self.root, "orch_sid", "claude-code", engage=True)
+        rec = _read_record(self.root, "orch_sid")
+        assert rec["has_evo_engaged"] is True
+        # Subagent dispatch leaks EVO_EXP_ID; subagent runs `evo` and
+        # auto_register_from_env resolves to the inherited orchestrator sid.
+        register_session(self.root, "orch_sid", "claude-code", exp_id="exp_0007")
+        rec = _read_record(self.root, "orch_sid")
+        assert rec["exp_id"] is None, (
+            "subagent exp_id must not be stamped onto the engaged "
+            "orchestrator record"
+        )
+        # And the orchestrator still receives direct fanout.
+        old_cwd = Path.cwd()
+        os.chdir(self.root)
+        try:
+            from evo.cli import cmd_direct
+            buf = io.StringIO()
+            with patch("sys.stdout", buf):
+                cmd_direct(_build_args("directive"))
+            out = buf.getvalue()
+        finally:
+            os.chdir(old_cwd)
+        assert marker.exists(self.root, "orch_sid")
+        assert "fanout=1" in out
+        assert "skipped_subagent=0" in out
+
+    def test_exp_id_still_merges_onto_unengaged_subagent_first_record(self):
+        # Genuine subagent-first registration: Rust registered at the
+        # subagent's SessionStart with exp_id=null (pre-fix binary) and
+        # unengaged; the later Python merge must still stamp exp_id.
+        register_session(self.root, "sub_sid", "claude-code")  # unengaged
+        register_session(self.root, "sub_sid", "claude-code", exp_id="exp_0123")
+        rec = _read_record(self.root, "sub_sid")
+        assert rec["exp_id"] == "exp_0123"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_hook_drain.py
+++ b/tests/unit/test_hook_drain.py
@@ -710,6 +710,64 @@ def test_legacy_session_record_exp_id_is_NOT_auto_migrated(tmp_path):
     )
 
 
+def test_session_start_engages_orchestrator(tmp_path):
+    """SessionStart on a hook host IS the orchestrator engagement signal.
+    The Rust register_session must write has_evo_engaged: true so the
+    Python `evo direct` broadcast doesn't filter the orchestrator out as
+    skipped_unengaged. Regression for the release-smoke fanout=0 failure
+    on claude-code/codex under /optimize."""
+    sid = "orch-engage-cc"
+    run = tmp_path / ".evo" / "run_test"
+    (run / "inject" / "sessions").mkdir(parents=True)
+
+    fake_bin = tmp_path / "fake-bin"
+    _write_fake_drain(fake_bin)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{_path_separator()}{_base_path()}"
+    env.pop("EVO_EXP_ID", None)
+
+    r = subprocess.run(
+        [str(HOOK_PATH)],
+        input=f'{{"session_id":"{sid}","hook_event_name":"SessionStart"}}'.encode(),
+        cwd=str(tmp_path), env=env, capture_output=True, timeout=10,
+    )
+    assert r.returncode == 0
+    import json
+    rec = json.loads((run / "inject" / "sessions" / f"{sid}.json").read_text())
+    assert rec.get("has_evo_engaged") is True, (
+        f"Rust register_session must engage the orchestrator at SessionStart; "
+        f"got {rec!r}"
+    )
+    assert rec.get("engaged_at") is not None
+
+
+def test_session_start_does_not_engage_subagent(tmp_path):
+    """A subagent registration (EVO_EXP_ID set) must NOT engage — a
+    subagent never joins the workspace loop on its own."""
+    sid = "sub-no-engage-cc"
+    run = tmp_path / ".evo" / "run_test"
+    (run / "inject" / "sessions").mkdir(parents=True)
+
+    fake_bin = tmp_path / "fake-bin"
+    _write_fake_drain(fake_bin)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{_path_separator()}{_base_path()}"
+    env["EVO_EXP_ID"] = "exp_0042"
+
+    r = subprocess.run(
+        [str(HOOK_PATH)],
+        input=f'{{"session_id":"{sid}","hook_event_name":"SessionStart"}}'.encode(),
+        cwd=str(tmp_path), env=env, capture_output=True, timeout=10,
+    )
+    assert r.returncode == 0
+    import json
+    rec = json.loads((run / "inject" / "sessions" / f"{sid}.json").read_text())
+    assert rec.get("exp_id") == "exp_0042"
+    assert rec.get("has_evo_engaged") is False, (
+        f"subagent registration must not engage; got {rec!r}"
+    )
+
+
 def test_session_start_writes_null_exp_id_without_env(tmp_path):
     """No EVO_EXP_ID env → exp_id stays null (orchestrator-class)."""
     sid = "orchestrator-cc"


### PR DESCRIPTION
Fixes the release-smoke mid-run inject failures on `v0.4.4-alpha.2`: `evo direct` directives were not consumed by **claude-code, codex, or hermes** (`fanout=0`). **pi** and **openclaw** were unaffected. (`opencode` errored separately at e2b setup — out of scope.)

## Root cause
`evo direct`'s broadcast skips any `HOSTS_WITH_ENGAGEMENT` session whose `has_evo_engaged` is false (cli.py:4261-4266 → `skipped_unengaged`). The only path that flipped engagement for the hook hosts was `auto_register_from_env`, which requires the orchestrator process to run an `evo` command with its host session-id env var set. Under `/optimize` the orchestrator dispatches every `evo` command to subagents, so it never runs `evo` itself, never engages, and the directive is filtered out before delivery.

The Rust binary's SessionStart `register_session` and hermes `_ensure_registered` registered the orchestrator but never marked it engaged. **pi/openclaw pass** because 930ff77 made their in-process JS plugins `markEngaged` at `session_start` — that fix was never ported to the Rust/Python/hermes paths. The difference between the passing and failing hosts is exactly this.

## Fix
SessionStart on a hook host is the orchestrator engagement signal:
- **main.rs** `register_session` takes `engage`; writes engagement fields to the v1 record and engages on SessionStart (and a resumed orchestrator's UserPromptSubmit), refusing when `EVO_EXP_ID` is set.
- **drain.py** engages on a SessionStart-class event for a non-subagent session — insurance for an already-published binary predating the fix.
- **hermes_plugin** engages its orchestrator on `session_start` (no Rust binary, so its only path).
- **registry.py** `engage` param; `mark_engaged` and the `exp_id` merge both refuse subagent records, so a subagent inheriting the parent's `CLAUDE_CODE_SESSION_ID` can't demote the orchestrator to `skipped_subagent`.

All engage paths refuse subagent (`exp_id`/`agent_id`) contexts. On the false→true transition the offset is seeded to the queue tail so pre-engagement events don't replay.

## Tests
- Unit: engage flag, subagent refusal, SessionStart drain engagement, inherited-session-id case, Rust SessionStart registration.
- `test_release_smoke.py` now asserts `fanout>=1` / `skipped_unengaged==0` right after `evo direct` — fails fast instead of after a 15-min poll.
- 569 unit tests pass locally.

Packaging unchanged: `publish.yml` rebuilds the per-platform binaries (gitignored), so the Rust source change ships on next publish.

**Refuted during diagnosis:** the wrong-arch `evo-hook-drain` binary (exit 126) theory. The published wheel is `py3-none-any` and ships no binary; `evo install` fetches the correct per-platform asset from the GitHub release.

## Test plan
- [ ] CI matrix green (ubuntu/macos/windows unit-tests)
- [ ] Re-run release-smoke against published artifacts: confirm `fanout>=1` and `consumed_by>=1` for claude-code/codex/hermes