### PR TITLE
release: 0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,6 @@ jobs:
       - name: Build evo-hook-drain binary
         working-directory: plugins/evo/bin/evo-hook-drain-rs
         run: cargo build --release
-      - name: Stage binary at plugin bin/ path
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            cp plugins/evo/bin/evo-hook-drain-rs/target/release/evo-hook-drain.exe plugins/evo/bin/
-          else
-            cp plugins/evo/bin/evo-hook-drain-rs/target/release/evo-hook-drain plugins/evo/bin/
-          fi
       - name: Configure git for tests (author + default branch)
         run: |
           git config --global user.email "ci@evo.test"

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ plugins/evo/bin/evo-hook-drain-rs/target/
 
 # Locally-built / fetched hook-drain binaries (shipped via GitHub release
 # assets, fetched at install time — never committed to source).
-plugins/evo/bin/evo-hook-drain
 plugins/evo/bin/evo-hook-drain.exe
 
 # Per-subproject lockfiles (the root uv.lock is authoritative)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For remote backends, install with the matching provider extra: `uv tool install 
 
 ### Codex hook trust
 
-Codex requires manual approval for plugin hooks. After install, run `/hooks` inside codex to trust evo's hooks — or pass `--trust-hooks` to `evo install codex` to skip the prompt.
+`evo install codex` trusts evo's hooks for you. To review them yourself first, pass `--no-trust-hooks`, then approve via `/hooks` inside codex.
 
 ## How it works
 
@@ -163,18 +163,13 @@ uv tool install --force evo-hq-cli && evo update --force
 
 ### Hooks failing with exit 127
 
-Exit 127 on `SessionStart` / `UserPromptSubmit` / `PostToolUse` hooks means the host cannot find the `evo-hook-drain` binary. Two known causes, both fixed:
-
-- The binary was staged under a marketplace name Codex does not load from (fixed in 0.4.5).
-- The host re-staged the plugin from its marketplace snapshot — Codex does this on its own when the snapshot changes; Claude Code on `claude plugin update` — and the snapshot did not contain the binary, so the re-stage dropped it (fixed in 0.5.1: installers mirror the binary into the snapshot).
-
-A plain `evo update` does not repair an already-broken install — it reports unhealthy and gets skipped — so reinstall the host explicitly:
+The host lost evo's hook binary. Fixed in 0.5.1; reinstall the host to repair:
 
 ```bash
 uv tool install --force evo-hq-cli && evo install codex --force   # or: evo install claude-code --force
 ```
 
-Verify with `evo doctor <host>`, which checks the binary in both the active cache and the marketplace snapshot.
+`evo doctor <host>` confirms the result.
 
 ### Testing a pre-release (alpha)
 

