### PR TITLE
Fix Codex hook paths for 0.6.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/evo-hq/evo"
 url: "https://github.com/evo-hq/evo"
 license: Apache-2.0
-version: 0.6.1
+version: 0.6.1-alpha.1
 date-released: 2026-06-19
 keywords:
   - autoresearch

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/evo-hq/evo"
 url: "https://github.com/evo-hq/evo"
 license: Apache-2.0
-version: 0.6.1-alpha.2
+version: 0.6.1
 date-released: 2026-06-19
 keywords:
   - autoresearch

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
 repository-code: "https://github.com/evo-hq/evo"
 url: "https://github.com/evo-hq/evo"
 license: Apache-2.0
-version: 0.6.0
-date-released: 2026-06-18
+version: 0.6.1
+date-released: 2026-06-19
 keywords:
   - autoresearch
   - code-optimization

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/evo-hq/evo"
 url: "https://github.com/evo-hq/evo"
 license: Apache-2.0
-version: 0.6.1-alpha.1
+version: 0.6.1-alpha.2
 date-released: 2026-06-19
 keywords:
   - autoresearch

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.6.1",
+  "version": "0.6.1-alpha.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.6.1-alpha.1",
+  "version": "0.6.1-alpha.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.6.1-alpha.2",
+  "version": "0.6.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.6.1-alpha.2",
+  "version": "0.6.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.6.1",
+  "version": "0.6.1-alpha.1",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.6.1-alpha.1",
+  "version": "0.6.1-alpha.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.6.1",
+  "version": "0.6.1-alpha.1",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.6.1-alpha.1",
+  "version": "0.6.1-alpha.2",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.6.1-alpha.2",
+  "version": "0.6.1",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1-alpha.2
+evo-hq-cli 0.6.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.2`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1-alpha.2
+   > uv tool install --force evo-hq-cli==0.6.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.2` (or `pipx install evo-hq-cli==0.6.1-alpha.2`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1
+evo-hq-cli 0.6.1-alpha.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1
+   > uv tool install --force evo-hq-cli==0.6.1-alpha.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.1` (or `pipx install evo-hq-cli==0.6.1-alpha.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.0
+evo-hq-cli 0.6.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.0`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.0
+   > uv tool install --force evo-hq-cli==0.6.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.0` (or `pipx install evo-hq-cli==0.6.0`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1-alpha.1
+evo-hq-cli 0.6.1-alpha.2
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.2`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1-alpha.1
+   > uv tool install --force evo-hq-cli==0.6.1-alpha.2
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.1` (or `pipx install evo-hq-cli==0.6.1-alpha.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.2` (or `pipx install evo-hq-cli==0.6.1-alpha.2`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Report

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Report

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Report

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Report

--- a/plugins/evo/npm/skills/ship/SKILL.md
+++ b/plugins/evo/npm/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Ship

--- a/plugins/evo/npm/skills/ship/SKILL.md
+++ b/plugins/evo/npm/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Ship

--- a/plugins/evo/npm/skills/ship/SKILL.md
+++ b/plugins/evo/npm/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Ship

--- a/plugins/evo/npm/skills/ship/SKILL.md
+++ b/plugins/evo/npm/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Ship

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.6.1"
+version = "0.6.1-alpha.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.6.1-alpha.2"
+version = "0.6.1"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.6.1-alpha.1"
+version = "0.6.1-alpha.2"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1-alpha.2
+evo-hq-cli 0.6.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.2`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1-alpha.2
+   > uv tool install --force evo-hq-cli==0.6.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.2` (or `pipx install evo-hq-cli==0.6.1-alpha.2`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1
+evo-hq-cli 0.6.1-alpha.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1
+   > uv tool install --force evo-hq-cli==0.6.1-alpha.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.1` (or `pipx install evo-hq-cli==0.6.1-alpha.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.0
+evo-hq-cli 0.6.1
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.0`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.0
+   > uv tool install --force evo-hq-cli==0.6.1
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.0` (or `pipx install evo-hq-cli==0.6.0`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1-alpha.1
+evo-hq-cli 0.6.1-alpha.2
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.1-alpha.2`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1-alpha.1
+   > uv tool install --force evo-hq-cli==0.6.1-alpha.2
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.1` (or `pipx install evo-hq-cli==0.6.1-alpha.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1-alpha.2` (or `pipx install evo-hq-cli==0.6.1-alpha.2`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Finetuning

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Finetuning

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Finetuning

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Finetuning

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Report

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Report

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Report

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Report

--- a/plugins/evo/skills/ship/SKILL.md
+++ b/plugins/evo/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Ship

--- a/plugins/evo/skills/ship/SKILL.md
+++ b/plugins/evo/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Ship

--- a/plugins/evo/skills/ship/SKILL.md
+++ b/plugins/evo/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Ship

--- a/plugins/evo/skills/ship/SKILL.md
+++ b/plugins/evo/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Ship

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1
+evo_version: 0.6.1-alpha.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1-alpha.2
+evo_version: 0.6.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1-alpha.1
+evo_version: 0.6.1-alpha.2
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.0
+evo_version: 0.6.1
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.6.1"
+__version__ = "0.6.1-alpha.1"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.6.1-alpha.2"
+__version__ = "0.6.1"

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.6.1-alpha.1"
+__version__ = "0.6.1-alpha.2"

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -109,6 +109,16 @@ def _marketplace_cache() -> Path:
     return _codex_base() / ".tmp" / "marketplaces" / "evo-hq"
 
 
+def _marketplace_plugin_version(mkt_root: Path) -> str | None:
+    manifest = mkt_root / "plugins" / "evo" / ".codex-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = data.get("version")
+    return str(version) if version else None
+
+
 def _toggle_plugin_hooks(enable: bool) -> tuple[bool, Path]:
     cfg = _codex_base() / "config.toml"
     if not cfg.exists():
@@ -200,13 +210,14 @@ def install(args: argparse.Namespace) -> int:
     mkt_cache = _marketplace_cache()
     if from_path:
         pass
-    elif mkt_cache.exists() and not force:
+    elif mkt_cache.exists() and not force and not getattr(args, "version", None):
         print(
             f"codex marketplace cache already at {mkt_cache}; "
             "skipping `codex plugin marketplace add` prereq (use --force to refresh)"
         )
     else:
         import subprocess as _sp
+        import sys as _sys
         version = getattr(args, "version", None)
         source = "evo-hq/evo"
         if version:
@@ -215,7 +226,28 @@ def install(args: argparse.Namespace) -> int:
             source = f"{source}@{ref}"
         mkt_cmd = ["codex", "plugin", "marketplace", "add", source]
         print(f"$ {' '.join(mkt_cmd)}")
-        _sp.call(mkt_cmd)
+        rc = _sp.call(mkt_cmd)
+        if rc != 0 and (force or version):
+            rm_cmd = ["codex", "plugin", "marketplace", "remove", "evo-hq"]
+            print(f"$ {' '.join(rm_cmd)}")
+            _sp.call(rm_cmd)
+            print(f"$ {' '.join(mkt_cmd)}")
+            rc = _sp.call(mkt_cmd)
+        if rc != 0:
+            print(
+                f"ERROR: failed to add Codex marketplace source {source!r}",
+                file=_sys.stderr,
+            )
+            return 2
+        if version:
+            actual = _marketplace_plugin_version(mkt_cache)
+            if actual != version:
+                print(
+                    "ERROR: Codex marketplace snapshot version mismatch: "
+                    f"expected {version}, found {actual or 'unknown'} at {mkt_cache}",
+                    file=_sys.stderr,
+                )
+                return 2
 
     # Ensure config.toml exists. On freshly-npm-installed codex (never run
     # interactively), the marketplace add above creates ~/.codex/ but may

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -5,7 +5,11 @@ done by adding a `[plugins."<name>@<marketplace>"]` section."""
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import platform
+import shlex
+import subprocess
 from pathlib import Path
 
 from ._hook_drain import (
@@ -26,6 +30,74 @@ not already done). This command:
   - adds [plugins."evo@evo-hq"]          (enables the plugin)
 in ~/.codex/config.toml.
 """
+
+
+def _command_quote(path: Path) -> str:
+    """Return a shell-safe command token for an absolute executable path."""
+    text = str(path)
+    if platform.system().lower() == "windows":
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
+def _stable_hook_command() -> str:
+    """Codex-safe hook command.
+
+    Codex does not guarantee Claude Code's `${CLAUDE_PLUGIN_ROOT}` env var.
+    Materialize the user's stable evo hook binary path at install time so
+    Codex hook execution does not depend on plugin-root expansion, cwd, or PATH.
+    """
+    return _command_quote(stable_binary_path().resolve())
+
+
+def _materialize_codex_hooks(hooks_json_path: Path) -> bool:
+    """Rewrite an installed Codex hooks.json to use machine-local commands.
+
+    The source plugin's hooks.json is shared with Claude Code and intentionally
+    keeps `${CLAUDE_PLUGIN_ROOT}`. Codex-installed copies get rewritten because
+    recent Codex versions may run plugin hooks without that variable, turning
+    `${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain` into `/bin/evo-hook-drain`
+    (exit 127).
+    """
+    try:
+        data = json.loads(hooks_json_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    changed = False
+    drain_cmd = _stable_hook_command()
+    hooks = data.get("hooks") or {}
+    for event_name, groups in list(hooks.items()):
+        updated_groups = []
+        for group in groups or []:
+            handlers = []
+            for handler in group.get("hooks", []) or []:
+                if handler.get("type") != "command":
+                    handlers.append(handler)
+                    continue
+                cmd = str(handler.get("command") or "")
+                if "evo-hook-drain" in cmd:
+                    if cmd != drain_cmd:
+                        handler = {**handler, "command": drain_cmd}
+                        changed = True
+                    handlers.append(handler)
+                elif "wait_hint.sh" in cmd:
+                    # Optional UX hint. Keeping a Claude-only path here makes
+                    # Codex emit hook failures, which is worse than omitting it.
+                    changed = True
+                    continue
+                else:
+                    handlers.append(handler)
+            group["hooks"] = handlers
+            if handlers:
+                updated_groups.append(group)
+            else:
+                changed = True
+        hooks[event_name] = updated_groups
+
+    if changed:
+        hooks_json_path.write_text(json.dumps(data, indent=2) + "\n")
+    return changed
 
 
 def _codex_base() -> Path:
@@ -269,12 +341,9 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) ->
                          ".git", ".venv", "__pycache__", "build", "dist",
                          ".pytest_cache", "*.egg-info"))
 
-    # Stage the platform-native evo-hook-drain binary. hooks.json points
-    # at <PLUGIN_ROOT>/bin/evo-hook-drain; without the binary every hook
-    # fire would be a no-op. The cache_dst was just (re)created above
-    # (rmtree if existed) so a fresh fetch is always correct here —
-    # `force=False` (default) avoids re-fetch only when the file is
-    # already at dest, which never happens since we just wiped.
+    # Stage the platform-native evo-hook-drain binary. Codex hook commands
+    # are materialized below to call the stable per-user binary directly,
+    # avoiding host-managed plugin-root env vars.
     ensure_hook_drain_binary(cache_dst)
 
     # Mirror the binary into the marketplace snapshot so codex's next
@@ -286,6 +355,14 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) ->
     # would dirty it.
     if not from_path:
         mirror_hook_drain_binary(cache_dst, plugin_root)
+
+    nested_hooks = cache_dst / "hooks" / "hooks.json"
+    if nested_hooks.exists() and _materialize_codex_hooks(nested_hooks):
+        print(f"updated {nested_hooks}: materialized Codex hook commands")
+    if not from_path:
+        snapshot_hooks = plugin_root / "hooks" / "hooks.json"
+        if snapshot_hooks.exists() and _materialize_codex_hooks(snapshot_hooks):
+            print(f"updated {snapshot_hooks}: materialized Codex hook commands")
 
     # Update config.toml: ensure `[features] plugin_hooks = true`
     # (gates whether codex fires plugin hooks at all) AND
@@ -312,7 +389,6 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) ->
     # registered but won't fire. Two paths to enable:
     #   - Interactive: user opens `codex` → `/hooks` → trusts each
     #   - Headless:    pass `--trust-hooks` to this command
-    nested_hooks = cache_dst / "hooks" / "hooks.json"
     if not nested_hooks.exists():
         print(
             "\n(no hooks/hooks.json in plugin — skill-only install complete)"
@@ -752,6 +828,18 @@ def doctor(args: argparse.Namespace) -> int:
         hooks_json = versions[-1] / "hooks" / "hooks.json"
         if not hooks_json.exists():
             continue
+        try:
+            hooks_text = hooks_json.read_text()
+        except OSError:
+            hooks_text = ""
+        if "CLAUDE_PLUGIN_ROOT" in hooks_text:
+            print(
+                f"✗ Codex hooks still reference CLAUDE_PLUGIN_ROOT in {hooks_json}; "
+                f"recent Codex versions may run them as /bin/evo-hook-drain "
+                f"(exit 127)\n"
+                f"  Run: evo install codex --force"
+            )
+            rc = 1
         expected = _expected_hook_state(hooks_json, f"evo@{mkt_name}")
         if not expected:
             continue

--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.6.0a1"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.6.1",
+  "version": "0.6.1-alpha.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.6.1-alpha.2",
+  "version": "0.6.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.6.1-alpha.1",
+  "version": "0.6.1-alpha.2",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.6.0"
+version = "0.6.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.6.1-alpha.1"
+version = "0.6.1-alpha.2"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.6.1-alpha.2"
+version = "0.6.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.6.1"
+version = "0.6.1-alpha.1"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.6.1-alpha.1"
+__version__ = "0.6.1-alpha.2"

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.6.1-alpha.2"
+__version__ = "0.6.1"

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.6.1"
+__version__ = "0.6.1-alpha.1"

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -308,6 +308,18 @@ class TestDoctorHookBinary(_Base):
         b.write_bytes(b"\x7fELF-fake\n")
         os.chmod(b, 0o755)
 
+    def _stage_hooks(self, version: str, command: str) -> None:
+        hooks = (
+            self.codex_home / "plugins" / "cache" / "evo-hq" / "evo"
+            / version / "hooks" / "hooks.json"
+        )
+        hooks.parent.mkdir(parents=True, exist_ok=True)
+        hooks.write_text(
+            '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":'
+            + repr(command).replace("'", '"')
+            + '}]}]}}\n'
+        )
+
     def _run_doctor(self) -> int:
         import argparse
         import contextlib
@@ -347,6 +359,12 @@ class TestDoctorHookBinary(_Base):
         (self.codex_home / ".tmp" / "marketplaces" / "evo-hq").mkdir(parents=True)
         self._stage_binary("0.4.5")
         self.assertEqual(self._run_doctor(), 0)
+
+    def test_doctor_fails_when_codex_hooks_still_depend_on_claude_plugin_root(self):
+        self._healthy_config()
+        self._stage_binary("0.6.0")
+        self._stage_hooks("0.6.0", "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain")
+        self.assertEqual(self._run_doctor(), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -155,7 +156,9 @@ class TestCodexRestageSurvival(_CodexSandbox):
         stable.write_text("#!/bin/sh\ncat >/dev/null\nprintf '{}'\n")
         stable.chmod(0o755)
 
-        hooks = json.loads((self._cache_plugin_dir() / "hooks" / "hooks.json").read_text())
+        hooks = json.loads(
+            (self._cache_plugin_dir() / "hooks" / "hooks.json").read_text()
+        )
         command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
         env = os.environ.copy()
         env.pop("CLAUDE_PLUGIN_ROOT", None)
@@ -187,6 +190,46 @@ class TestCodexRestageSurvival(_CodexSandbox):
         self.assertTrue(os.access(restaged, os.X_OK))
         text = (cache_dir / "hooks" / "hooks.json").read_text()
         self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_upgrade_repairs_previous_codex_install_after_host_restage(self):
+        """User path: an older evo install is present, Codex re-stages its
+        cache from that old marketplace snapshot, then the new installer
+        must repair both hook commands and the snapshot for future starts."""
+        stale_cache = self._cache_plugin_dir()
+        shutil.copytree(self.snapshot / "plugins" / "evo", stale_cache)
+        self.assertIn(
+            "CLAUDE_PLUGIN_ROOT",
+            (stale_cache / "hooks" / "hooks.json").read_text(),
+        )
+
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        stable = self.root / ".evo" / "bin" / HOOK_NAME
+        stable.write_text("#!/bin/sh\ncat >/dev/null\nprintf '{}'\n")
+        stable.chmod(0o755)
+
+        for hooks_json in (
+            self._cache_plugin_dir() / "hooks" / "hooks.json",
+            self.snapshot / "plugins" / "evo" / "hooks" / "hooks.json",
+        ):
+            text = hooks_json.read_text()
+            self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
+            self.assertNotIn("wait_hint.sh", text)
+
+        hooks = json.loads((self._cache_plugin_dir() / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        result = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"upgrade"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), b"{}")
 
     def test_doctor_warns_when_snapshot_binary_missing(self):
         import argparse

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -247,6 +247,108 @@ class TestCodexRestageSurvival(_CodexSandbox):
         self.assertEqual(rc, 0)
 
 
+class TestCodexMarketplaceRefresh(_CodexSandbox):
+    """Version-pinned Codex installs must refresh the marketplace snapshot.
+
+    Codex rejects `marketplace add evo-hq/evo@new-ref` when `evo-hq` is
+    already registered to another ref. The installer must remove/re-add and
+    must not proceed against the stale snapshot.
+    """
+
+    def _with_fake_codex_on_path(self):
+        fake_bin = self.root / "fake-path-bin"
+        fake_bin.mkdir(exist_ok=True)
+        if sys.platform == "win32":
+            (fake_bin / "codex.cmd").write_text("@echo off\r\nexit /b 0\r\n")
+        else:
+            stub = fake_bin / "codex"
+            stub.write_text("#!/bin/sh\nexit 0\n")
+            stub.chmod(0o755)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}{os.pathsep}{old_path}"
+        return old_path
+
+    def test_version_pin_retries_after_existing_marketplace_source(self):
+        import argparse
+        from unittest import mock
+
+        target = "0.6.1-alpha.2"
+        plugin_json = (
+            self.snapshot / "plugins" / "evo" / ".codex-plugin" / "plugin.json"
+        )
+        plugin_json.write_text(json.dumps({"name": "evo", "version": "0.6.0"}))
+        old_path = self._with_fake_codex_on_path()
+        calls = []
+        add_attempts = 0
+
+        def fake_call(cmd):
+            nonlocal add_attempts
+            calls.append(cmd)
+            if cmd[:4] == ["codex", "plugin", "marketplace", "remove"]:
+                return 0
+            if cmd[:4] == ["codex", "plugin", "marketplace", "add"]:
+                add_attempts += 1
+                if add_attempts == 1:
+                    return 1
+                plugin_json.write_text(json.dumps({"name": "evo", "version": target}))
+                return 0
+            return 0
+
+        try:
+            with mock.patch("subprocess.call", side_effect=fake_call):
+                rc = codex.install(argparse.Namespace(
+                    from_path=None,
+                    trust_hooks=True,
+                    force=False,
+                    version=target,
+                ))
+        finally:
+            os.environ["PATH"] = old_path
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            [c[:4] for c in calls],
+            [
+                ["codex", "plugin", "marketplace", "add"],
+                ["codex", "plugin", "marketplace", "remove"],
+                ["codex", "plugin", "marketplace", "add"],
+            ],
+        )
+        cache_hooks = (
+            self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" /
+            target / "hooks" / "hooks.json"
+        )
+        self.assertTrue(cache_hooks.exists())
+        self.assertNotIn("CLAUDE_PLUGIN_ROOT", cache_hooks.read_text())
+
+    def test_version_pin_fails_closed_when_snapshot_stays_stale(self):
+        import argparse
+        from unittest import mock
+
+        plugin_json = (
+            self.snapshot / "plugins" / "evo" / ".codex-plugin" / "plugin.json"
+        )
+        plugin_json.write_text(json.dumps({"name": "evo", "version": "0.6.0"}))
+        old_path = self._with_fake_codex_on_path()
+
+        try:
+            with mock.patch("subprocess.call", return_value=0):
+                rc = codex.install(argparse.Namespace(
+                    from_path=None,
+                    trust_hooks=True,
+                    force=False,
+                    version="0.6.1-alpha.2",
+                ))
+        finally:
+            os.environ["PATH"] = old_path
+
+        self.assertEqual(rc, 2)
+        self.assertFalse(
+            (self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" /
+             "0.6.0").exists()
+        )
+
+
 class TestWrapperFallback(_SandboxBase):
     """The committed bin/evo-hook-drain wrapper keeps hooks working when
     a host re-stage replaces the staged binary with the git tree's

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -145,7 +145,19 @@ class TestCodexRestageSurvival(_CodexSandbox):
             text = hooks_json.read_text()
             self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
             self.assertNotIn("wait_hint.sh", text)
-            self.assertIn(str(self.root / ".evo" / "bin" / HOOK_NAME), text)
+            data = json.loads(text)
+            commands = [
+                handler["command"]
+                for groups in data["hooks"].values()
+                for group in groups
+                for handler in group.get("hooks", [])
+                if handler.get("type") == "command"
+            ]
+            self.assertTrue(commands)
+            for command in commands:
+                self.assertTrue(
+                    Path(command).samefile(self.root / ".evo" / "bin" / HOOK_NAME)
+                )
 
     @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
     def test_materialized_hook_runs_without_claude_plugin_root(self):

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -103,6 +103,13 @@ class _CodexSandbox(_SandboxBase):
                         "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain",
                     }],
                 }],
+                "PostToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/wait_hint.sh",
+                    }],
+                }],
             }
         }))
         (self.codex_home / "config.toml").write_text(
@@ -126,6 +133,43 @@ class TestCodexRestageSurvival(_CodexSandbox):
             (self.snapshot / "plugins" / "evo" / "bin" / HOOK_NAME).exists()
         )
 
+    def test_install_materializes_codex_hooks_in_cache_and_snapshot(self):
+        rc = codex._install_via_filecopy(None)
+        self.assertEqual(rc, 0)
+
+        for hooks_json in (
+            self._cache_plugin_dir() / "hooks" / "hooks.json",
+            self.snapshot / "plugins" / "evo" / "hooks" / "hooks.json",
+        ):
+            text = hooks_json.read_text()
+            self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
+            self.assertNotIn("wait_hint.sh", text)
+            self.assertIn(str(self.root / ".evo" / "bin" / HOOK_NAME), text)
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_materialized_hook_runs_without_claude_plugin_root(self):
+        import subprocess
+
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        stable = self.root / ".evo" / "bin" / HOOK_NAME
+        stable.write_text("#!/bin/sh\ncat >/dev/null\nprintf '{}'\n")
+        stable.chmod(0o755)
+
+        hooks = json.loads((self._cache_plugin_dir() / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        result = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), b"{}")
+
     def test_binary_survives_codex_restage(self):
         """The regression: codex wipes the cache dir and re-copies the
         snapshot. With the binary mirrored into the snapshot, the
@@ -141,6 +185,8 @@ class TestCodexRestageSurvival(_CodexSandbox):
             "(hooks would exit 127)",
         )
         self.assertTrue(os.access(restaged, os.X_OK))
+        text = (cache_dir / "hooks" / "hooks.json").read_text()
+        self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
 
     def test_doctor_warns_when_snapshot_binary_missing(self):
         import argparse


### PR DESCRIPTION
Patch release for Codex hook startup failures after Codex re-stages plugin hooks.

What changed:

- Materialize Codex-installed hook commands to the user's stable `~/.evo/bin/evo-hook-drain` path instead of relying on `${CLAUDE_PLUGIN_ROOT}`.
- Remove the optional Claude-only `wait_hint.sh` hook from Codex-installed hook files so it cannot fail under Codex.
- Recompute trust hashes from the materialized Codex hook file.
- Make `evo doctor codex` fail if installed Codex hooks still reference `CLAUDE_PLUGIN_ROOT`.
- Bump plugin, SDKs, npm package, skills, and citation metadata to `0.6.1`.

Validation:

- `uv run pytest tests/unit/test_hook_drain_restage.py tests/unit/test_codex_install_migration.py tests/unit/test_inject.py -q`
- Local install smoke: `uv run --project plugins/evo evo install codex --from-path /Users/alokbishoyi/Work/structure-autoresearch --force`
- Direct hook smoke with `CLAUDE_PLUGIN_ROOT` unset returned `{}` with exit 0.