### PR TITLE
fix(codex): stage hook binary under owner marketplace name + bump 0.4.5

### DIFF
--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Discover
@@ -40,20 +40,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.4.4
+evo-hq-cli 0.4.5
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.4.4`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.4.5`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.4.4
+   > uv tool install --force evo-hq-cli==0.4.5
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.4.4` (or `pipx install evo-hq-cli==0.4.4`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.4.5` (or `pipx install evo-hq-cli==0.4.5`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
 disable-model-invocation: true
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Run the evo optimization loop with parallel subagents until interrupted.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns parallel subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Print the dashboard's dot chart (score over experiment order, status colors, best-path stair) inline in the terminal for every run in the workspace. Use when the user invokes /evo:report, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output.
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Report

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Internal protocol for evo optimization subagents. Loaded by subagents spawned from /optimize via their host's skill loader. Not for orchestrator use.
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.4.4"
+version = "0.4.5"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Discover
@@ -40,20 +40,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.4.4
+evo-hq-cli 0.4.5
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.4.4`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.4.5`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.4.4
+   > uv tool install --force evo-hq-cli==0.4.5
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.4.4` (or `pipx install evo-hq-cli==0.4.4`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.4.5` (or `pipx install evo-hq-cli==0.4.5`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
 disable-model-invocation: true
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Run the evo optimization loop with parallel subagents until interrupted.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns parallel subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Print the dashboard's dot chart (score over experiment order, status colors, best-path stair) inline in the terminal for every run in the workspace. Use when the user invokes /evo:report, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output.
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Report

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Internal protocol for evo optimization subagents. Loaded by subagents spawned from /optimize via their host's skill loader. Not for orchestrator use.
-evo_version: 0.4.4
+evo_version: 0.4.5
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/plugins/evo/src/evo/host_install/claude_code.py
+++ b/plugins/evo/src/evo/host_install/claude_code.py
@@ -17,6 +17,7 @@ working around an upstream cache-invalidation bug
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -31,11 +32,25 @@ _PLUGIN = "evo@evo-hq-evo"
 _MARKETPLACE_NAME = "evo-hq-evo"
 
 
+def _claude_config_dir() -> Path:
+    """Return the Claude Code config root. Honors `CLAUDE_CONFIG_DIR` (used
+    by Claude Code to relocate state outside `~/.claude`, e.g. in cloud
+    containers where the home dir is ephemeral and a persistent volume is
+    mounted elsewhere). Falls back to `~/.claude`.
+
+    Without this, every helper here that hardcodes `Path.home() / ".claude"`
+    misses the plugin cache when `CLAUDE_CONFIG_DIR` is set -- silently
+    skipping `ensure_hook_drain_binary` and breaking `evo direct` delivery.
+    """
+    cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(cfg) if cfg else Path.home() / ".claude"
+
+
 def _latest_cache_dir() -> Path | None:
     """Return the latest-version plugin cache dir, or None if not installed.
-    Cache layout: ~/.claude/plugins/cache/<mkt>/evo/<version>/
+    Cache layout: <claude-config-dir>/plugins/cache/<mkt>/evo/<version>/
     """
-    root = Path.home() / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME / "evo"
+    root = _claude_config_dir() / "plugins" / "cache" / _MARKETPLACE_NAME / "evo"
     if not root.exists():
         return None
     versions = sorted(p for p in root.iterdir() if p.is_dir())
@@ -157,7 +172,7 @@ def update(args: argparse.Namespace) -> int:
 
     if force:
         # Sidestep the upstream cache-invalidation bug: wipe cache, reinstall.
-        cache = Path.home() / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME
+        cache = _claude_config_dir() / "plugins" / "cache" / _MARKETPLACE_NAME
         if cache.exists():
             print(f"$ rm -rf {cache}")
             shutil.rmtree(cache)
@@ -192,8 +207,8 @@ def uninstall(args: argparse.Namespace) -> int:
 def doctor(args: argparse.Namespace) -> int:
     import json
 
-    home = Path.home()
-    settings = home / ".claude" / "settings.json"
+    home = _claude_config_dir()
+    settings = home / "settings.json"
     if not settings.exists():
         print(f"✗ {settings} not found — Claude Code not installed?")
         return 1
@@ -217,7 +232,7 @@ def doctor(args: argparse.Namespace) -> int:
     src = marketplaces.get(_MARKETPLACE_NAME, {}).get("source", {})
     src_type = src.get("source")
     if src_type == "github":
-        cache = home / ".claude" / "plugins" / "marketplaces" / _MARKETPLACE_NAME
+        cache = home / "plugins" / "marketplaces" / _MARKETPLACE_NAME
         if cache.exists():
             print(f"✓ marketplace cached at {cache}")
         else:
@@ -234,9 +249,9 @@ def doctor(args: argparse.Namespace) -> int:
         print(f"? unknown marketplace source type: {src_type}")
 
     # Detect cache-staleness (#35-shape): marketplace clone version vs cache.
-    plugin_cache_root = home / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME / "evo"
+    plugin_cache_root = home / "plugins" / "cache" / _MARKETPLACE_NAME / "evo"
     mkt_manifest = (
-        home / ".claude" / "plugins" / "marketplaces" / _MARKETPLACE_NAME
+        home / "plugins" / "marketplaces" / _MARKETPLACE_NAME
         / "plugins" / "evo" / ".claude-plugin" / "plugin.json"
     )
     if plugin_cache_root.exists() and mkt_manifest.exists():

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -645,15 +645,30 @@ def doctor(args: argparse.Namespace) -> int:
     # plugin root codex resolves for the active `evo@<owner>` selector.
     import re as _re
     plugin_cache_root = _codex_base() / "plugins" / "cache"
-    active_mkts = _re.findall(r'\[plugins\."evo@([^"]+)"\]', cfg_text)
+    # Strip comment lines so a commented-out `# [plugins."evo@old"]` isn't
+    # matched and chased to a non-existent cache dir.
+    uncommented = "\n".join(
+        ln for ln in cfg_text.splitlines() if not ln.lstrip().startswith("#")
+    )
+    active_mkts = _re.findall(r'\[plugins\."evo@([^"]+)"\]', uncommented)
     if not active_mkts:
         # No enabled plugin entry to resolve a binary path against; the
         # checks above already flagged the missing _PLUGIN_KEY.
         return rc
+
+    def _ver_key(name: str):
+        # Numeric-aware so 0.10.0 sorts after 0.9.0 (plain sorted() is
+        # lexicographic and would invert that). Non-numeric segments
+        # (pre-release tags) fall into a separate rank so int/str never
+        # compare.
+        return [(0, int(s)) if s.isdigit() else (1, s)
+                for s in _re.split(r"[.-]", name)]
+
     for mkt_name in active_mkts:
         mkt_cache = plugin_cache_root / mkt_name / "evo"
         versions = (
-            sorted(p for p in mkt_cache.iterdir() if p.is_dir())
+            sorted((p for p in mkt_cache.iterdir() if p.is_dir()),
+                   key=lambda p: _ver_key(p.name))
             if mkt_cache.is_dir() else []
         )
         if not versions:

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -75,9 +75,23 @@ def _enable_plugin(enable: bool) -> tuple[bool, Path]:
     else:
         if not present:
             return False, cfg
-        text = "\n".join(
-            line for line in text.splitlines() if line.strip() != _PLUGIN_KEY.strip()
-        ) + "\n"
+        # Remove the section header AND the key lines that belong to it
+        # (`enabled = true`, written by _install_via_filecopy) up to the
+        # next section. Dropping only the header would orphan
+        # `enabled = true`, which a TOML parser attaches to the preceding
+        # table.
+        new_lines: list[str] = []
+        skip = False
+        for line in text.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("["):
+                skip = stripped.rstrip() == _PLUGIN_KEY
+                if skip:
+                    continue
+            if skip:
+                continue
+            new_lines.append(line)
+        text = "\n".join(new_lines).rstrip() + "\n"
 
     cfg.write_text(text)
     return True, cfg

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -215,20 +215,22 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -
             )
             return 2
 
-    # Marketplace name: ALWAYS read marketplace.json's top-level `"name"`
-    # field (`evo-hq-evo`) regardless of install mode. The previous
-    # logic split on PyPI vs --from-path and used the cache dir basename
-    # (`evo-hq` — codex's owner-based naming) in PyPI mode, which caused
-    # the two install modes to register the plugin under DIFFERENT names.
-    # Users who upgraded across modes ended up with two parallel
-    # `[plugins."evo@<X>"]` entries and exit-127 errors from the orphaned
-    # one. Migration of pre-fix installs runs at the end of install().
+    # Marketplace name: ALWAYS use marketplace.json's `"owner"."name"`
+    # field (`evo-hq`). Codex 0.130+ names the marketplace after the repo
+    # OWNER, so `codex plugin marketplace add evo-hq/evo` registers
+    # `[plugins."evo@evo-hq"]` and resolves `${CLAUDE_PLUGIN_ROOT}` to
+    # `cache/evo-hq/evo/<ver>/`. The cache dir + binary staging + plugin
+    # registration here MUST land under that same name, or codex fires
+    # hooks against a cache dir we never populated → exit 127 on every
+    # hook event. (Using the top-level `"name"` field — `evo-hq-evo` —
+    # staged the binary into a sibling cache dir codex never reads, which
+    # is exactly that failure.) This matches `_PLUGIN_KEY` above.
     try:
         mkt = _json.loads(marketplace_json.read_text())
     except (OSError, _json.JSONDecodeError) as exc:
         print(f"✗ could not parse {marketplace_json}: {exc}", file=_sys.stderr)
         return 2
-    mkt_name = mkt.get("name") or "evo-hq-evo"
+    mkt_name = (mkt.get("owner") or {}).get("name") or "evo-hq"
     try:
         manifest = _json.loads(codex_manifest.read_text())
         version = manifest.get("version") or "0.0.0"
@@ -304,15 +306,15 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -
 
 def _cleanup_legacy_codex_registrations(target_mkt: str) -> None:
     """Remove leftover `evo@<other-mkt>` entries from codex's config.toml
-    that don't match the canonical marketplace name.
+    that don't match the canonical marketplace name (`evo-hq`, the repo
+    owner — see `_install_via_filecopy`).
 
-    Codex installer pre-fix used `mkt_root.name` (the GitHub owner,
-    `evo-hq`) for PyPI installs and marketplace.json's `"name"`
-    (`evo-hq-evo`) for `--from-path` installs. Users who hit both code
-    paths ended up with two parallel `[plugins."evo@<X>"]` blocks. Both
-    are enabled, both fire on every event, the old one fails exit 127
-    because its cache dir is missing the binary that only the most
-    recent install staged.
+    Pre-0.4.0 installs registered the plugin under `evo-hq-evo`
+    (marketplace.json's top-level `name`), while codex itself loads it
+    under `evo@evo-hq` (owner-based naming, 0.130+). Users carrying both
+    end up with two parallel `[plugins."evo@<X>"]` blocks: both enabled,
+    both fire on every event, and the one whose cache dir never had the
+    binary staged fails exit 127.
 
     This cleanup runs at the end of every codex install and removes:
       - `[plugins."evo@<other>"]` blocks and their `enabled` lines
@@ -621,4 +623,39 @@ def doctor(args: argparse.Namespace) -> int:
         print(f"✗ no marketplace cache at {cache}")
         print("  Run: codex plugin marketplace add evo-hq/evo")
         rc = 1
+
+    # The hook drain binary is what every hooks.json command resolves to.
+    # config.toml can have plugin_hooks=true and the plugin enabled while
+    # the binary is missing from the cache dir codex actually loads — then
+    # every hook fires exit 127. Verify it exists + is executable at the
+    # plugin root codex resolves for the active `evo@<owner>` selector.
+    import re as _re
+    plugin_cache_root = _codex_base() / "plugins" / "cache"
+    active_mkts = _re.findall(r'\[plugins\."evo@([^"]+)"\]', cfg_text)
+    if not active_mkts:
+        # No enabled plugin entry to resolve a binary path against; the
+        # checks above already flagged the missing _PLUGIN_KEY.
+        return rc
+    for mkt_name in active_mkts:
+        mkt_cache = plugin_cache_root / mkt_name / "evo"
+        versions = (
+            sorted(p for p in mkt_cache.iterdir() if p.is_dir())
+            if mkt_cache.is_dir() else []
+        )
+        if not versions:
+            print(f"✗ no plugin cache for evo@{mkt_name} at {mkt_cache}")
+            print("  Run: evo install codex --force")
+            rc = 1
+            continue
+        binary = versions[-1] / "bin" / "evo-hook-drain"
+        if binary.exists() and os.access(binary, os.X_OK):
+            print(f"✓ evo-hook-drain present + executable at {binary}")
+        elif binary.exists():
+            print(f"✗ evo-hook-drain at {binary} is not executable")
+            print("  Run: evo install codex --force")
+            rc = 1
+        else:
+            print(f"✗ evo-hook-drain missing at {binary} (hooks fire exit 127)")
+            print("  Run: evo install codex --force")
+            rc = 1
     return rc

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.4.4"
+version = "0.4.5"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/tests/unit/test_claude_code_install_paths.py
+++ b/tests/unit/test_claude_code_install_paths.py
@@ -1,0 +1,70 @@
+"""Regression: claude_code.install path helpers must honor CLAUDE_CONFIG_DIR.
+
+Without this, evo install runs in a container with CLAUDE_CONFIG_DIR=/persistent/path
+silently look at ~/.claude (which is empty), can't find the freshly-installed
+plugin cache, and skip ensure_hook_drain_binary. The hook then fires with
+exit 127 at runtime and `evo direct` delivery is permanently broken.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from evo.host_install import claude_code
+
+
+@pytest.fixture
+def env_with_config_dir(tmp_path, monkeypatch):
+    cfg = tmp_path / "alt-claude"
+    cfg.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg))
+    return cfg
+
+
+def test_claude_config_dir_honors_env_var(env_with_config_dir):
+    assert claude_code._claude_config_dir() == env_with_config_dir
+
+
+def test_claude_config_dir_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    assert claude_code._claude_config_dir() == Path.home() / ".claude"
+
+
+def test_latest_cache_dir_returns_none_when_cache_absent(env_with_config_dir):
+    assert claude_code._latest_cache_dir() is None
+
+
+def test_latest_cache_dir_finds_versioned_cache_under_config_dir(env_with_config_dir):
+    versioned = (
+        env_with_config_dir
+        / "plugins" / "cache" / claude_code._MARKETPLACE_NAME / "evo" / "0.4.4"
+    )
+    versioned.mkdir(parents=True)
+    assert claude_code._latest_cache_dir() == versioned
+
+
+def test_latest_cache_dir_picks_latest_version(env_with_config_dir):
+    base = env_with_config_dir / "plugins" / "cache" / claude_code._MARKETPLACE_NAME / "evo"
+    for v in ("0.4.1", "0.4.2", "0.4.4", "0.4.3"):
+        (base / v).mkdir(parents=True)
+    # `sorted()` over directory names gives lex order; for 3-part SemVer with
+    # single-digit minors/patches, lex == numeric. Latest is "0.4.4".
+    assert claude_code._latest_cache_dir() == base / "0.4.4"
+
+
+def test_latest_cache_dir_does_not_leak_to_home_when_env_set(env_with_config_dir, monkeypatch):
+    """If CLAUDE_CONFIG_DIR is set, the helper must not fall back to ~/.claude
+    even when ~/.claude exists with a plugin cache. This was the production
+    bug: helpers silently looked at the wrong root."""
+    fake_home = env_with_config_dir.parent / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    # Populate fake home with a decoy plugin cache.
+    decoy = fake_home / ".claude" / "plugins" / "cache" / claude_code._MARKETPLACE_NAME / "evo" / "0.4.4"
+    decoy.mkdir(parents=True)
+    # _latest_cache_dir must look at env_with_config_dir, not fake_home/.claude.
+    # env_with_config_dir has no plugins/ tree -> returns None.
+    assert claude_code._latest_cache_dir() is None

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -276,5 +276,69 @@ class TestDisablePlugin(_Base):
         self.assertEqual(self._read_config(), original)
 
 