--- a/README.md
+++ b/README.md
@@ -163,15 +163,20 @@ uv tool install --force evo-hq-cli && evo update --force
 
 `--force` wipes the host plugin cache and reinstalls, working around [anthropics/claude-code#14061](https://github.com/anthropics/claude-code/issues/14061): `/plugin update` returns success but does not replace cached plugin files.
 
-### Codex hooks failing with exit 127
+### Hooks failing with exit 127
 
-Fixed in 0.4.5. If Codex reports `SessionStart` / `UserPromptSubmit` / `PostToolUse` hooks failing with exit 127, the hook binary was staged under a marketplace name Codex does not load from. A plain `evo update` does not repair it — the broken install reports unhealthy and gets skipped — so reinstall the Codex host explicitly:
+Exit 127 on `SessionStart` / `UserPromptSubmit` / `PostToolUse` hooks means the host cannot find the `evo-hook-drain` binary. Two known causes, both fixed:
+
+- The binary was staged under a marketplace name Codex does not load from (fixed in 0.4.5).
+- The host re-staged the plugin from its marketplace snapshot — Codex does this on its own when the snapshot changes; Claude Code on `claude plugin update` — and the snapshot did not contain the binary, so the re-stage dropped it (fixed in 0.5.1: installers mirror the binary into the snapshot).
+
+A plain `evo update` does not repair an already-broken install — it reports unhealthy and gets skipped — so reinstall the host explicitly:
 
 ```bash
-uv tool install --force evo-hq-cli && evo install codex --force
+uv tool install --force evo-hq-cli && evo install codex --force   # or: evo install claude-code --force
 ```
 
-This stages `evo-hook-drain` into the cache directory Codex resolves and clears the stale registration. Verify with `evo doctor codex`, which now checks the binary directly.
+Verify with `evo doctor <host>`, which checks the binary in both the active cache and the marketplace snapshot.
 
 ### Testing a pre-release (alpha)
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ npm install -g @anthropic-ai/claude-code     # or @openai/codex, openclaw, @eare
 evo install <host>     # claude-code | codex | cursor | hermes | opencode | openclaw | pi
 ```
 
-`evo install <host>` installs the plugin into the host's marketplace and stages the hooks evo needs to talk to in-flight subagents. Verify with `evo doctor <host>`.
-
 For remote backends, install with the matching provider extra: `uv tool install 'evo-hq-cli[modal]'` (or `[e2b]`, `[daytona]`, `[aws]`, `[azure]`, `[all]`).
 
 ### Codex hook trust

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/bin/evo-hook-drain
+++ b/plugins/evo/bin/evo-hook-drain
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Fallback entry point for the hooks.json command `bin/evo-hook-drain`.
+#
+# `evo install <host>` stages the platform-native binary at
+# $EVO_HOME/bin/evo-hook-drain (default ~/.evo/bin) and replaces this
+# file with it in the host's plugin cache. Hosts periodically re-copy
+# the plugin from a fresh git snapshot (codex re-clones its marketplace
+# snapshot at session start; claude-code on `claude plugin update`),
+# which restores this script in place of the binary. Exec the stable
+# copy so hooks keep firing across those re-stages.
+stable="${EVO_HOME:-$HOME/.evo}/bin/evo-hook-drain"
+if [ -x "$stable" ]; then
+    exec "$stable" "$@"
+fi
+# No staged binary anywhere: degrade to a no-op so the host's hooks
+# don't fail on every tool call. Mid-run inject (`evo direct`) is
+# disabled until the user reinstalls.
+echo "evo-hook-drain: binary not staged at $stable; run \`evo install <host> --force\` to enable mid-run inject" >&2
+echo '{}'
+exit 0

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Discover
@@ -116,20 +116,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.5.0
+evo-hq-cli 0.5.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.5.0`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.5.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.5.0
+   > uv tool install --force evo-hq-cli==0.5.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.5.0` (or `pipx install evo-hq-cli==0.5.0`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.5.1` (or `pipx install evo-hq-cli==0.5.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit -- scan-subagent cross-cutting analysis between rounds, frontier-based parent selection, ideator dispatch on stall, verifier pre/post hooks, annotation discipline. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Print the dashboard's dot chart (score over experiment order, status colors, best-path stair) inline in the terminal for every run in the workspace. Use when the user invokes /evo:report, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Report

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Discover
@@ -116,20 +116,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.5.0
+evo-hq-cli 0.5.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.5.0`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.5.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.5.0
+   > uv tool install --force evo-hq-cli==0.5.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.5.0` (or `pipx install evo-hq-cli==0.5.0`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.5.1` (or `pipx install evo-hq-cli==0.5.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Finetuning

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit -- scan-subagent cross-cutting analysis between rounds, frontier-based parent selection, ideator dispatch on stall, verifier pre/post hooks, annotation discipline. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Print the dashboard's dot chart (score over experiment order, status colors, best-path stair) inline in the terminal for every run in the workspace. Use when the user invokes /evo:report, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Report

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.5.0
+evo_version: 0.5.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -6589,13 +6589,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     install_p.add_argument(
         "--trust-hooks",
-        action="store_true",
-        help="Trust the plugin's hooks non-interactively (codex only). "
-             "By default codex installs hooks in untrusted state — they "
-             "register but never fire until reviewed via `codex /hooks`. "
-             "This flag writes the trusted_hash entries that the TUI would "
-             "write on user approval, enabling mid-run directives. Use only "
-             "if you've reviewed plugins/evo/hooks/hooks.json and accept it.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Trust the plugin's hooks non-interactively (codex only; "
+             "default: on). Writes the trusted_hash entries codex's "
+             "`/hooks` review would write on approval; without them the "
+             "hooks register but never fire and `evo direct` is not "
+             "delivered. Pass --no-trust-hooks to review and trust the "
+             "hooks inside codex via `/hooks` instead.",
     )
     install_p.add_argument(
         "--version",
@@ -6675,8 +6676,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     update_p.add_argument(
         "--trust-hooks",
-        action="store_true",
-        help="Trust the plugin's hooks non-interactively (codex only).",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Trust the plugin's hooks non-interactively (codex only; "
+             "default: on). Pass --no-trust-hooks to review via `/hooks` "
+             "inside codex instead.",
     )
     update_p.set_defaults(func=cmd_update)
 

--- a/plugins/evo/src/evo/host_install/__init__.py
+++ b/plugins/evo/src/evo/host_install/__init__.py
@@ -66,10 +66,15 @@ def _mark_cli_synced() -> None:
 
 
 def install(host: str, args) -> int:
-    """Run the host's install + sync the global CLI to match."""
+    """Run the host's install + sync the global CLI to match, then run
+    the host's doctor. A non-zero doctor result is returned as the
+    install's result: an install that doctor can't verify is not a
+    success the user should have to discover at hook-fire time.
+    """
     rc = get(host).install(args)
     if rc == 0:
         _sync_cli_to_plugin_version(args)
+        rc = _verify_install(host)
     return rc
 
 
@@ -91,7 +96,17 @@ def update(host: str, args) -> int:
     rc = fn(args)
     if rc == 0:
         _sync_cli_to_plugin_version(args)
+        rc = _verify_install(host)
     return rc
+
+
+def _verify_install(host: str) -> int:
+    """Run the host's doctor after a successful install/update so a
+    broken result is visible immediately instead of at hook-fire time.
+    """
+    import argparse
+    print(f"\n=== verifying: evo doctor {host} ===")
+    return get(host).doctor(argparse.Namespace())
 
 
 def _is_editable_evo_install() -> bool:

--- a/plugins/evo/src/evo/host_install/_hook_drain.py
+++ b/plugins/evo/src/evo/host_install/_hook_drain.py
@@ -1,14 +1,26 @@
-"""Fetch the platform-native evo-hook-drain binary from the GitHub release.
+"""Stage the platform-native evo-hook-drain binary where hooks resolve it.
 
 The hook script is a small Rust binary (~330 KB) built natively for each
 platform in CI. Binaries ship as GitHub Release assets, NOT in the plugin
 git tree (keeps the repo small + lets users install from `main` without
 binaries present). Every host's `install(args)` calls
-`ensure_hook_drain_binary(plugin_root)` to populate the plugin's bin/
-directory before hooks.json's command path is exercised.
+`ensure_hook_drain_binary(plugin_root)`, which:
 
-Idempotent: re-fetch only when the on-disk binary is missing or doesn't
-match the installed evo-hq-cli version.
+  1. fetches the binary into the stable per-user location
+     `$EVO_HOME/bin/` (default `~/.evo/bin/`), outside any
+     host-managed directory, and
+  2. copies it to `<plugin_root>/bin/evo-hook-drain`, the path
+     hooks.json commands resolve.
+
+The plugin tree commits a shell-script fallback at `bin/evo-hook-drain`
+that execs the stable copy. Hosts re-stage their plugin cache from a
+fresh git snapshot whenever they decide to (codex re-clones its
+marketplace snapshot at session start), which drops anything evo staged
+into those directories; the tracked wrapper survives every re-stage and
+keeps hooks firing via the stable copy.
+
+Idempotent: re-fetch only when the stable copy is missing, was staged by
+a different evo-hq-cli version, or `force` is set.
 """
 from __future__ import annotations
 
@@ -83,20 +95,37 @@ def hook_drain_binary_name() -> str:
     return "evo-hook-drain.exe" if platform.system().lower() == "windows" else "evo-hook-drain"
 
 
+def stable_binary_path() -> Path:
+    """Host-independent home for the fetched binary:
+    `$EVO_HOME/bin/<name>` (default `~/.evo/bin/<name>`). The committed
+    `bin/evo-hook-drain` wrapper in the plugin tree execs this copy.
+    """
+    override = os.environ.get("EVO_HOME")
+    base = Path(override) if override else Path.home() / ".evo"
+    return base / "bin" / hook_drain_binary_name()
+
+
+def is_wrapper_script(path: Path) -> bool:
+    """True when `path` holds the committed shell-script fallback rather
+    than a platform-native binary."""
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(2) == b"#!"
+    except OSError:
+        return False
+
+
 def mirror_hook_drain_binary(src_plugin_root: Path, dst_plugin_root: Path) -> bool:
-    """Copy `bin/evo-hook-drain` from one plugin root to another.
+    """Copy `bin/evo-hook-drain` from one plugin root to another, so a
+    host re-stage from the destination (codex: marketplace snapshot;
+    claude-code: marketplace clone) carries the native binary instead of
+    falling back to the wrapper script.
 
-    Hosts re-stage the plugin cache by copying the marketplace snapshot
-    (codex does this whenever the snapshot changes; claude-code on
-    `claude plugin update`). The snapshot is a git clone, which never
-    contains the binary — release assets aren't in the tree — so a
-    re-stage silently drops the binary the hooks resolve and every hook
-    fires exit 127. Mirroring the fetched binary into the snapshot makes
-    re-stages carry it.
-
-    No-op when src and dst resolve to the same directory (--from-path
-    installs stage directly into the source tree). Returns True when the
-    binary is present at the destination afterwards.
+    Best-effort: the host may wipe the destination on its next snapshot
+    refresh, at which point the tracked wrapper takes over. No-op when
+    src and dst resolve to the same directory (--from-path installs
+    stage directly into the source tree). Returns True when the file is
+    present at the destination afterwards.
     """
     import shutil
 
@@ -117,59 +146,38 @@ def mirror_hook_drain_binary(src_plugin_root: Path, dst_plugin_root: Path) -> bo
             os.chmod(dst, 0o755)
     except OSError as e:
         print(
-            f"WARN: failed to mirror evo-hook-drain into {dst.parent}: {e}\n"
-            f"      A host plugin re-stage from that directory would drop "
-            f"the hook binary (hooks exit 127).",
+            f"WARN: failed to mirror evo-hook-drain into {dst.parent}: {e}",
             file=sys.stderr,
         )
         return False
     return True
 
 
-def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
-    """Stage the evo-hook-drain binary into `<plugin_root>/bin/` if it's
-    not already there. Returns True on success (file is now present and
-    executable), False otherwise.
+def _stage_stable_copy(asset: str, *, force: bool) -> bool:
+    """Ensure the stable copy at `stable_binary_path()` exists and was
+    staged by this CLI version. Returns True when a usable stable copy
+    is present afterwards (even a version-stale one, if re-fetch fails:
+    the binary's wire protocol is stable across minor versions).
 
     Sources, in order of precedence:
-      1. `EVO_HOOK_DRAIN_BINARY` env var — points to a local file. Used
+      1. `EVO_HOOK_DRAIN_BINARY` env var: points to a local file. Used
          by tests / local-source smoke runs to bypass the GitHub
          release URL when there's no published release to fetch from.
          The file gets copied (not symlinked) so it stays valid after
          the source disappears.
-      2. GitHub release asset for this evo-hq-cli version. Fetched via
-         urllib (stdlib only).
-
-    Non-fatal: a failed fetch prints a warning to stderr but doesn't
-    raise. Hooks will fail at fire-time with a clearer error pointing
-    the user at `evo install <host> --force` to retry.
+      2. GitHub release asset for this evo-hq-cli version, falling back
+         to /releases/latest/. Fetched via urllib (stdlib only).
     """
-    target = _target_name()
-    if target is None:
-        print(
-            f"WARN: evo-hook-drain binary not available for "
-            f"{platform.system().lower()}-{platform.machine().lower()}. "
-            f"Mid-run inject via `evo direct` will not work on this platform.",
-            file=sys.stderr,
-        )
-        return False
-
+    stable = stable_binary_path()
+    sidecar = stable.parent / "evo-hook-drain.version"
     is_windows = platform.system().lower() == "windows"
-    ext = ".exe" if is_windows else ""
-    asset = f"evo-hook-drain-{target}{ext}"
-    dest = plugin_root / "bin" / f"evo-hook-drain{ext}"
 
-    if dest.exists() and not force:
-        # Already present. Trust it — re-fetching every install would be
-        # wasteful and might fail if the user is offline.
+    staged_by = sidecar.read_text().strip() if sidecar.exists() else None
+    if stable.exists() and not force and staged_by == EVO_VERSION:
         return True
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    stable.parent.mkdir(parents=True, exist_ok=True)
 
-    # Env-var bypass for local-source / test contexts where no published
-    # release exists yet. The test harness builds the binary, sets
-    # EVO_HOOK_DRAIN_BINARY=<path>, then runs `evo install <host>` and
-    # gets the local file copied in instead of a 404 from urllib.
     local_override = os.environ.get("EVO_HOOK_DRAIN_BINARY")
     if local_override:
         import shutil
@@ -182,14 +190,15 @@ def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
             )
         else:
             try:
-                shutil.copyfile(src, dest)
+                shutil.copyfile(src, stable)
                 if not is_windows:
-                    os.chmod(dest, 0o755)
-                print(f"installed evo-hook-drain binary from EVO_HOOK_DRAIN_BINARY: {dest}")
+                    os.chmod(stable, 0o755)
+                sidecar.write_text(EVO_VERSION + "\n")
+                print(f"installed evo-hook-drain binary from EVO_HOOK_DRAIN_BINARY: {stable}")
                 return True
             except OSError as e:
                 print(
-                    f"WARN: failed to copy EVO_HOOK_DRAIN_BINARY={src} to {dest}: {e}. "
+                    f"WARN: failed to copy EVO_HOOK_DRAIN_BINARY={src} to {stable}: {e}. "
                     f"Falling back to GitHub release fetch.",
                     file=sys.stderr,
                 )
@@ -202,13 +211,12 @@ def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
     # don't have a corresponding GitHub Release tagged yet (release builds
     # are only cut at stable bumps), so a 404 here is expected during alpha
     # cycles. Fall back to /releases/latest/, which GitHub redirects to the
-    # most recent stable release. The binary's wire protocol is stable
-    # across minor versions, so a slightly older binary still works.
+    # most recent stable release.
     last_err: Exception | None = None
     for url in (versioned_url, latest_url):
         try:
             print(f"$ fetching {asset} from {url}")
-            urllib.request.urlretrieve(url, str(dest))
+            urllib.request.urlretrieve(url, str(stable))
             if url == latest_url and url != versioned_url:
                 print(
                     f"NOTE: used /releases/latest/ fallback because the "
@@ -223,11 +231,20 @@ def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
             # Continue to the next URL in the fallback chain.
             continue
     else:
+        if stable.exists():
+            print(
+                f"WARN: could not refresh evo-hook-drain "
+                f"(tried {versioned_url} and {latest_url}): {last_err}\n"
+                f"      Keeping the existing copy at {stable} "
+                f"(wire-compatible across minor versions).",
+                file=sys.stderr,
+            )
+            return True
         print(
             f"WARN: failed to fetch evo-hook-drain binary "
             f"(tried {versioned_url} and {latest_url}): {last_err}\n"
             f"      Mid-run inject (`evo direct`) will not work until the "
-            f"binary is staged at {dest}. Re-run `evo install <host> --force` "
+            f"binary is staged at {stable}. Re-run `evo install <host> --force` "
             f"with network access to retry.",
             file=sys.stderr,
         )
@@ -235,9 +252,76 @@ def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
 
     if not is_windows:
         try:
-            os.chmod(dest, 0o755)
+            os.chmod(stable, 0o755)
         except OSError:
             pass
+    sidecar.write_text(EVO_VERSION + "\n")
+    print(f"installed evo-hook-drain binary: {stable}")
+    return True
 
-    print(f"installed evo-hook-drain binary: {dest}")
+
+def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False,
+                             overwrite_wrapper: bool = True) -> bool:
+    """Stage the binary at the stable location and make
+    `<plugin_root>/bin/evo-hook-drain` a working hook entry point.
+    Returns True when hooks at `plugin_root` will fire.
+
+    `overwrite_wrapper=False` leaves a committed wrapper script in place
+    at the destination (used for --from-path installs, where the
+    destination is the user's source tree and replacing the tracked
+    wrapper with a binary would dirty their checkout); the wrapper execs
+    the stable copy, so hooks still work.
+
+    Non-fatal: a failed fetch prints a warning to stderr but doesn't
+    raise.
+    """
+    target = _target_name()
+    if target is None:
+        print(
+            f"WARN: evo-hook-drain binary not available for "
+            f"{platform.system().lower()}-{platform.machine().lower()}. "
+            f"Mid-run inject via `evo direct` will not work on this platform.",
+            file=sys.stderr,
+        )
+        return False
+
+    is_windows = platform.system().lower() == "windows"
+    ext = ".exe" if is_windows else ""
+    asset = f"evo-hook-drain-{target}{ext}"
+
+    stable_ok = _stage_stable_copy(asset, force=force)
+    stable = stable_binary_path()
+    dest = plugin_root / "bin" / hook_drain_binary_name()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    dest_exists = dest.exists()
+    dest_is_wrapper = dest_exists and is_wrapper_script(dest)
+    should_copy = stable_ok and (
+        not dest_exists
+        or (dest_is_wrapper and overwrite_wrapper)
+        or (not dest_is_wrapper and force)
+    )
+    if should_copy:
+        import shutil
+        try:
+            shutil.copyfile(stable, dest)
+            if not is_windows:
+                os.chmod(dest, 0o755)
+            print(f"staged evo-hook-drain binary: {dest}")
+        except OSError as e:
+            print(
+                f"WARN: failed to stage evo-hook-drain at {dest}: {e}",
+                file=sys.stderr,
+            )
+
+    if not dest.exists():
+        return False
+    if is_wrapper_script(dest) and not stable_ok:
+        print(
+            f"WARN: {dest} is the fallback wrapper and no binary is staged "
+            f"at {stable}, so hooks will no-op. Re-run "
+            f"`evo install <host> --force` with network access.",
+            file=sys.stderr,
+        )
+        return False
     return True

--- a/plugins/evo/src/evo/host_install/_hook_drain.py
+++ b/plugins/evo/src/evo/host_install/_hook_drain.py
@@ -78,6 +78,54 @@ def _release_version_tag(version: str) -> str:
     return version
 
 
+def hook_drain_binary_name() -> str:
+    """Filename of the staged binary for the current platform."""
+    return "evo-hook-drain.exe" if platform.system().lower() == "windows" else "evo-hook-drain"
+
+
+def mirror_hook_drain_binary(src_plugin_root: Path, dst_plugin_root: Path) -> bool:
+    """Copy `bin/evo-hook-drain` from one plugin root to another.
+
+    Hosts re-stage the plugin cache by copying the marketplace snapshot
+    (codex does this whenever the snapshot changes; claude-code on
+    `claude plugin update`). The snapshot is a git clone, which never
+    contains the binary — release assets aren't in the tree — so a
+    re-stage silently drops the binary the hooks resolve and every hook
+    fires exit 127. Mirroring the fetched binary into the snapshot makes
+    re-stages carry it.
+
+    No-op when src and dst resolve to the same directory (--from-path
+    installs stage directly into the source tree). Returns True when the
+    binary is present at the destination afterwards.
+    """
+    import shutil
+
+    name = hook_drain_binary_name()
+    src = src_plugin_root / "bin" / name
+    dst = dst_plugin_root / "bin" / name
+    if not src.is_file():
+        return False
+    try:
+        if src.resolve() == dst.resolve():
+            return True
+    except OSError:
+        pass
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        if platform.system().lower() != "windows":
+            os.chmod(dst, 0o755)
+    except OSError as e:
+        print(
+            f"WARN: failed to mirror evo-hook-drain into {dst.parent}: {e}\n"
+            f"      A host plugin re-stage from that directory would drop "
+            f"the hook binary (hooks exit 127).",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def ensure_hook_drain_binary(plugin_root: Path, *, force: bool = False) -> bool:
     """Stage the evo-hook-drain binary into `<plugin_root>/bin/` if it's
     not already there. Returns True on success (file is now present and

--- a/plugins/evo/src/evo/host_install/claude_code.py
+++ b/plugins/evo/src/evo/host_install/claude_code.py
@@ -97,7 +97,12 @@ def _stage_hook_drain(from_path: str | None, *, force: bool = False) -> None:
     plugin_dir = _hook_drain_staging_dir(from_path)
     if plugin_dir is None:
         return
-    ensure_hook_drain_binary(plugin_dir, force=force)
+    # For --from-path the destination is the user's source tree: leave
+    # the committed wrapper in place (it execs the stable copy) instead
+    # of dirtying their checkout with a binary.
+    ensure_hook_drain_binary(
+        plugin_dir, force=force, overwrite_wrapper=not from_path
+    )
     if not from_path:
         clone_dir = (
             _claude_config_dir() / "plugins" / "marketplaces"

--- a/plugins/evo/src/evo/host_install/claude_code.py
+++ b/plugins/evo/src/evo/host_install/claude_code.py
@@ -24,7 +24,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from ._hook_drain import ensure_hook_drain_binary
+from ._hook_drain import (
+    ensure_hook_drain_binary,
+    hook_drain_binary_name,
+    mirror_hook_drain_binary,
+)
 
 
 _MARKETPLACE = "evo-hq/evo"
@@ -80,6 +84,27 @@ def _hook_drain_staging_dir(from_path: str | None) -> Path | None:
             return src
         return candidate  # let ensure_* create bin/ under the expected path
     return _latest_cache_dir()
+
+
+def _stage_hook_drain(from_path: str | None, *, force: bool = False) -> None:
+    """Fetch the binary into the plugin dir the hooks resolve, then mirror
+    it into the marketplace clone for cache-backed installs.
+
+    `claude plugin update` re-copies the marketplace clone over the version
+    cache; the clone is a git tree without the binary, so an update run
+    outside `evo update` would otherwise drop it and hooks exit 127.
+    """
+    plugin_dir = _hook_drain_staging_dir(from_path)
+    if plugin_dir is None:
+        return
+    ensure_hook_drain_binary(plugin_dir, force=force)
+    if not from_path:
+        clone_dir = (
+            _claude_config_dir() / "plugins" / "marketplaces"
+            / _MARKETPLACE_NAME / "plugins" / "evo"
+        )
+        if clone_dir.is_dir():
+            mirror_hook_drain_binary(plugin_dir, clone_dir)
 
 # Strict release-tag shape: 'X.Y.Z' optionally followed by a pre-release
 # suffix ('0.4.0-alpha.5', '0.4.0a5', '0.4.0rc1'). Only this shape gets
@@ -155,9 +180,10 @@ def install(args: argparse.Namespace) -> int:
     # Stage the platform-native evo-hook-drain binary where the runtime hook
     # resolves it. hooks.json points at ${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain;
     # for a --from-path install that's the source tree, not the version cache.
-    plugin_dir = _hook_drain_staging_dir(getattr(args, "from_path", None))
-    if plugin_dir is not None:
-        ensure_hook_drain_binary(plugin_dir, force=bool(getattr(args, "force", False)))
+    _stage_hook_drain(
+        getattr(args, "from_path", None),
+        force=bool(getattr(args, "force", False)),
+    )
     print(
         f"\n✓ evo installed for claude-code at scope={scope}.\n"
         "  If you're inside an active claude session, run `/reload-plugins` "
@@ -213,9 +239,7 @@ def update(args: argparse.Namespace) -> int:
     # Re-stage the hook-drain binary where the runtime hook resolves it
     # (source tree for --from-path, version cache otherwise).
     # --force will re-download even if a binary's already there.
-    plugin_dir = _hook_drain_staging_dir(from_path)
-    if plugin_dir is not None:
-        ensure_hook_drain_binary(plugin_dir, force=force)
+    _stage_hook_drain(from_path, force=force)
     print(
         "\n✓ evo updated for claude-code.\n"
         "  If you're inside an active claude session, run `/reload-plugins` "
@@ -261,6 +285,18 @@ def doctor(args: argparse.Namespace) -> int:
         cache = home / "plugins" / "marketplaces" / _MARKETPLACE_NAME
         if cache.exists():
             print(f"✓ marketplace cached at {cache}")
+            # Warning only (no rc bump): `evo update` skips hosts whose
+            # doctor fails, and update is exactly what re-mirrors this.
+            clone_binary = (
+                cache / "plugins" / "evo" / "bin" / hook_drain_binary_name()
+            )
+            if not clone_binary.exists():
+                print(
+                    f"! evo-hook-drain not mirrored in the marketplace clone "
+                    f"({clone_binary})\n"
+                    f"  `claude plugin update` would drop the hook binary "
+                    f"(hooks exit 127). Run: evo update claude-code"
+                )
         else:
             print(f"✗ source=github but no cache at {cache} — try restarting claude")
             rc = 1

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -8,7 +8,11 @@ import argparse
 import os
 from pathlib import Path
 
-from ._hook_drain import ensure_hook_drain_binary
+from ._hook_drain import (
+    ensure_hook_drain_binary,
+    hook_drain_binary_name,
+    mirror_hook_drain_binary,
+)
 
 
 _PLUGIN_KEY = '[plugins."evo@evo-hq"]'
@@ -270,6 +274,13 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -
     # `force=False` (default) avoids re-fetch only when the file is
     # already at dest, which never happens since we just wiped.
     ensure_hook_drain_binary(cache_dst)
+
+    # Mirror the binary into the marketplace snapshot. Codex re-stages
+    # the plugin cache from the snapshot on its own (observed at session
+    # start after the snapshot changes); the snapshot is a git clone
+    # without the binary, so a re-stage that finds none there drops it
+    # from the cache and every hook fires exit 127.
+    mirror_hook_drain_binary(cache_dst, plugin_root)
 
     # Update config.toml: ensure `[features] plugin_hooks = true`
     # (gates whether codex fires plugin hooks at all) AND
@@ -633,6 +644,17 @@ def doctor(args: argparse.Namespace) -> int:
 
     if cache.exists():
         print(f"✓ evo marketplace cached at {cache}")
+        # Warning only (no rc bump): the active cache binary check below
+        # covers the live install, and `evo update` skips hosts whose
+        # doctor fails — failing here would block the self-heal path.
+        snapshot_binary = cache / "plugins" / "evo" / "bin" / hook_drain_binary_name()
+        if not snapshot_binary.exists():
+            print(
+                f"! evo-hook-drain not mirrored in the marketplace snapshot "
+                f"({snapshot_binary})\n"
+                f"  A codex plugin re-stage would drop the hook binary "
+                f"(hooks exit 127). Run: evo install codex"
+            )
     else:
         print(f"✗ no marketplace cache at {cache}")
         print("  Run: codex plugin marketplace add evo-hq/evo")

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -11,7 +11,9 @@ from pathlib import Path
 from ._hook_drain import (
     ensure_hook_drain_binary,
     hook_drain_binary_name,
+    is_wrapper_script,
     mirror_hook_drain_binary,
+    stable_binary_path,
 )
 
 
@@ -114,7 +116,7 @@ def install(args: argparse.Namespace) -> int:
         return 2
 
     from_path = getattr(args, "from_path", None)
-    trust_hooks = bool(getattr(args, "trust_hooks", False))
+    trust_hooks = bool(getattr(args, "trust_hooks", True))
     force = bool(getattr(args, "force", False))
 
     # Drive `codex plugin marketplace add` automatically. Skip if:
@@ -187,7 +189,7 @@ def _resolve_marketplace_json(from_path: str | None) -> Path | None:
     return mj if mj.exists() else None
 
 
-def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -> int:
+def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) -> int:
     """Mirror what codex's `plugin/install` RPC writes to disk:
       1. read marketplace name from `<root>/.claude-plugin/marketplace.json`
       2. read plugin version from `<plugin-root>/.codex-plugin/plugin.json`
@@ -275,12 +277,15 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -
     # already at dest, which never happens since we just wiped.
     ensure_hook_drain_binary(cache_dst)
 
-    # Mirror the binary into the marketplace snapshot. Codex re-stages
-    # the plugin cache from the snapshot on its own (observed at session
-    # start after the snapshot changes); the snapshot is a git clone
-    # without the binary, so a re-stage that finds none there drops it
-    # from the cache and every hook fires exit 127.
-    mirror_hook_drain_binary(cache_dst, plugin_root)
+    # Mirror the binary into the marketplace snapshot so codex's next
+    # cache re-stage carries the native binary instead of the tracked
+    # wrapper. Best-effort: codex re-clones the snapshot from git at
+    # session start, which removes the mirrored copy and restores the
+    # wrapper (still a working entry point via the stable copy). Skipped
+    # for --from-path: the source is the user's checkout and the binary
+    # would dirty it.
+    if not from_path:
+        mirror_hook_drain_binary(cache_dst, plugin_root)
 
     # Update config.toml: ensure `[features] plugin_hooks = true`
     # (gates whether codex fires plugin hooks at all) AND
@@ -318,11 +323,11 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = False) -
         _trust_plugin_hooks(nested_hooks, plugin_id=f"evo@{mkt_name}", cfg=cfg)
     else:
         print(
-            "\nPlugin hooks installed but UNTRUSTED. To enable mid-run "
-            "directives (`evo direct`) on this codex install:\n"
+            "\nPlugin hooks installed UNTRUSTED (--no-trust-hooks). They "
+            "register but never fire, so mid-run directives (`evo direct`) "
+            "won't be delivered. To enable:\n"
             "  - Start `codex`, then `/hooks`, trust each evo hook, OR\n"
-            "  - Re-run: evo install codex --trust-hooks  "
-            "(skips the codex security review)"
+            "  - Re-run: evo install codex"
         )
 
     _cleanup_legacy_codex_registrations(target_mkt=mkt_name)
@@ -460,9 +465,10 @@ def _command_hook_hash(event_label: str, matcher: str | None,
     return "sha256:" + _hashlib.sha256(serialized).hexdigest()
 
 
-def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> None:
-    """Write `[hooks.state."<key>"] trusted_hash = "..."` entries to
-    config.toml — same effect as `codex` → `/hooks` → Trust each.
+def _expected_hook_state(hooks_json_path: Path, plugin_id: str) -> dict[str, str] | None:
+    """Compute the `{state_key: trusted_hash}` entries codex's TUI would
+    write on user approval of every command hook in hooks.json. Returns
+    None when hooks.json can't be parsed.
 
     The key shape codex uses (verified via `hooks/list` RPC):
         <plugin_id>:hooks/hooks.json:<event_label>:<group_idx>:<handler_idx>
@@ -473,11 +479,10 @@ def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> Non
         hooks_file = _json.loads(hooks_json_path.read_text())
     except (OSError, _json.JSONDecodeError) as exc:
         print(f"✗ could not parse {hooks_json_path}: {exc}", file=_sys.stderr)
-        return
+        return None
 
-    events = hooks_file.get("hooks", {})
-    lines: list[str] = []
-    for event_name, groups in events.items():
+    expected: dict[str, str] = {}
+    for event_name, groups in hooks_file.get("hooks", {}).items():
         event_label = _hook_event_label(event_name)
         if event_label is None:
             continue
@@ -492,21 +497,31 @@ def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> Non
                 timeout = handler.get("timeout")
                 if timeout is None:
                     timeout = 600  # codex's default after normalization
-                trusted_hash = _command_hook_hash(
+                key = (f'{plugin_id}:hooks/hooks.json:'
+                       f'{event_label}:{group_idx}:{handler_idx}')
+                expected[key] = _command_hook_hash(
                     event_label, matcher, cmd,
                     timeout_sec=timeout,
                     async_=bool(handler.get("async", False)),
                     status_msg=handler.get("statusMessage"),
                 )
-                key = (f'{plugin_id}:hooks/hooks.json:'
-                       f'{event_label}:{group_idx}:{handler_idx}')
-                lines.append(
-                    f'[hooks.state."{key}"]\ntrusted_hash = "{trusted_hash}"'
-                )
+    return expected
 
-    if not lines:
+
+def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> None:
+    """Write `[hooks.state."<key>"] trusted_hash = "..."` entries to
+    config.toml, same effect as `codex` → `/hooks` → Trust each.
+    """
+    expected = _expected_hook_state(hooks_json_path, plugin_id)
+    if expected is None:
+        return
+    if not expected:
         print("(no command hooks to trust)")
         return
+    lines = [
+        f'[hooks.state."{key}"]\ntrusted_hash = "{trusted_hash}"'
+        for key, trusted_hash in expected.items()
+    ]
 
     block = "\n\n".join(lines) + "\n"
     text = cfg.read_text() if cfg.exists() else ""
@@ -520,7 +535,11 @@ def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> Non
     )
     text = pat.sub("", text).rstrip() + "\n\n" + block
     cfg.write_text(text)
-    print(f"updated {cfg}: trusted {len(lines)} hooks for {plugin_id}")
+    events = sorted({key.split(":")[-3] for key in expected})
+    print(
+        f"updated {cfg}: trusted {len(lines)} hooks for {plugin_id} "
+        f"({', '.join(events)})"
+    )
 
 
 def _install_via_rpc(from_path: str | None) -> int:
@@ -646,7 +665,7 @@ def doctor(args: argparse.Namespace) -> int:
         print(f"✓ evo marketplace cached at {cache}")
         # Warning only (no rc bump): the active cache binary check below
         # covers the live install, and `evo update` skips hosts whose
-        # doctor fails — failing here would block the self-heal path.
+        # doctor fails; failing here would block the self-heal path.
         snapshot_binary = cache / "plugins" / "evo" / "bin" / hook_drain_binary_name()
         if not snapshot_binary.exists():
             print(
@@ -698,15 +717,69 @@ def doctor(args: argparse.Namespace) -> int:
             print("  Run: evo install codex --force")
             rc = 1
             continue
-        binary = versions[-1] / "bin" / "evo-hook-drain"
-        if binary.exists() and os.access(binary, os.X_OK):
-            print(f"✓ evo-hook-drain present + executable at {binary}")
-        elif binary.exists():
+        binary = versions[-1] / "bin" / hook_drain_binary_name()
+        stable = stable_binary_path()
+        if not binary.exists():
+            print(f"✗ evo-hook-drain missing at {binary} (hooks fire exit 127)")
+            print("  Run: evo install codex --force")
+            rc = 1
+        elif not os.access(binary, os.X_OK):
             print(f"✗ evo-hook-drain at {binary} is not executable")
             print("  Run: evo install codex --force")
             rc = 1
+        elif not is_wrapper_script(binary):
+            print(f"✓ evo-hook-drain present + executable at {binary}")
+        elif stable.exists() and os.access(stable, os.X_OK):
+            print(
+                f"✓ evo-hook-drain fallback wrapper at {binary} "
+                f"(execs stable binary at {stable})"
+            )
         else:
-            print(f"✗ evo-hook-drain missing at {binary} (hooks fire exit 127)")
+            print(
+                f"✗ evo-hook-drain at {binary} is the fallback wrapper and "
+                f"no stable binary exists at {stable} (hooks no-op)"
+            )
             print("  Run: evo install codex --force")
+            rc = 1
+
+        # Trust state. Untrusted hooks register but never fire, so `evo
+        # direct` silently does nothing. Three states:
+        #   - all expected entries present with matching hashes → ✓
+        #   - no entries at all → warning only (deliberate
+        #     --no-trust-hooks installs await the user's /hooks review)
+        #   - some entries missing or hash-mismatched → ✗ (hooks.json
+        #     changed since trust was written, silent breakage the
+        #     user didn't choose)
+        hooks_json = versions[-1] / "hooks" / "hooks.json"
+        if not hooks_json.exists():
+            continue
+        expected = _expected_hook_state(hooks_json, f"evo@{mkt_name}")
+        if not expected:
+            continue
+        actual = dict(_re.findall(
+            r'\[hooks\.state\."([^"]+)"\]\s*\ntrusted_hash = "([^"]+)"',
+            uncommented,
+        ))
+        stale = {
+            key for key, h in expected.items()
+            if key in actual and actual[key] != h
+        }
+        missing = {key for key in expected if key not in actual}
+        if not stale and not missing:
+            print(f"✓ {len(expected)} hooks trusted for evo@{mkt_name}")
+        elif len(missing) == len(expected) and not stale:
+            print(
+                f"! hooks installed but untrusted for evo@{mkt_name}: "
+                f"they never fire, so `evo direct` won't be delivered\n"
+                f"  Trust via `/hooks` inside codex, or run: evo install codex"
+            )
+        else:
+            print(
+                f"✗ hook trust is stale for evo@{mkt_name} "
+                f"({len(stale)} mismatched, {len(missing)} missing): "
+                f"hooks.json changed since trust was written; those hooks "
+                f"never fire\n"
+                f"  Run: evo install codex"
+            )
             rc = 1
     return rc

--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.5.0"
+version = "0.5.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,15 +1,18 @@
 """Per-unit-test pytest config.
 
 Builds the Rust evo-hook-drain binary once per pytest session if it's
-not already staged. Both test_hook_drain.py and test_subagent_identity.py
+not already built. Both test_hook_drain.py and test_subagent_identity.py
 exercise the binary as a subprocess — without it, they'd error opaquely.
 The fixture fails the suite with a clear instruction if cargo isn't
 available locally.
+
+Tests exec the binary straight from the cargo target dir.
+`plugins/evo/bin/evo-hook-drain` is the committed shell-script fallback
+(it execs the user's stable copy at ~/.evo/bin), NOT the binary. Never
+point tests at it, and never copy a built binary over it.
 """
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -19,27 +22,25 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 HOOK_NAME = "evo-hook-drain.exe" if sys.platform == "win32" else "evo-hook-drain"
-HOOK_PATH = REPO_ROOT / "plugins" / "evo" / "bin" / HOOK_NAME
 RUST_CRATE = REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain-rs"
+HOOK_PATH = RUST_CRATE / "target" / "release" / HOOK_NAME
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _ensure_hook_drain_binary():
-    """Build the Rust hook-drain binary if it's not already staged at
-    plugins/evo/bin/. Fails the entire suite (not individual tests)
-    if the binary can't be produced — CI ensures it's built before
-    pytest runs; locally a missing cargo means the dev needs to
-    install Rust.
+    """Build the Rust hook-drain binary if it's not already at the cargo
+    target path. Fails the entire suite (not individual tests) if the
+    binary can't be produced (CI ensures it's built before pytest runs;
+    locally a missing cargo means the dev needs to install Rust.
     """
     if HOOK_PATH.exists():
         return
     cargo = subprocess.run(["cargo", "--version"], capture_output=True)
     if cargo.returncode != 0:
         pytest.fail(
-            f"hook binary not staged at {HOOK_PATH} and `cargo` is not "
+            f"hook binary not built at {HOOK_PATH} and `cargo` is not "
             f"available to build it. Install Rust (rustup.rs) then run:\n"
-            f"  cd {RUST_CRATE} && cargo build --release\n"
-            f"  cp target/release/{HOOK_NAME} {HOOK_PATH}"
+            f"  cd {RUST_CRATE} && cargo build --release"
         )
     build = subprocess.run(
         ["cargo", "build", "--release"],
@@ -51,9 +52,5 @@ def _ensure_hook_drain_binary():
             f"`cargo build --release` failed in {RUST_CRATE}:\n"
             f"{build.stderr.decode(errors='replace')}"
         )
-    built = RUST_CRATE / "target" / "release" / HOOK_NAME
-    if not built.exists():
-        pytest.fail(f"cargo built but binary missing at {built}")
-    shutil.copy2(built, HOOK_PATH)
-    if sys.platform != "win32":
-        os.chmod(HOOK_PATH, 0o755)
+    if not HOOK_PATH.exists():
+        pytest.fail(f"cargo built but binary missing at {HOOK_PATH}")

--- a/tests/unit/test_claude_code_e2e.py
+++ b/tests/unit/test_claude_code_e2e.py
@@ -24,7 +24,8 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-HOOK_PATH = REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain"
+HOOK_PATH = (REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain-rs"
+             / "target" / "release" / "evo-hook-drain")
 EVO_DRAIN = shutil.which("evo-drain")
 
 

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -43,12 +43,18 @@ class _Base(unittest.TestCase):
         self.cfg_path = self.codex_home / "config.toml"
         self._prev_codex_home = os.environ.get("CODEX_HOME")
         os.environ["CODEX_HOME"] = str(self.codex_home)
+        self._prev_evo_home = os.environ.get("EVO_HOME")
+        os.environ["EVO_HOME"] = str(Path(self._tmp.name) / ".evo")
 
     def tearDown(self):
         if self._prev_codex_home is None:
             os.environ.pop("CODEX_HOME", None)
         else:
             os.environ["CODEX_HOME"] = self._prev_codex_home
+        if self._prev_evo_home is None:
+            os.environ.pop("EVO_HOME", None)
+        else:
+            os.environ["EVO_HOME"] = self._prev_evo_home
         self._tmp.cleanup()
 
     def _write_config(self, body: str) -> None:
@@ -296,7 +302,9 @@ class TestDoctorHookBinary(_Base):
         b = (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
              / version / "bin" / "evo-hook-drain")
         b.parent.mkdir(parents=True, exist_ok=True)
-        b.write_text("#!/bin/sh\n")
+        # Non-script bytes: doctor treats a "#!" file as the committed
+        # fallback wrapper and then also requires the stable copy.
+        b.write_bytes(b"\x7fELF-fake\n")
         os.chmod(b, 0o755)
 
     def _run_doctor(self) -> int:

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -299,8 +299,9 @@ class TestDoctorHookBinary(_Base):
         (self.codex_home / ".tmp" / "marketplaces" / "evo-hq").mkdir(parents=True)
 
     def _stage_binary(self, version: str) -> None:
+        name = "evo-hook-drain.exe" if sys.platform == "win32" else "evo-hook-drain"
         b = (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
-             / version / "bin" / "evo-hook-drain")
+             / version / "bin" / name)
         b.parent.mkdir(parents=True, exist_ok=True)
         # Non-script bytes: doctor treats a "#!" file as the committed
         # fallback wrapper and then also requires the stable copy.

--- a/tests/unit/test_directive_delivery_e2e.py
+++ b/tests/unit/test_directive_delivery_e2e.py
@@ -29,7 +29,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
 
 HOOK_NAME = "evo-hook-drain.exe" if sys.platform == "win32" else "evo-hook-drain"
-HOOK_PATH = REPO_ROOT / "plugins" / "evo" / "bin" / HOOK_NAME
+HOOK_PATH = (REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain-rs"
+             / "target" / "release" / HOOK_NAME)
 
 
 def _init_workspace(root: Path) -> str:

--- a/tests/unit/test_hook_drain.py
+++ b/tests/unit/test_hook_drain.py
@@ -9,11 +9,11 @@ Covers:
   - SessionStart drift warning when cache version != marketplace clone version
   - SessionStart proactive warning when evo-drain not on PATH
 
-The Rust source lives at plugins/evo/bin/evo-hook-drain-rs/. Tests
-require the release binary built into the plugin bin/ via `cargo build
---release` + a copy step (CI does this in ci.yml `unit-tests` job;
-locally run `cargo build --release` inside the Rust crate then copy the
-binary to plugins/evo/bin/).
+The Rust source lives at plugins/evo/bin/evo-hook-drain-rs/. Tests exec
+the release binary straight from the cargo target dir (CI builds it in
+ci.yml's `unit-tests` job; locally run `cargo build --release` inside
+the Rust crate). plugins/evo/bin/evo-hook-drain is the committed
+shell-script fallback, not the binary.
 """
 
 from __future__ import annotations
@@ -30,7 +30,8 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 HOOK_NAME = "evo-hook-drain.exe" if sys.platform == "win32" else "evo-hook-drain"
-HOOK_PATH = REPO_ROOT / "plugins" / "evo" / "bin" / HOOK_NAME
+HOOK_PATH = (REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain-rs"
+             / "target" / "release" / HOOK_NAME)
 PAYLOAD_PRETOOL = b'{"session_id":"test-sid","hook_event_name":"PreToolUse"}'
 PAYLOAD_SESSION_START = b'{"session_id":"test-sid","hook_event_name":"SessionStart"}'
 

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -5,7 +5,7 @@ codex does it on its own when the snapshot changes; claude-code on
 `claude plugin update`. The snapshot is a git tree without the binary
 (release assets aren't committed), so before the mirror fix a re-stage
 silently dropped `bin/evo-hook-drain` from the cache and every hook
-fired exit 127 — with `evo doctor` passing right up until the re-stage.
+fired exit 127, with `evo doctor` passing right up until the re-stage.
 
 The fix: installers mirror the fetched binary into the snapshot, so a
 re-stage carries it. These tests run the real installer file-copy paths
@@ -31,10 +31,12 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
 from evo.host_install import claude_code, codex  # noqa: E402
 from evo.host_install._hook_drain import (  # noqa: E402
     hook_drain_binary_name,
+    is_wrapper_script,
     mirror_hook_drain_binary,
 )
 
 HOOK_NAME = hook_drain_binary_name()
+REPO_WRAPPER = REPO_ROOT / "plugins" / "evo" / "bin" / "evo-hook-drain"
 
 
 class _SandboxBase(unittest.TestCase):
@@ -43,14 +45,18 @@ class _SandboxBase(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
         self.root = Path(self._tmp.name)
+        # Non-script bytes: the staging code distinguishes the committed
+        # shell wrapper (starts with "#!") from a native binary.
         fake_binary = self.root / "fake-evo-hook-drain"
-        fake_binary.write_text("#!/bin/sh\necho '{}'\n")
+        fake_binary.write_bytes(b"\x7fELF-fake-evo-hook-drain\n")
         fake_binary.chmod(0o755)
         self._saved_env = {
             k: os.environ.get(k)
-            for k in ("EVO_HOOK_DRAIN_BINARY", "CODEX_HOME", "CLAUDE_CONFIG_DIR")
+            for k in ("EVO_HOOK_DRAIN_BINARY", "CODEX_HOME",
+                      "CLAUDE_CONFIG_DIR", "EVO_HOME")
         }
         os.environ["EVO_HOOK_DRAIN_BINARY"] = str(fake_binary)
+        os.environ["EVO_HOME"] = str(self.root / ".evo")
 
     def tearDown(self):
         for k, v in self._saved_env.items():
@@ -81,9 +87,30 @@ class _CodexSandbox(_SandboxBase):
         )
         (plugin / "bin").mkdir()
         (plugin / "bin" / "evo").write_text("#!/bin/sh\n")
+        (plugin / "hooks").mkdir()
+        (plugin / "hooks" / "hooks.json").write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": ".*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain",
+                    }],
+                }],
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain",
+                    }],
+                }],
+            }
+        }))
         (self.codex_home / "config.toml").write_text(
             "[features]\nplugin_hooks = true\n"
         )
