### PR TITLE
Dashboard: fall back to trace data for committed experiments when `result.tasks` is missing

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -2324,17 +2324,6 @@ def _cmd_run_check(
         score, parsed = load_result(result_path, bench.stdout)
         benchmark_record = {"command": benchmark_cmd, "returncode": 0, "result": parsed}
 
-        # Check that if there are multiple task trace files, then result has tasks
-        if traces_dir.exists():
-            trace_files = list(traces_dir.glob("task_*.json"))
-            if len(trace_files) > 1 and "tasks" not in parsed:
-                raise RuntimeError(
-                    f"benchmark wrote {len(trace_files)} per-task traces but result.json is missing the `tasks` array; "
-                    "write_result() is likely not aggregating from per-task scores. "
-                    "Replace the rolled-own log_task/write_result with the canonical "
-                    "references/inline_instrumentation.py paste-in."
-                )
-
         post_records, post_failures = _run_gate_batch(
             post_gates, gate_origins=gate_origins, config=config,
             target=target, worktree=worktree, run_cwd=run_cwd,

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -2324,6 +2324,17 @@ def _cmd_run_check(
         score, parsed = load_result(result_path, bench.stdout)
         benchmark_record = {"command": benchmark_cmd, "returncode": 0, "result": parsed}
 
+        # Check that if there are multiple task trace files, then result has tasks
+        if traces_dir.exists():
+            trace_files = list(traces_dir.glob("task_*.json"))
+            if len(trace_files) > 1 and "tasks" not in parsed:
+                raise RuntimeError(
+                    f"benchmark wrote {len(trace_files)} per-task traces but result.json is missing the `tasks` array; "
+                    "write_result() is likely not aggregating from per-task scores. "
+                    "Replace the rolled-own log_task/write_result with the canonical "
+                    "references/inline_instrumentation.py paste-in."
+                )
+
         post_records, post_failures = _run_gate_batch(
             post_gates, gate_origins=gate_origins, config=config,
             target=target, worktree=worktree, run_cwd=run_cwd,

--- a/plugins/evo/src/evo/static/app.js
+++ b/plugins/evo/src/evo/static/app.js
@@ -2193,14 +2193,14 @@ async function openDrawer(expId, opts) {
     const tasks = node.benchmark_result?.tasks;
     const isActive = node.status === 'active';
 
-    // Build unified task map: completed results take priority, live traces fill in during active runs
+    // Build unified task map: completed results take priority, traces fill in when result tasks missing
     const taskMap = {};
     if (tasks) {
     for (const [tid, score] of Object.entries(tasks)) {
       taskMap[tid] = score;
     }
-    } else if (isActive && Object.keys(traces).length > 0) {
-    // Active experiment with no result yet -- build task map from live traces
+    } else if (Object.keys(traces).length > 0) {
+    // Experiment with no tasks in result -- build task map from available traces
     for (const [filename, trace] of Object.entries(traces)) {
       taskMap[trace.task_id] = trace.score;
     }


### PR DESCRIPTION
Complements #65 
& Completely fixes #56 
### Problem

The Tasks panel currently builds its task map from `benchmark_result.tasks`.

When that field is missing, the dashboard falls back to per-task trace files only for active experiments:

```js
else if (isActive && Object.keys(traces).length > 0)
```

As a result, committed experiments with valid `task_<id>.json` traces but no aggregated `result.tasks` display:

```
No benchmark task results recorded.
```

even though task data is available through the traces endpoint.

### Solution

Remove the `isActive` restriction from the trace fallback path.

Before:

```js
else if (isActive && Object.keys(traces).length > 0)
```

After:

```js
else if (Object.keys(traces).length > 0)
```

The dashboard now uses trace data whenever `benchmark_result.tasks` is unavailable, regardless of experiment status.

### Behavior

| Scenario                                  | Result                     |
| ----------------------------------------- | -------------------------- |
| `result.tasks` present                    | Use aggregated result data |
| `result.tasks` missing + traces available | Build task map from traces |
| No task data available                    | Show existing empty state  |

### Notes

This is a defensive UI fallback and complements the `evo run --check` validation that prevents new benchmarks from omitting `result.tasks`. It does not change precedence: aggregated result data still takes priority when present.