+class TestDoctorHookBinary(_Base):
+    """`doctor()` resolves the hook-drain binary at the cache dir codex
+    actually loads. These exercise the version-dir selection (numeric, not
+    lexicographic) and comment-line handling in that resolution."""
+
+    def _healthy_config(self) -> None:
+        self._write_config(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = true\n'
+        )
+        # `cache` check in doctor() looks at the marketplace clone.
+        (self.codex_home / ".tmp" / "marketplaces" / "evo-hq").mkdir(parents=True)
+
+    def _stage_binary(self, version: str) -> None:
+        b = (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
+             / version / "bin" / "evo-hook-drain")
+        b.parent.mkdir(parents=True, exist_ok=True)
+        b.write_text("#!/bin/sh\n")
+        os.chmod(b, 0o755)
+
+    def _run_doctor(self) -> int:
+        import argparse
+        import contextlib
+        import io
+        from evo.host_install.codex import doctor
+        with contextlib.redirect_stdout(io.StringIO()):
+            return doctor(argparse.Namespace())
+
+    def test_picks_numerically_latest_version_dir(self):
+        # Binary only in 0.10.0. Lexicographic sort would pick 0.9.0 and
+        # wrongly report the binary missing.
+        self._healthy_config()
+        (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
+         / "0.9.0").mkdir(parents=True)
+        self._stage_binary("0.10.0")
+        self.assertEqual(self._run_doctor(), 0)
+
+    def test_missing_binary_fails(self):
+        self._healthy_config()
+        (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
+         / "0.4.5" / "bin").mkdir(parents=True)
+        self.assertEqual(self._run_doctor(), 1)
+
+    def test_ignores_commented_plugin_entry(self):
+        # A commented-out registration must not be chased to a missing
+        # cache dir.
+        self._write_config(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = true\n'
+            '\n'
+            '# [plugins."evo@ghost"]\n'
+            '# enabled = true\n'
+        )
+        (self.codex_home / ".tmp" / "marketplaces" / "evo-hq").mkdir(parents=True)
+        self._stage_binary("0.4.5")
+        self.assertEqual(self._run_doctor(), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -229,5 +229,52 @@ class TestLegacyCleanup(_Base):
         self.assertTrue((self.codex_home / "plugins" / "cache" / "evo-hq").exists())
 
 
+class TestDisablePlugin(_Base):
+    """`uninstall` → `_enable_plugin(enable=False)` must remove the
+    `[plugins."evo@evo-hq"]` header AND the `enabled = true` key written
+    beneath it. Removing only the header orphans `enabled = true`, which
+    a TOML parser attaches to the preceding table."""
+
+    def test_disable_removes_header_and_enabled_key(self):
+        from evo.host_install.codex import _enable_plugin
+
+        self._write_config(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = true\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+        )
+        changed, _ = _enable_plugin(enable=False)
+        self.assertTrue(changed)
+        text = self._read_config()
+        # evo block fully gone — no orphan key.
+        self.assertNotIn('"evo@evo-hq"', text)
+        self.assertNotIn('[features]\nplugin_hooks = true\nenabled = true', text)
+        # Surrounding sections + the other plugin's own enabled key intact.
+        self.assertIn('[features]', text)
+        self.assertIn('plugin_hooks = true', text)
+        self.assertIn('[plugins."github@openai-curated"]', text)
+        self.assertIn('enabled = true', text)  # github's, not evo's
+
+    def test_disable_noop_when_absent(self):
+        from evo.host_install.codex import _enable_plugin
+
+        original = (
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+        )
+        self._write_config(original)
+        changed, _ = _enable_plugin(enable=False)
+        self.assertFalse(changed)
+        self.assertEqual(self._read_config(), original)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -1,15 +1,18 @@
 """Tests for codex installer's legacy-marketplace cleanup.
 
-Backstory: codex.py pre-fix used different marketplace names based on
-install mode — `evo-hq` (the GitHub owner) for PyPI mode and
-`evo-hq-evo` (marketplace.json's `name` field) for `--from-path` mode.
-Users hitting both modes ended up with two parallel `[plugins."evo@<X>"]`
-registrations. Both fired hooks; the older one failed exit 127 because
-its cache dir never had the binary staged.
+Canonical codex marketplace name is `evo-hq` — codex 0.130+ names a
+marketplace after the repo OWNER, so `codex plugin marketplace add
+evo-hq/evo` registers `[plugins."evo@evo-hq"]` and resolves the plugin
+root to `cache/evo-hq/evo/<ver>/`. `evo-hq-evo` (marketplace.json's
+top-level `name` field) is the pre-0.4.0 name and is now legacy.
 
-The fix:
-  1. Always read marketplace.json's `name` field as the canonical mkt
-     name (no mode-dependent branching).
+A staging-to-the-wrong-name bug shipped exit-127 hooks: the installer
+used `evo-hq-evo` for the cache dir + binary staging while codex loaded
+the plugin under `evo@evo-hq`, so every hook fired against a binary-less
+cache dir. The fix uses the owner name (`evo-hq`) everywhere.
+
+Cleanup contract:
+  1. The canonical mkt name is the owner name (`evo-hq`).
   2. On every install, scan config.toml for `evo@<other>` entries that
      don't match the target name and remove them + their cache dirs.
 
@@ -62,7 +65,7 @@ class _Base(unittest.TestCase):
 
 class TestLegacyCleanup(_Base):
 
-    def test_removes_stale_evo_hq_plugin_block(self):
+    def test_removes_stale_evo_hq_evo_plugin_block(self):
         from evo.host_install.codex import _cleanup_legacy_codex_registrations
 
         self._write_config(
@@ -72,10 +75,10 @@ class TestLegacyCleanup(_Base):
             '[plugins."evo@evo-hq-evo"]\n'
             'enabled = true\n'
         )
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         text = self._read_config()
-        self.assertNotIn('"evo@evo-hq"', text)
-        self.assertIn('"evo@evo-hq-evo"', text)
+        self.assertNotIn('"evo@evo-hq-evo"', text)
+        self.assertIn('"evo@evo-hq"', text)
 
     def test_removes_stale_marketplace_block(self):
         from evo.host_install.codex import _cleanup_legacy_codex_registrations
@@ -87,12 +90,12 @@ class TestLegacyCleanup(_Base):
             '[plugins."evo@evo-hq-evo"]\n'
             'enabled = true\n'
             '\n'
-            '[marketplaces.evo-hq]\n'
+            '[marketplaces.evo-hq-evo]\n'
             'source = "https://github.com/evo-hq/evo.git"\n'
         )
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         text = self._read_config()
-        self.assertNotIn("[marketplaces.evo-hq]", text)
+        self.assertNotIn("[marketplaces.evo-hq-evo]", text)
 
     def test_removes_stale_hook_state_entries(self):
         from evo.host_install.codex import _cleanup_legacy_codex_registrations
@@ -110,10 +113,10 @@ class TestLegacyCleanup(_Base):
             '[hooks.state."evo@evo-hq-evo:hooks/hooks.json:pre_tool_use:0:0"]\n'
             'trusted_hash = "sha256:def"\n'
         )
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         text = self._read_config()
-        self.assertNotIn('"evo@evo-hq:hooks', text)
-        self.assertIn('"evo@evo-hq-evo:hooks', text)
+        self.assertNotIn('"evo@evo-hq-evo:hooks', text)
+        self.assertIn('"evo@evo-hq:hooks', text)
 
     def test_removes_stale_cache_directory(self):
         from evo.host_install.codex import _cleanup_legacy_codex_registrations
@@ -125,14 +128,14 @@ class TestLegacyCleanup(_Base):
             '[plugins."evo@evo-hq-evo"]\n'
             'enabled = true\n'
         )
-        stale_cache = self._make_cache("evo-hq")
-        target_cache = self._make_cache("evo-hq-evo")
+        target_cache = self._make_cache("evo-hq")
+        stale_cache = self._make_cache("evo-hq-evo")
 
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         self.assertFalse(stale_cache.exists(),
-                         "stale evo-hq cache dir must be removed")
+                         "stale evo-hq-evo cache dir must be removed")
         self.assertTrue(target_cache.exists(),
-                        "target evo-hq-evo cache dir must remain")
+                        "target evo-hq cache dir must remain")
 
     def test_preserves_unrelated_plugins_and_sections(self):
         """Cleanup must only touch evo@<other> registrations. Other
@@ -162,10 +165,10 @@ class TestLegacyCleanup(_Base):
             '[tui]\n'
             'status_line = ["model-with-reasoning"]\n'
         )
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         text = self._read_config()
-        self.assertNotIn('"evo@evo-hq"', text)
-        self.assertIn('"evo@evo-hq-evo"', text)
+        self.assertNotIn('"evo@evo-hq-evo"', text)
+        self.assertIn('"evo@evo-hq"', text)
         self.assertIn('"computer-use@openai-bundled"', text)
         self.assertIn('"github@openai-curated"', text)
         self.assertIn("[marketplaces.openai-bundled]", text)