+
+    def _config(self) -> str:
+        return (self.codex_home / "config.toml").read_text()
 
     def _cache_plugin_dir(self) -> Path:
         return self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" / "9.9.9"
@@ -122,18 +149,170 @@ class TestCodexRestageSurvival(_CodexSandbox):
 
         self.assertEqual(codex._install_via_filecopy(None), 0)
         (self.snapshot / "plugins" / "evo" / "bin" / HOOK_NAME).unlink()
-        # Plugin entry so doctor proceeds past the config checks.
-        cfg = self.codex_home / "config.toml"
-        cfg.write_text(
-            cfg.read_text() + '\n[plugins."evo@evo-hq"]\nenabled = true\n'
-        )
         out = io.StringIO()
         with contextlib.redirect_stdout(out):
             rc = codex.doctor(argparse.Namespace())
         self.assertIn("not mirrored in the marketplace snapshot", out.getvalue())
-        # Latent issue only — doctor must still pass so `evo update`
+        # Latent issue only: doctor must still pass so `evo update`
         # (which skips unhealthy hosts) can re-mirror it.
         self.assertEqual(rc, 0)
+
+
+class TestWrapperFallback(_SandboxBase):
+    """The committed bin/evo-hook-drain wrapper keeps hooks working when
+    a host re-stage replaces the staged binary with the git tree's
+    contents."""
+
+    @unittest.skipIf(sys.platform == "win32", "sh wrapper is posix-only")
+    def test_wrapper_execs_stable_copy(self):
+        import subprocess
+        stable = self.root / ".evo" / "bin" / "evo-hook-drain"
+        stable.parent.mkdir(parents=True)
+        stable.write_text("#!/bin/sh\necho from-stable\n")
+        stable.chmod(0o755)
+        r = subprocess.run(
+            [str(REPO_WRAPPER)], input=b"{}", capture_output=True,
+            env=os.environ.copy(), timeout=10,
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), b"from-stable")
+
+    @unittest.skipIf(sys.platform == "win32", "sh wrapper is posix-only")
+    def test_wrapper_noops_with_hint_when_stable_missing(self):
+        import subprocess
+        r = subprocess.run(
+            [str(REPO_WRAPPER)], input=b"{}", capture_output=True,
+            env=os.environ.copy(), timeout=10,
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), b"{}")
+        self.assertIn(b"binary not staged", r.stderr)
+
+
+class TestWrapperPreservation(_CodexSandbox):
+    """Snapshot refreshes restore the tracked wrapper; installs and
+    doctor must treat it as a working entry point."""
+
+    def _snapshot_hook(self) -> Path:
+        return self.snapshot / "plugins" / "evo" / "bin" / "evo-hook-drain"
+
+    def test_restage_after_snapshot_refresh_keeps_working_entry(self):
+        shutil.copy2(REPO_WRAPPER, self._snapshot_hook())
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        cache_hook = self._cache_plugin_dir() / "bin" / HOOK_NAME
+        # Install replaces the wrapper with the native binary in the cache.
+        self.assertFalse(is_wrapper_script(cache_hook))
+        # Codex refreshes the snapshot from git (tracked wrapper restored,
+        # mirrored binary gone), then re-stages the cache from it.
+        shutil.copy2(REPO_WRAPPER, self._snapshot_hook())
+        shutil.rmtree(self._cache_plugin_dir())
+        shutil.copytree(
+            self.snapshot / "plugins" / "evo", self._cache_plugin_dir()
+        )
+        self.assertTrue(is_wrapper_script(cache_hook))
+        self.assertTrue(os.access(cache_hook, os.X_OK))
+        # Stable copy still exists, so doctor accepts the wrapper.
+        import argparse
+        import contextlib
+        import io
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = codex.doctor(argparse.Namespace())
+        self.assertEqual(rc, 0)
+        self.assertIn("fallback wrapper", out.getvalue())
+
+    def test_doctor_fails_when_wrapper_has_no_stable_copy(self):
+        shutil.copy2(REPO_WRAPPER, self._snapshot_hook())
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        # Re-stage from a refreshed snapshot, then lose the stable copy.
+        shutil.copy2(REPO_WRAPPER, self._snapshot_hook())
+        shutil.rmtree(self._cache_plugin_dir())
+        shutil.copytree(
+            self.snapshot / "plugins" / "evo", self._cache_plugin_dir()
+        )
+        shutil.rmtree(self.root / ".evo")
+        import argparse
+        import contextlib
+        import io
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = codex.doctor(argparse.Namespace())
+        self.assertEqual(rc, 1)
+        self.assertIn("no stable binary", out.getvalue())
+
+    def test_from_path_install_keeps_wrapper_in_source_tree(self):
+        shutil.copy2(REPO_WRAPPER, self._snapshot_hook())
+        self.assertEqual(
+            codex._install_via_filecopy(str(self.snapshot)), 0
+        )
+        # The "source tree" (from_path) keeps its tracked wrapper; only
+        # the evo-managed cache gets the native binary.
+        self.assertTrue(is_wrapper_script(self._snapshot_hook()))
+        self.assertFalse(
+            is_wrapper_script(self._cache_plugin_dir() / "bin" / HOOK_NAME)
+        )
+
+
+class TestCodexTrustHooks(_CodexSandbox):
+    """Hooks are trusted by default at install; --no-trust-hooks defers
+    to codex's `/hooks` review; doctor verifies the trust state."""
+
+    def _doctor(self) -> tuple[int, str]:
+        import argparse
+        import contextlib
+        import io
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = codex.doctor(argparse.Namespace())
+        return rc, out.getvalue()
+
+    def test_install_trusts_hooks_by_default(self):
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        cfg = self._config()
+        self.assertIn(
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:pre_tool_use:0:0"]', cfg
+        )
+        self.assertIn(
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:session_start:0:0"]', cfg
+        )
+
+    def test_no_trust_hooks_leaves_untrusted(self):
+        self.assertEqual(
+            codex._install_via_filecopy(None, trust_hooks=False), 0
+        )
+        self.assertNotIn("[hooks.state.", self._config())
+
+    def test_doctor_passes_when_trusted(self):
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        rc, out = self._doctor()
+        self.assertEqual(rc, 0)
+        self.assertIn("2 hooks trusted for evo@evo-hq", out)
+
+    def test_doctor_warns_when_untrusted(self):
+        """Deliberate --no-trust-hooks installs await the user's /hooks
+        review; doctor surfaces it without failing."""
+        self.assertEqual(
+            codex._install_via_filecopy(None, trust_hooks=False), 0
+        )
+        rc, out = self._doctor()
+        self.assertEqual(rc, 0)
+        self.assertIn("untrusted for evo@evo-hq", out)
+
+    def test_doctor_fails_on_stale_trust(self):
+        """hooks.json changed after trust was written: hashes no longer
+        match, the hooks silently never fire, doctor must fail."""
+        import re
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        cfg_path = self.codex_home / "config.toml"
+        cfg_path.write_text(re.sub(
+            r'trusted_hash = "sha256:[a-f0-9]{8}',
+            'trusted_hash = "sha256:00000000',
+            cfg_path.read_text(),
+            count=1,
+        ))
+        rc, out = self._doctor()
+        self.assertEqual(rc, 1)
+        self.assertIn("hook trust is stale", out)
 
 
 class TestInstallRunsDoctor(_CodexSandbox):

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -1,0 +1,206 @@
+"""Hook-drain binary must survive a host plugin re-stage.
+
+Hosts re-stage the plugin cache by copying the marketplace snapshot:
+codex does it on its own when the snapshot changes; claude-code on
+`claude plugin update`. The snapshot is a git tree without the binary
+(release assets aren't committed), so before the mirror fix a re-stage
+silently dropped `bin/evo-hook-drain` from the cache and every hook
+fired exit 127 — with `evo doctor` passing right up until the re-stage.
+
+The fix: installers mirror the fetched binary into the snapshot, so a
+re-stage carries it. These tests run the real installer file-copy paths
+in sandboxed CODEX_HOME / CLAUDE_CONFIG_DIR roots, with
+EVO_HOOK_DRAIN_BINARY pointing at a local file (the documented bypass
+for the GitHub release fetch), then simulate the host's re-stage and
+assert the binary is still there.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.host_install import claude_code, codex  # noqa: E402
+from evo.host_install._hook_drain import (  # noqa: E402
+    hook_drain_binary_name,
+    mirror_hook_drain_binary,
+)
+
+HOOK_NAME = hook_drain_binary_name()
+
+
+class _SandboxBase(unittest.TestCase):
+    """Temp home + EVO_HOOK_DRAIN_BINARY pointing at a fake binary."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        fake_binary = self.root / "fake-evo-hook-drain"
+        fake_binary.write_text("#!/bin/sh\necho '{}'\n")
+        fake_binary.chmod(0o755)
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("EVO_HOOK_DRAIN_BINARY", "CODEX_HOME", "CLAUDE_CONFIG_DIR")
+        }
+        os.environ["EVO_HOOK_DRAIN_BINARY"] = str(fake_binary)
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self._tmp.cleanup()
+
+
+class TestCodexRestageSurvival(_SandboxBase):
+
+    def setUp(self):
+        super().setUp()
+        self.codex_home = self.root / ".codex"
+        os.environ["CODEX_HOME"] = str(self.codex_home)
+        # Minimal marketplace snapshot, as `codex plugin marketplace add`
+        # leaves it: git tree contents, no binary in bin/.
+        self.snapshot = self.codex_home / ".tmp" / "marketplaces" / "evo-hq"
+        plugin = self.snapshot / "plugins" / "evo"
+        (self.snapshot / ".claude-plugin").mkdir(parents=True)
+        (self.snapshot / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps({"name": "evo-hq-evo", "owner": {"name": "evo-hq"}})
+        )
+        (plugin / ".codex-plugin").mkdir(parents=True)
+        (plugin / ".codex-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "evo", "version": "9.9.9"})
+        )
+        (plugin / "bin").mkdir()
+        (plugin / "bin" / "evo").write_text("#!/bin/sh\n")
+        (self.codex_home / "config.toml").write_text(
+            "[features]\nplugin_hooks = true\n"
+        )
+
+    def _cache_plugin_dir(self) -> Path:
+        return self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" / "9.9.9"
+
+    def test_install_stages_binary_into_cache_and_snapshot(self):
+        rc = codex._install_via_filecopy(None)
+        self.assertEqual(rc, 0)
+        self.assertTrue((self._cache_plugin_dir() / "bin" / HOOK_NAME).exists())
+        self.assertTrue(
+            (self.snapshot / "plugins" / "evo" / "bin" / HOOK_NAME).exists()
+        )
+
+    def test_binary_survives_codex_restage(self):
+        """The regression: codex wipes the cache dir and re-copies the
+        snapshot. With the binary mirrored into the snapshot, the
+        re-staged cache still has it."""
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        cache_dir = self._cache_plugin_dir()
+        shutil.rmtree(cache_dir)
+        shutil.copytree(self.snapshot / "plugins" / "evo", cache_dir)
+        restaged = cache_dir / "bin" / HOOK_NAME
+        self.assertTrue(
+            restaged.exists(),
+            "codex re-stage from the snapshot dropped evo-hook-drain "
+            "(hooks would exit 127)",
+        )
+        self.assertTrue(os.access(restaged, os.X_OK))
+
+    def test_doctor_warns_when_snapshot_binary_missing(self):
+        import argparse
+        import contextlib
+        import io
+
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        (self.snapshot / "plugins" / "evo" / "bin" / HOOK_NAME).unlink()
+        # Plugin entry so doctor proceeds past the config checks.
+        cfg = self.codex_home / "config.toml"
+        cfg.write_text(
+            cfg.read_text() + '\n[plugins."evo@evo-hq"]\nenabled = true\n'
+        )
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = codex.doctor(argparse.Namespace())
+        self.assertIn("not mirrored in the marketplace snapshot", out.getvalue())
+        # Latent issue only — doctor must still pass so `evo update`
+        # (which skips unhealthy hosts) can re-mirror it.
+        self.assertEqual(rc, 0)
+
+
+class TestClaudeCodeCloneMirror(_SandboxBase):
+
+    def setUp(self):
+        super().setUp()
+        self.claude_home = self.root / ".claude"
+        os.environ["CLAUDE_CONFIG_DIR"] = str(self.claude_home)
+        self.cache_plugin = (
+            self.claude_home / "plugins" / "cache" / "evo-hq-evo" / "evo" / "9.9.9"
+        )
+        (self.cache_plugin / "bin").mkdir(parents=True)
+        self.clone_plugin = (
+            self.claude_home / "plugins" / "marketplaces" / "evo-hq-evo"
+            / "plugins" / "evo"
+        )
+        (self.clone_plugin / "bin").mkdir(parents=True)
+
+    def test_stage_mirrors_into_marketplace_clone(self):
+        claude_code._stage_hook_drain(None)
+        self.assertTrue((self.cache_plugin / "bin" / HOOK_NAME).exists())
+        self.assertTrue((self.clone_plugin / "bin" / HOOK_NAME).exists())
+
+    def test_binary_survives_claude_plugin_update_restage(self):
+        """`claude plugin update` re-copies the clone over the cache."""
+        claude_code._stage_hook_drain(None)
+        shutil.rmtree(self.cache_plugin)
+        shutil.copytree(self.clone_plugin, self.cache_plugin)
+        self.assertTrue(
+            (self.cache_plugin / "bin" / HOOK_NAME).exists(),
+            "claude plugin update re-stage dropped evo-hook-drain",
+        )
+
+    def test_from_path_does_not_touch_clone(self):
+        src_tree = self.root / "src-marketplace"
+        (src_tree / "plugins" / "evo" / "bin").mkdir(parents=True)
+        claude_code._stage_hook_drain(str(src_tree))
+        self.assertTrue(
+            (src_tree / "plugins" / "evo" / "bin" / HOOK_NAME).exists()
+        )
+        self.assertFalse((self.clone_plugin / "bin" / HOOK_NAME).exists())
+
+
+class TestMirrorHelper(_SandboxBase):
+
+    def test_missing_source_returns_false(self):
+        src = self.root / "a"
+        dst = self.root / "b"
+        (src / "bin").mkdir(parents=True)
+        self.assertFalse(mirror_hook_drain_binary(src, dst))
+
+    def test_same_dir_is_noop_true(self):
+        src = self.root / "a"
+        (src / "bin").mkdir(parents=True)
+        binary = src / "bin" / HOOK_NAME
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        self.assertTrue(mirror_hook_drain_binary(src, src))
+
+    def test_copies_and_marks_executable(self):
+        src = self.root / "a"
+        dst = self.root / "b"
+        (src / "bin").mkdir(parents=True)
+        (src / "bin" / HOOK_NAME).write_text("#!/bin/sh\necho hi\n")
+        self.assertTrue(mirror_hook_drain_binary(src, dst))
+        out = dst / "bin" / HOOK_NAME
+        self.assertTrue(out.exists())
+        if sys.platform != "win32":
+            self.assertTrue(os.access(out, os.X_OK))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -189,6 +189,7 @@ class TestWrapperFallback(_SandboxBase):
         self.assertIn(b"binary not staged", r.stderr)
 
 
