### PR TITLE
fix(deps): upgrade urllib3 to 2.7.0 (CVE-2026-44431)

### DIFF
--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
@@ -2489,11 +2489,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades urllib3 2.6.3 -> 2.7.0 in plugins/evo/uv.lock to address CVE-2026-44431 (sensitive headers forwarded on cross-origin redirects).

Regenerated with `uv lock --upgrade-package urllib3`. Also syncs the lockfile's stale evo-hq-cli self-version (0.5.1 -> 0.5.2) left behind by the 0.5.2 release bump. Supersedes #72, which regenerated the full lockfile (1,730 lines) for the same bump.