@@ -176,14 +179,14 @@ class TestLegacyCleanup(_Base):
         from evo.host_install.codex import _cleanup_legacy_codex_registrations
 
         original = (
-            '[plugins."evo@evo-hq-evo"]\n'
+            '[plugins."evo@evo-hq"]\n'
             'enabled = true\n'
             '\n'
             '[plugins."github@openai-curated"]\n'
             'enabled = true\n'
         )
         self._write_config(original)
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         # File untouched when nothing to clean.
         self.assertEqual(self._read_config(), original)
 
@@ -193,7 +196,7 @@ class TestLegacyCleanup(_Base):
 
         self.assertFalse(self.cfg_path.exists())
         # Should silently return, not raise.
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         self.assertFalse(self.cfg_path.exists())
 
     def test_handles_multiple_legacy_names(self):
@@ -216,14 +219,14 @@ class TestLegacyCleanup(_Base):
         self._make_cache("old-alpha")
         self._make_cache("evo-hq-evo")
 
-        _cleanup_legacy_codex_registrations(target_mkt="evo-hq-evo")
+        _cleanup_legacy_codex_registrations(target_mkt="evo-hq")
         text = self._read_config()
-        self.assertNotIn('"evo@evo-hq"', text)
         self.assertNotIn('"evo@old-alpha"', text)