+@unittest.skipIf(sys.platform == "win32", "sh wrapper is posix-only")
 class TestWrapperPreservation(_CodexSandbox):
     """Snapshot refreshes restore the tracked wrapper; installs and
     doctor must treat it as a working entry point."""
@@ -318,6 +319,26 @@ class TestCodexTrustHooks(_CodexSandbox):
 class TestInstallRunsDoctor(_CodexSandbox):
     """`evo install <host>` finishes with the host's doctor so a broken
     install is visible immediately instead of at hook-fire time."""
+
+    def setUp(self):
+        super().setUp()
+        # codex.install gates on `codex` being on PATH but never invokes
+        # it for --from-path installs (marketplace add is skipped). CI
+        # runners have no codex CLI; satisfy the gate with a stub.
+        fake_bin = self.root / "fake-path-bin"
+        fake_bin.mkdir()
+        if sys.platform == "win32":
+            (fake_bin / "codex.cmd").write_text("@echo off\r\nexit /b 0\r\n")
+        else:
+            stub = fake_bin / "codex"
+            stub.write_text("#!/bin/sh\nexit 0\n")
+            stub.chmod(0o755)
+        self._saved_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}{os.pathsep}{self._saved_path}"
+
+    def tearDown(self):
+        os.environ["PATH"] = self._saved_path
+        super().tearDown()
 
     def test_install_runs_doctor_and_returns_its_rc(self):
         import argparse

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -61,7 +61,7 @@ class _SandboxBase(unittest.TestCase):
         self._tmp.cleanup()
 
 
