### PR TITLE
docs: note evo install/update re-syncs CLI to stable without --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ evo update <host>                    # update one host (also bumps CLI to match)
 evo update <host> --version 0.4.1    # pin to a release
 ```
 
-Every `evo install` / `evo update` keeps the CLI on PATH in lockstep with the host plugin version it just installed (`uv tool install --force evo-hq-cli` under the hood). The CLI binary, the skill files, and the hook protocol share wire formats — letting them drift caused silent failures in earlier versions. Editable installs (`uv tool install --editable`, `pip install -e`) are detected and left untouched.
+Every `evo install` / `evo update` keeps the CLI on PATH in lockstep with the host plugin version it just installed (`uv tool install --force evo-hq-cli` under the hood). Without a `--version` pin that resolves to the latest **stable** release, so running an unpinned `evo install`/`evo update` against a pre-release pulls the CLI back to stable — pin both sides for an alpha (see [Testing a pre-release](#testing-a-pre-release-alpha)). The CLI binary, the skill files, and the hook protocol share wire formats — letting them drift caused silent failures in earlier versions. Editable installs (`uv tool install --editable`, `pip install -e`) are detected and left untouched.
 
 See `evo update --help` for `--force`, `--scope`, and additional flags.
 


### PR DESCRIPTION
The Upgrading section says `evo install` / `evo update` keeps the CLI "in lockstep with the host plugin version it just installed." The underlying `uv tool install --force evo-hq-cli` carries no version pin, so it resolves to the latest stable release. Running an unpinned `evo install`/`evo update` on a host whose plugin is a pre-release silently pulls the CLI back to stable, breaking the lockstep the sentence claims — e.g. a 0.4.4-alpha.5 CLI drops to 0.4.3.

Adds one clause pointing at the existing [Testing a pre-release](https://github.com/evo-hq/evo#testing-a-pre-release-alpha) recipe, which already pins both sides.