### PR TITLE
ci: disable the post-release live smoke job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,9 +285,12 @@ jobs:
     # uploaded assets — those land in github-release's last step. Without
     # this dependency the smoke would race and fetch from a release that
     # exists (artifact metadata) but has no binary attached yet, 404ing.
-    if: |
-      startsWith(github.ref, 'refs/tags/v') ||
-      startsWith(github.ref, 'refs/tags/cli-v')
+    #
+    # DISABLED: kept publish runs alive for ~35 min per release (v0.5.1's
+    # run was cancelled mid-smoke). Re-enable by restoring the condition:
+    #   startsWith(github.ref, 'refs/tags/v') ||
+    #   startsWith(github.ref, 'refs/tags/cli-v')
+    if: false
     needs: [publish-cli, github-release]
     runs-on: ubuntu-latest
     # Each host run can take 5-10 min (codex slow, opencode + openclaw


### PR DESCRIPTION
release-smoke keeps the publish run alive for up to 30 minutes per
release (v0.5.1's run was cancelled mid-smoke at ~35 min). The job is
reactive, not gating, so disabling it does not affect publishing.
Condition preserved in a comment for re-enabling.