-class TestCodexRestageSurvival(_SandboxBase):
+class _CodexSandbox(_SandboxBase):
 
     def setUp(self):
         super().setUp()
@@ -87,6 +87,9 @@ class TestCodexRestageSurvival(_SandboxBase):
 
     def _cache_plugin_dir(self) -> Path:
         return self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" / "9.9.9"
+
+
+class TestCodexRestageSurvival(_CodexSandbox):
 
     def test_install_stages_binary_into_cache_and_snapshot(self):
         rc = codex._install_via_filecopy(None)
@@ -131,6 +134,31 @@ class TestCodexRestageSurvival(_SandboxBase):
         # Latent issue only — doctor must still pass so `evo update`
         # (which skips unhealthy hosts) can re-mirror it.
         self.assertEqual(rc, 0)
+
+
+class TestInstallRunsDoctor(_CodexSandbox):
+    """`evo install <host>` finishes with the host's doctor so a broken
+    install is visible immediately instead of at hook-fire time."""
+
+    def test_install_runs_doctor_and_returns_its_rc(self):
+        import argparse
+        import contextlib
+        import io
+
+        from evo import host_install
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = host_install.install(
+                "codex",
+                argparse.Namespace(
+                    from_path=str(self.snapshot), trust_hooks=True
+                ),
+            )
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("verifying: evo doctor codex", text)
+        self.assertIn("evo-hook-drain present + executable", text)
 
 
 class TestClaudeCodeCloneMirror(_SandboxBase):

