### PR TITLE
fix(infra): centralize infra event schema

### DIFF
--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -639,15 +639,36 @@ def append_annotation(root: Path, exp_id: str, task_id: str | None, analysis: st
         return entry
 
 
+def make_infra_event(event_kind: str, event_message: str, **fields: Any) -> dict[str, Any]:
+    """Build a canonical infra-log event.
+
+    Keep required schema fields in one helper so event producers do not drift
+    from what scratchpad/dashboard readers expect.
+    """
+    reserved = {"kind", "message", "timestamp"}
+    overlap = reserved.intersection(fields)
+    if overlap:
+        names = ", ".join(sorted(overlap))
+        raise ValueError(f"infra event fields may not override: {names}")
+    event_kind = event_kind.strip()
+    event_message = event_message.strip()
+    if not event_kind:
+        raise ValueError("infra event kind is required")
+    if not event_message:
+        raise ValueError("infra event message is required")
+    return {
+        "kind": event_kind,
+        "message": event_message,
+        "timestamp": utc_now(),
+        **fields,
+    }
+
+
 def append_infra_event(root: Path, message: str, breaking: bool) -> dict[str, Any]:
     path = infra_path(root)
     with advisory_lock(lock_file_for(path)):
         data = load_json(path, {"events": []})
-        event = {
-            "message": message,
-            "breaking": breaking,
-            "timestamp": utc_now(),
-        }
+        event = make_infra_event("infra", message, breaking=breaking)
         data.setdefault("events", []).append(event)
         atomic_write_json(path, data)
         return event

--- a/plugins/evo/src/evo/frontier_strategies.py
+++ b/plugins/evo/src/evo/frontier_strategies.py
@@ -21,7 +21,7 @@ from .core import (
     infra_path,
     load_json,
     lock_file_for,
-    utc_now,
+    make_infra_event,
 )
 from .locking import advisory_lock
 
@@ -444,15 +444,17 @@ def append_frontier_log(root: Path, strategy: dict[str, Any],
     """Append a frontier-selection event to .evo/infra_log.json."""
     path = infra_path(root)
     seed_str = f" seed={seed}" if seed is not None else ""
-    event = {
-        "kind": "frontier",
-        "timestamp": utc_now(),
-        "message": f"frontier({strategy.get('kind', '?')}) -> {len(returned_ids)} id(s){seed_str}",
+    fields: dict[str, Any] = {
         "strategy": strategy,
         "returned_ids": returned_ids,
     }
     if seed is not None:
-        event["seed"] = seed
+        fields["seed"] = seed
+    event = make_infra_event(
+        "frontier",
+        f"frontier({strategy.get('kind', '?')}) -> {len(returned_ids)} id(s){seed_str}",
+        **fields,
+    )
     with advisory_lock(lock_file_for(path)):
         data = load_json(path, {"events": []})
         data.setdefault("events", []).append(event)

--- a/tests/unit/test_infra_event_schema.py
+++ b/tests/unit/test_infra_event_schema.py
@@ -1,0 +1,63 @@
+"""Infra-log schema regression tests.
+
+Issue #24: infra-log writers should share one event constructor so scratchpad
+readers do not depend on multiple subtly different dict shapes.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from evo import frontier_strategies as fs
+from evo.core import append_infra_event, init_workspace, make_infra_event
+from evo.scratchpad import build_scratchpad
+
+
+class TestInfraEventSchema(unittest.TestCase):
+    def test_generic_and_frontier_events_share_required_fields(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            init_workspace(
+                root,
+                target="target.py",
+                benchmark="python bench.py",
+                metric="max",
+                gate=None,
+            )
+
+            generic = append_infra_event(root, "runtime changed", breaking=True)
+            frontier = fs.append_frontier_log(
+                root,
+                {"kind": "softmax", "params": {"temperature": 1, "k": 1}},
+                ["exp_0001"],
+                seed=7,
+            )
+
+            for event in (generic, frontier):
+                self.assertIn("kind", event)
+                self.assertIn("message", event)
+                self.assertIn("timestamp", event)
+                self.assertNotIn("at", event)
+
+            self.assertEqual(generic["kind"], "infra")
+            self.assertEqual(generic["breaking"], True)
+            self.assertEqual(frontier["kind"], "frontier")
+            self.assertEqual(frontier["returned_ids"], ["exp_0001"])
+            self.assertEqual(frontier["seed"], 7)
+
+            text = build_scratchpad(root)
+            self.assertIn("runtime changed (breaking)", text)
+            self.assertIn("frontier(softmax)", text)
+
+    def test_extra_fields_cannot_override_required_schema(self):
+        with self.assertRaises(ValueError):
+            make_infra_event("frontier", "msg", timestamp="later")
+        with self.assertRaises(ValueError):
+            make_infra_event("frontier", "msg", **{"kind": "other"})
+        with self.assertRaises(ValueError):
+            make_infra_event("frontier", "msg", **{"message": "other"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a canonical infra-log event constructor for required `kind`, `message`, and `timestamp` fields
- route generic infra events and frontier-selection logs through the shared helper
- cover mixed infra/frontier events through scratchpad rendering and reserved-field guards

## Why
Infra log writers were building event dictionaries independently, so future event kinds could drift from the schema read by scratchpad and dashboard consumers. Keeping the required fields in one helper prevents the same class of drift that prompted #24.

## Tests
- `uv run --with pytest --with-editable plugins/evo pytest tests/unit/test_infra_event_schema.py tests/unit/test_frontier_strategies.py tests/unit/test_config_get.py -q`
- `uv run --with pytest --with-editable plugins/evo pytest tests/unit/ -q`

Closes #24
