### PR TITLE
Fix Codex hook launcher for 0.6.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,7 +14,7 @@ authors:
 repository-code: "https://github.com/evo-hq/evo"
 url: "https://github.com/evo-hq/evo"
 license: Apache-2.0
-version: 0.6.1
+version: 0.6.2
 date-released: 2026-06-19
 keywords:
   - autoresearch

--- a/plugins/evo/.claude-plugin/plugin.json
+++ b/plugins/evo/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "evo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents"
 }

--- a/plugins/evo/.codex-plugin/plugin.json
+++ b/plugins/evo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
   "author": {
     "name": "evo-hq",

--- a/plugins/evo/hooks/hooks.json
+++ b/plugins/evo/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }
@@ -17,16 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/wait_hint.sh"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }
@@ -36,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }
@@ -46,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }
@@ -56,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }
@@ -66,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+            "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
       }

--- a/plugins/evo/hooks/hooks.json
+++ b/plugins/evo/hooks/hooks.json
@@ -20,6 +20,15 @@
             "command": "node -e \"eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxvcz1yZXF1aXJlKCdvcycpLHBhdGg9cmVxdWlyZSgncGF0aCcpLGNwPXJlcXVpcmUoJ2NoaWxkX3Byb2Nlc3MnKTtjb25zdCBpbnB1dD1mcy5yZWFkRmlsZVN5bmMoMCk7Y29uc3QgbmFtZXM9cHJvY2Vzcy5wbGF0Zm9ybT09PSd3aW4zMic/Wydldm8taG9vay1kcmFpbi5leGUnLCdldm8taG9vay1kcmFpbiddOlsnZXZvLWhvb2stZHJhaW4nXTtjb25zdCBjYW5kaWRhdGVzPVtdO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKHJvb3Qpe2Zvcihjb25zdCBuIG9mIG5hbWVzKWNhbmRpZGF0ZXMucHVzaChwYXRoLmpvaW4ocm9vdCwnYmluJyxuKSk7fWNvbnN0IGhvbWU9cHJvY2Vzcy5lbnYuRVZPX0hPTUV8fHBhdGguam9pbihvcy5ob21lZGlyKCksJy5ldm8nKTtmb3IoY29uc3QgbiBvZiBuYW1lcyljYW5kaWRhdGVzLnB1c2gocGF0aC5qb2luKGhvbWUsJ2JpbicsbikpO2Zvcihjb25zdCBiIG9mIGNhbmRpZGF0ZXMpe3RyeXtpZihmcy5leGlzdHNTeW5jKGIpKXtjb25zdCByPWNwLnNwYXduU3luYyhiLFtdLHtpbnB1dH0pO2lmKHIuc3RhdHVzPT09MCYmci5zdGRvdXQmJnIuc3Rkb3V0Lmxlbmd0aCl7cHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9fXByb2Nlc3Muc3Rkb3V0LndyaXRlKCd7fVxuJyk7','base64').toString())\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"/*evo-wait-hint*/eval(Buffer.from('Y29uc3QgZnM9cmVxdWlyZSgnZnMnKSxwYXRoPXJlcXVpcmUoJ3BhdGgnKSxjcD1yZXF1aXJlKCdjaGlsZF9wcm9jZXNzJyk7Y29uc3QgaW5wdXQ9ZnMucmVhZEZpbGVTeW5jKDApO2NvbnN0IHJvb3Q9cHJvY2Vzcy5lbnYuQ0xBVURFX1BMVUdJTl9ST09UO2lmKCFyb290KXtwcm9jZXNzLnN0ZG91dC53cml0ZSgne31cbicpO3Byb2Nlc3MuZXhpdCgwKTt9Y29uc3Qgc2NyaXB0PXBhdGguam9pbihyb290LCdob29rcycsJ3dhaXRfaGludC5zaCcpO3RyeXtpZihmcy5leGlzdHNTeW5jKHNjcmlwdCkpe2NvbnN0IHI9Y3Auc3Bhd25TeW5jKCdiYXNoJyxbc2NyaXB0XSx7aW5wdXR9KTtpZihyLnN0YXR1cz09PTApe2lmKHIuc3Rkb3V0JiZyLnN0ZG91dC5sZW5ndGgpcHJvY2Vzcy5zdGRvdXQud3JpdGUoci5zdGRvdXQpO3Byb2Nlc3MuZXhpdCgwKTt9fX1jYXRjaChlKXt9cHJvY2Vzcy5zdGRvdXQud3JpdGUoJ3t9XG4nKTs=','base64').toString())\""
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/plugins/evo/npm/package.json
+++ b/plugins/evo/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/pi-evo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Evo plugin for pi-coding-agent: optimize/discover/subagent skills + mid-run inject extension.",
   "publishConfig": {
     "access": "public"

--- a/plugins/evo/npm/skills/discover/SKILL.md
+++ b/plugins/evo/npm/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1
+evo-hq-cli 0.6.2
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.2`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1
+   > uv tool install --force evo-hq-cli==0.6.2
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.2` (or `pipx install evo-hq-cli==0.6.2`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/npm/skills/infra-setup/SKILL.md
+++ b/plugins/evo/npm/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Infra Setup

--- a/plugins/evo/npm/skills/optimize/SKILL.md
+++ b/plugins/evo/npm/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/npm/skills/report/SKILL.md
+++ b/plugins/evo/npm/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Report

--- a/plugins/evo/npm/skills/ship/SKILL.md
+++ b/plugins/evo/npm/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Ship

--- a/plugins/evo/npm/skills/subagent/SKILL.md
+++ b/plugins/evo/npm/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/pyproject.toml
+++ b/plugins/evo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-cli"
-version = "0.6.1"
+version = "0.6.2"
 description = "Structured experiment-driven code optimization with git worktrees, traces, and a local dashboard. CLI for the evo plugin (Claude Code, Codex)."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/plugins/evo/skills/discover/SKILL.md
+++ b/plugins/evo/skills/discover/SKILL.md
@@ -2,7 +2,7 @@
 name: discover
 description: Initialize evo for the current repository by exploring the codebase, proposing unexplored optimization dimensions, constructing the benchmark inside a baseline worktree, and running the first experiment. Use when the user invokes /evo:discover, mentions setting up evo, wants to instrument a codebase for autonomous optimization, or asks to start a new evo run on a project.
 argument-hint: <optional context about what to optimize>
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Discover
@@ -119,20 +119,20 @@ evo --version
 The output must be exactly:
 
 ```
-evo-hq-cli 0.6.1
+evo-hq-cli 0.6.2
 ```
 
 Three outcomes:
 
 1. **Matches exactly** — continue to step 1.
 2. **Reports a different version** (`evo-hq-cli 0.4.2`, etc.) — the host refetched a newer/older skill bundle than the CLI on PATH. Drift breaks skills silently. Stop and tell the user:
-   > Your installed evo CLI is on a different version than this skill (`0.6.1`). Run:
+   > Your installed evo CLI is on a different version than this skill (`0.6.2`). Run:
    > ```
-   > uv tool install --force evo-hq-cli==0.6.1
+   > uv tool install --force evo-hq-cli==0.6.2
    > ```
    > Then re-invoke this skill.
 3. **`command not found`, or reports a different package** (commonly `evo 1.x` — the unrelated SLAM tool) — the CLI isn't installed. Tell the user:
-   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.1` (or `pipx install evo-hq-cli==0.6.1`). Then re-invoke this skill.
+   > `evo-hq-cli` isn't on your PATH. Install it: `uv tool install evo-hq-cli==0.6.2` (or `pipx install evo-hq-cli==0.6.2`). Then re-invoke this skill.
 
 Do not try to auto-install. Host sandbox + network policy may block it; leaving the install as a user action keeps failure modes clear.
 

--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finetuning
 description: This skill should be used when picking or diagnosing a training move (SFT, LoRA, DPO/KTO/ORPO, RFT, GRPO/PPO/RLOO, RLHF), or when the user mentions fine-tuning, post-training, training recipe, reward design, or weight updates. Decision tree by reward shape, smoke-run gate, three failure diagnostics, five false-progress patterns. Provider recipes and I/O contract in references/.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Finetuning

--- a/plugins/evo/skills/infra-setup/SKILL.md
+++ b/plugins/evo/skills/infra-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infra-setup
 description: Non-user-invocable provider/setup reference for evo backend switching, prerequisite checks, and auth/install guidance.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Infra Setup

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -2,7 +2,7 @@
 name: optimize
 description: Drive structured autoresearch iteration after evo:discover and the baseline commit. Use when the user invokes /evo:optimize or asks to try ideas, try variants, run experiments, use available GPUs, improve the current best/frontier, continue an evo search, or compare candidate changes in an evo workspace. The orchestrator plans and spawns optimization subagents; candidate edits/runs belong to those subagents. Width is set via subagents=N (1 for serial workloads, larger for parallel); the loop's structural value applies at any width.
 argument-hint: "[subagents=N] [budget=N] [stall=N]"
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 Run the `evo` optimization loop. Each round, the orchestrator writes structured briefs and spawns subagents that execute within them. Each subagent is semi-autonomous: it reads the pointer traces, forms the concrete edit, runs experiments, and can iterate within its branch. Runs until interrupted or the stall limit is reached.

--- a/plugins/evo/skills/report/SKILL.md
+++ b/plugins/evo/skills/report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: report
 description: Read-only evo run reporting. Use when the user invokes /evo:report, asks what happened overnight, asks what improved recently, asks for the best/frontier candidates, asks for a quick score chart without opening the dashboard, or wants the scatter plot in chat output. Never run benchmarks, gates, Slurm commands, evo run, or ad-hoc verification scripts for report requests.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Report

--- a/plugins/evo/skills/ship/SKILL.md
+++ b/plugins/evo/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Land the winning experiment from an evo run as a clean, mergeable change -- open a PR when the repo has a remote, otherwise merge into the working branch. Distills the best-scoring experiment down to the minimal diff that reproduces its behaviour, shaped for the qualities a maintainer merges on (scope discipline, test integrity, style adherence), then attaches an advisory mergeability report. Use when the user invokes /evo:ship, asks to land/merge/ship the best result, or wants to turn a finished optimization into a pull request.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Ship

--- a/plugins/evo/skills/subagent/SKILL.md
+++ b/plugins/evo/skills/subagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent
 description: Protocol that evo optimization subagents follow when dispatched from /optimize. Auto-loaded by spawned subagents via their host's skill loader. The orchestrator may also invoke this skill to understand the brief shape its dispatched subagents expect + what they're required to emit -- useful when writing briefs or debugging a subagent's behavior.
-evo_version: 0.6.1
+evo_version: 0.6.2
 ---
 
 # Evo Subagent Protocol

--- a/plugins/evo/src/evo/__init__.py
+++ b/plugins/evo/src/evo/__init__.py
@@ -5,4 +5,4 @@ __all__ = ["__version__", "DISTRIBUTION_NAME"]
 # PyPI distribution name. Stable string used by skill checks to distinguish
 # our binary from unrelated `evo` packages on PATH (e.g. the SLAM tool).
 DISTRIBUTION_NAME = "evo-hq-cli"
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -5,10 +5,9 @@ done by adding a `[plugins."<name>@<marketplace>"]` section."""
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
-import platform
-import shlex
 import subprocess
 from pathlib import Path
 
@@ -32,22 +31,27 @@ in ~/.codex/config.toml.
 """
 
 
-def _command_quote(path: Path) -> str:
-    """Return a shell-safe command token for an absolute executable path."""
-    text = str(path)
-    if platform.system().lower() == "windows":
-        return subprocess.list2cmdline([text])
-    return shlex.quote(text)
-
-
 def _stable_hook_command() -> str:
     """Codex-safe hook command.
 
     Codex does not guarantee Claude Code's `${CLAUDE_PLUGIN_ROOT}` env var.
     Materialize the user's stable evo hook binary path at install time so
     Codex hook execution does not depend on plugin-root expansion, cwd, or PATH.
+    The Node wrapper deliberately fails open: hooks run in every Codex session,
+    and a killed/corrupt helper binary must not break unrelated work.
     """
-    return _command_quote(stable_binary_path().resolve())
+    stable_json = json.dumps(str(stable_binary_path().resolve()))
+    script = (
+        "const fs=require('fs'),cp=require('child_process');"
+        "const input=fs.readFileSync(0);"
+        f"const bin={stable_json};"
+        "try{const r=cp.spawnSync(bin,[],{input});"
+        "if(r.status===0&&r.stdout&&r.stdout.length){"
+        "process.stdout.write(r.stdout);process.exit(0)}}catch(e){}"
+        "process.stdout.write('{}\\n')"
+    )
+    encoded = base64.b64encode(script.encode("utf-8")).decode("ascii")
+    return f"node -e \"eval(Buffer.from('{encoded}','base64').toString())\""
 
 
 def _materialize_codex_hooks(hooks_json_path: Path) -> bool:

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -85,7 +85,7 @@ def _materialize_codex_hooks(hooks_json_path: Path) -> bool:
                         handler = {**handler, "command": drain_cmd}
                         changed = True
                     handlers.append(handler)
-                elif "wait_hint.sh" in cmd:
+                elif "wait_hint.sh" in cmd or "evo-wait-hint" in cmd:
                     # Optional UX hint. Keeping a Claude-only path here makes
                     # Codex emit hook failures, which is worse than omitting it.
                     changed = True

--- a/plugins/evo/uv.lock
+++ b/plugins/evo/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "evo-hq-cli"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evo-hq/evo-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Lightweight reporting SDK for evo experiments. Zero dependencies.",
   "type": "module",
   "publishConfig": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-hq-agent"
-version = "0.6.1"
+version = "0.6.2"
 description = "Lightweight reporting SDK for evo experiments. Zero dependencies."
 requires-python = ">=3.10"
 dependencies = []

--- a/sdk/python/src/evo_agent/__init__.py
+++ b/sdk/python/src/evo_agent/__init__.py
@@ -5,4 +5,4 @@ from ._gate import Gate
 from ._run import Run
 
 __all__ = ["Backend", "Gate", "LocalBackend", "Run"]
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -155,9 +155,8 @@ class TestCodexRestageSurvival(_CodexSandbox):
             ]
             self.assertTrue(commands)
             for command in commands:
-                self.assertTrue(
-                    Path(command).samefile(self.root / ".evo" / "bin" / HOOK_NAME)
-                )
+                self.assertIn("node -e", command)
+                self.assertIn("Buffer.from", command)
 
     @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
     def test_materialized_hook_runs_without_claude_plugin_root(self):
@@ -179,6 +178,57 @@ class TestCodexRestageSurvival(_CodexSandbox):
             input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
             capture_output=True,
             env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), b"{}")
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_materialized_hook_preserves_real_hook_output(self):
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        stable = self.root / ".evo" / "bin" / HOOK_NAME
+        stable.write_text(
+            "#!/bin/sh\n"
+            "cat >/dev/null\n"
+            "printf '{\"decision\":\"block\",\"reason\":\"evo-test\"}'\n"
+        )
+        stable.chmod(0o755)
+
+        hooks = json.loads(
+            (self._cache_plugin_dir() / "hooks" / "hooks.json").read_text()
+        )
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        result = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=os.environ.copy(),
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"decision": "block", "reason": "evo-test"},
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_materialized_hook_fails_open_when_stable_binary_is_killed(self):
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        stable = self.root / ".evo" / "bin" / HOOK_NAME
+        stable.write_text("#!/bin/sh\ncat >/dev/null\nkill -9 $$\n")
+        stable.chmod(0o755)
+
+        hooks = json.loads(
+            (self._cache_plugin_dir() / "hooks" / "hooks.json").read_text()
+        )
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        result = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=os.environ.copy(),
             shell=True,
             timeout=10,
         )
@@ -390,6 +440,89 @@ class TestWrapperFallback(_SandboxBase):
         self.assertEqual(r.returncode, 0)
         self.assertEqual(r.stdout.strip(), b"{}")
         self.assertIn(b"binary not staged", r.stderr)
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_committed_hooks_do_not_require_claude_plugin_root(self):
+        """Codex may refresh its cache from the raw marketplace source after
+        `evo install codex` has already materialized hooks. The committed hook
+        command must still work when CLAUDE_PLUGIN_ROOT is absent."""
+        import subprocess
+        stable = self.root / ".evo" / "bin" / "evo-hook-drain"
+        stable.parent.mkdir(parents=True)
+        stable.write_text("#!/bin/sh\ncat >/dev/null\nprintf '{}'\n")
+        stable.chmod(0o755)
+
+        hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
+        self.assertNotIn(
+            "CLAUDE_PLUGIN_ROOT",
+            (REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text(),
+        )
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        r = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), b"{}")
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_committed_hooks_preserve_real_hook_output(self):
+        import subprocess
+        stable = self.root / ".evo" / "bin" / "evo-hook-drain"
+        stable.parent.mkdir(parents=True)
+        stable.write_text(
+            "#!/bin/sh\n"
+            "cat >/dev/null\n"
+            "printf '{\"hookSpecificOutput\":{\"permissionDecision\":\"deny\"}}'\n"
+        )
+        stable.chmod(0o755)
+
+        hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        r = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(
+            json.loads(r.stdout),
+            {"hookSpecificOutput": {"permissionDecision": "deny"}},
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_committed_hooks_fail_open_when_stable_binary_is_killed(self):
+        import subprocess
+        stable = self.root / ".evo" / "bin" / "evo-hook-drain"
+        stable.parent.mkdir(parents=True)
+        stable.write_text("#!/bin/sh\ncat >/dev/null\nkill -9 $$\n")
+        stable.chmod(0o755)
+
+        hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        r = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), b"{}")
 
 
 @unittest.skipIf(sys.platform == "win32", "sh wrapper is posix-only")

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -184,6 +184,30 @@ class TestCodexRestageSurvival(_CodexSandbox):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), b"{}")
 
+    def test_materialized_hook_fails_open_when_stable_binary_is_missing(self):
+        import subprocess
+
+        self.assertEqual(codex._install_via_filecopy(None), 0)
+        stable = self.root / ".evo" / "bin" / HOOK_NAME
+        stable.unlink()
+
+        hooks = json.loads(
+            (self._cache_plugin_dir() / "hooks" / "hooks.json").read_text()
+        )
+        command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        result = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"SessionStart","session_id":"s"}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), b"{}")
+
     @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
     def test_materialized_hook_preserves_real_hook_output(self):
         self.assertEqual(codex._install_via_filecopy(None), 0)

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -143,8 +143,8 @@ class TestCodexRestageSurvival(_CodexSandbox):
             self.snapshot / "plugins" / "evo" / "hooks" / "hooks.json",
         ):
             text = hooks_json.read_text()
-            self.assertNotIn("CLAUDE_PLUGIN_ROOT", text)
             self.assertNotIn("wait_hint.sh", text)
+            self.assertNotIn("evo-wait-hint", text)
             data = json.loads(text)
             commands = [
                 handler["command"]
@@ -477,11 +477,9 @@ class TestWrapperFallback(_SandboxBase):
         stable.chmod(0o755)
 
         hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
-        self.assertNotIn(
-            "CLAUDE_PLUGIN_ROOT",
-            (REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text(),
-        )
         command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        self.assertIn("node -e", command)
+        self.assertNotIn("${CLAUDE_PLUGIN_ROOT}", command)
         env = os.environ.copy()
         env.pop("CLAUDE_PLUGIN_ROOT", None)
         r = subprocess.run(
@@ -494,6 +492,56 @@ class TestWrapperFallback(_SandboxBase):
         )
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertEqual(r.stdout.strip(), b"{}")
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_committed_wait_hint_hook_is_safe_without_claude_plugin_root(self):
+        import subprocess
+
+        hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["PostToolUse"][1]["hooks"][0]["command"]
+        self.assertIn("evo-wait-hint", command)
+        self.assertNotIn("${CLAUDE_PLUGIN_ROOT}", command)
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        r = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"python train.py"}}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), b"{}")
+
+    @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
+    def test_committed_wait_hint_hook_runs_for_claude_plugin_root(self):
+        import subprocess
+
+        plugin_root = self.root / "plugin"
+        hooks_dir = plugin_root / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "wait_hint.sh").write_text(
+            "#!/bin/sh\n"
+            "cat >/dev/null\n"
+            "printf '[evo-hint] test\\n'\n"
+        )
+        (hooks_dir / "wait_hint.sh").chmod(0o755)
+
+        hooks = json.loads((REPO_ROOT / "plugins" / "evo" / "hooks" / "hooks.json").read_text())
+        command = hooks["hooks"]["PostToolUse"][1]["hooks"][0]["command"]
+        env = os.environ.copy()
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+        r = subprocess.run(
+            command,
+            input=b'{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"python train.py"}}',
+            capture_output=True,
+            env=env,
+            shell=True,
+            timeout=10,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), b"[evo-hint] test")
 
     @unittest.skipIf(sys.platform == "win32", "shell-script smoke is posix-only")
     def test_committed_hooks_preserve_real_hook_output(self):


### PR DESCRIPTION
## Summary

Fixes the Codex hook failure path that could come back after Codex refreshed its plugin cache from the marketplace source.

The 0.6.1 fix materialized Codex's installed hooks, but the shared source `hooks.json` still depended on Claude's `CLAUDE_PLUGIN_ROOT`. If Codex restored that raw hook file, unrelated Codex sessions could see hook failures again.

This patch:

- removes the `CLAUDE_PLUGIN_ROOT` dependency from the committed hook file
- routes hooks through a small Node launcher that finds the real Rust hook binary in `~/.evo/bin`
- fails open with `{}` if the helper is missing, killed, or corrupt, so unrelated Codex sessions are not broken
- keeps real hook output intact when the Rust helper succeeds
- bumps package/plugin/SDK metadata to `0.6.2`

## Upgrade path after release

Existing Codex users should refresh both the CLI and the installed plugin hooks:

```sh
uv tool install --force evo-hq-cli
evo update codex --force
```

If they use `pipx`, replace the first command with the equivalent `pipx upgrade`/reinstall command.

## Validation

- `python3 scripts/check_versions.py`
- `python3 -m json.tool plugins/evo/hooks/hooks.json`
- `uv run --with pytest --project plugins/evo pytest tests/unit/test_hook_drain_restage.py tests/unit/test_codex_install_migration.py -q`
- `uv run --with pytest --project plugins/evo pytest tests/unit -q`
- E2B Codex install sandbox passed
- E2B raw-hook simulation passed with `CLAUDE_PLUGIN_ROOT` unset and with `~/.evo/bin/evo-hook-drain` removed

## Container repro

Ran a fresh E2B Linux container with Codex `0.141.0`:

1. Installed released `evo-hq-cli==0.6.1` and ran `evo install codex --force`.
2. Simulated Codex restoring the raw `v0.6.1` marketplace hook file into the active plugin cache.
3. Ran the `SessionStart` hook with `CLAUDE_PLUGIN_ROOT` unset.

Observed the old failure:

```text
hook_cmd:${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain
bash: line 1: /bin/evo-hook-drain: No such file or directory
hook_rc:127
```

Then upgraded the same container to the local `0.6.2` candidate and ran `evo update codex --from-path /tmp/evo-local-repo --force`. After simulating the same raw-hook restore:

```text
raw_has_claude_plugin_root: False
raw_has_node_launcher: True
{}
hook_rc:0
```

Also removed `~/.evo/bin/evo-hook-drain` and reran the raw hook. It still returned `{}` with rc 0, which is the intended fail-open behavior for unrelated Codex sessions.