-        self.assertIn('"evo@evo-hq-evo"', text)
-        self.assertFalse((self.codex_home / "plugins" / "cache" / "evo-hq").exists())
+        self.assertNotIn('"evo@evo-hq-evo"', text)
+        self.assertIn('"evo@evo-hq"', text)
         self.assertFalse((self.codex_home / "plugins" / "cache" / "old-alpha").exists())
-        self.assertTrue((self.codex_home / "plugins" / "cache" / "evo-hq-evo").exists())
+        self.assertFalse((self.codex_home / "plugins" / "cache" / "evo-hq-evo").exists())
+        self.assertTrue((self.codex_home / "plugins" / "cache" / "evo-hq").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
codex install staged the evo-hook-drain binary, copied the plugin, and registered it under the marketplace name read from marketplace.json's top-level "name" field (evo-hq-evo). Codex 0.130+ names a marketplace after the repo owner, so it loads the plugin under evo@evo-hq and resolves ${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain to cache/evo-hq/evo/<ver>/bin/ — a directory the installer never populated. Every hook (SessionStart, UserPromptSubmit, PostToolUse, ...) fired exit 127. The fetched binary sat in the sibling cache/evo-hq-evo/ that codex never reads.

`evo doctor codex` passed because it checked only plugin_hooks, the plugin key, and the marketplace cache dir in config.toml — never that the binary existed at the resolved path.

Changes:
- `_install_via_filecopy` uses the owner name (evo-hq) for the cache dir, binary staging, and plugin registration, matching `_PLUGIN_KEY` and what `codex plugin marketplace add evo-hq/evo` registers.
- Legacy cleanup targets evo-hq, so it now removes orphaned evo@evo-hq-evo registrations + caches instead of the live one.
- `doctor()` verifies evo-hook-drain exists and is executable at the resolved cache path.
- Migration tests asserted the inverted orientation (remove evo@evo-hq, keep evo@evo-hq-evo) and shipped the bug green; corrected to the canonical owner name.
- Bump to 0.4.5 (all 8 pins).

Existing broken installs recover with `evo install codex --force` on 0.4.5: stages the binary into cache/evo-hq/ and clears the stale evo@evo-hq-evo registration.