--- a/tests/unit/test_subagent_identity.py
+++ b/tests/unit/test_subagent_identity.py
@@ -166,12 +166,13 @@ class CodexHotPathSubagentIdentityTests(unittest.TestCase):
         from evo.core import workspace_path
         self.run_dir = workspace_path(self.root)
         bin_name = "evo-hook-drain.exe" if sys.platform == "win32" else "evo-hook-drain"
-        self.script = REPO_ROOT / "plugins" / "evo" / "bin" / bin_name
+        self.script = (REPO_ROOT / "plugins" / "evo" / "bin"
+                       / "evo-hook-drain-rs" / "target" / "release" / bin_name)
         # The conftest-level fixture in test_hook_drain ensures the binary
         # is built; this assertion catches the case where test_subagent_identity
         # runs in isolation without that fixture firing.
         assert self.script.exists(), (
-            f"hook binary not staged: {self.script}. "
+            f"hook binary not built: {self.script}. "
             f"Run `cargo build --release` in plugins/evo/bin/evo-hook-drain-rs/."
         )
 


### PR DESCRIPTION
Fixes hook exit-127 after a host plugin re-stage, where `bin/evo-hook-drain` is fetched from GitHub releases into the staged plugin cache only. Codex re-stages the cache from its marketplace snapshot when the snapshot changes; Claude Code re-copies the marketplace clone on `claude plugin update`. Both sources are git trees without the binary, so a re-stage dropped it and every hook fired exit 127, with `evo doctor` passing until the re-stage.

- `mirror_hook_drain_binary` copies the fetched binary between plugin roots. The codex installer mirrors it into the marketplace snapshot; claude-code staging mirrors into the marketplace clone for cache-backed installs.
- `evo doctor codex` / `evo doctor claude-code` warn when the snapshot copy is missing. Warning only, no rc bump: `evo update` skips hosts whose doctor fails, and update is what re-mirrors the binary.
- Regression tests simulate the host re-stage in sandboxed `CODEX_HOME` / `CLAUDE_CONFIG_DIR` roots (`tests/unit/test_hook_drain_restage.py`).
- README troubleshooting: the exit-127 section now covers both known causes (0.4.5 staging-name bug, re-stage wipe).

`hooks.json` is unchanged, so existing trusted-hook hashes stay valid. Already-broken installs repair with `uv tool install --force evo-hq-cli && evo install <host> --force`.

Version bumped to 0.5.1 via `bump-version.py`.