### PR TITLE
[codex] Repair Codex evo config on update

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -6894,10 +6894,9 @@ def build_parser() -> argparse.ArgumentParser:
     install_p.add_argument(
         "--force",
         action="store_true",
-        help="Re-run the host's marketplace install even if the install state "
-             "already exists. Without --force, the prereq is skipped when the "
-             "host plugin is already present (avoids overwriting a tag-pinned "
-             "install with default-branch content).",
+        help="Refresh the host marketplace/source even if one already exists. "
+             "Normal install still repairs evo config and cached plugin files; "
+             "--force is for replacing stale, pinned, or broken source state.",
     )
     install_p.set_defaults(func=cmd_install)
 
@@ -6918,10 +6917,10 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Refresh evo's installation. With <host>: update just that host. "
             "Without <host>: refresh the global CLI from PyPI, then update every "
-            "host whose `evo doctor` currently passes. Use --force to wipe the "
-            "host's plugin cache and reinstall from scratch (workaround for the "
-            "upstream Claude Code cache-invalidation bug, "
-            "anthropics/claude-code#14061)."
+            "host whose `evo doctor` currently passes. A normal update repairs "
+            "evo config, hooks, helper binaries, and cached plugin files. Use "
+            "--force when the host marketplace/source itself should be refreshed "
+            "or replaced."
         ),
     )
     update_p.add_argument(
@@ -6934,8 +6933,8 @@ def build_parser() -> argparse.ArgumentParser:
     update_p.add_argument(
         "--force",
         action="store_true",
-        help="Uninstall + wipe plugin cache + reinstall (routes around upstream "
-             "cache-invalidation bug). Use this for migrating from pre-0.4.1.",
+        help="Refresh/reinstall the host marketplace or source before repairing "
+             "the host integration.",
     )
     update_p.add_argument(
         "--scope",

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -150,41 +150,48 @@ def _toggle_plugin_hooks(enable: bool) -> tuple[bool, Path]:
     return True, cfg
 
 
+def _strip_toml_sections(text: str, should_strip) -> str:
+    """Remove whole TOML sections whose header matches ``should_strip``.
+
+    The Codex config is user-owned, so keep this deliberately text-based and
+    narrow: when a matching table header is seen, drop that header and every
+    following line until the next table header.
+    """
+    new_lines: list[str] = []
+    skip = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith("["):
+            header = stripped.rstrip()
+            skip = bool(should_strip(header))
+            if skip:
+                continue
+        if skip:
+            continue
+        new_lines.append(line)
+    return "".join(new_lines)
+
+
 def _enable_plugin(enable: bool) -> tuple[bool, Path]:
     """Add or remove the `[plugins."evo@evo-hq"]` section in
     config.toml. Codex 0.130+ uses owner-only marketplace names, so the
     plugin key is `evo@evo-hq` (not `evo@evo-hq-evo`)."""
     cfg = _codex_base() / "config.toml"
-    if not cfg.exists():
+    if not cfg.exists() and not enable:
         return False, cfg
-    text = cfg.read_text()
-    present = _PLUGIN_KEY in text
+    text = cfg.read_text() if cfg.exists() else ""
 
+    stripped = _strip_toml_sections(text, lambda header: header == _PLUGIN_KEY)
     if enable:
-        if present:
-            return False, cfg
-        text = text.rstrip() + f"\n\n{_PLUGIN_KEY}\n"
+        text = stripped.rstrip() + f"\n\n{_PLUGIN_KEY}\nenabled = true\n"
     else:
-        if not present:
+        if stripped == text:
             return False, cfg
-        # Remove the section header AND the key lines that belong to it
-        # (`enabled = true`, written by _install_via_filecopy) up to the
-        # next section. Dropping only the header would orphan
-        # `enabled = true`, which a TOML parser attaches to the preceding
-        # table.
-        new_lines: list[str] = []
-        skip = False
-        for line in text.splitlines():
-            stripped = line.lstrip()
-            if stripped.startswith("["):
-                skip = stripped.rstrip() == _PLUGIN_KEY
-                if skip:
-                    continue
-            if skip:
-                continue
-            new_lines.append(line)
-        text = "\n".join(new_lines).rstrip() + "\n"
+        text = stripped.rstrip() + "\n"
 
+    if text == (cfg.read_text() if cfg.exists() else ""):
+        return False, cfg
+    cfg.parent.mkdir(parents=True, exist_ok=True)
     cfg.write_text(text)
     return True, cfg
 
@@ -411,14 +418,11 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) ->
     else:
         print(f"plugin_hooks already enabled in {cfg}")
 
-    plugin_key = f'[plugins."evo@{mkt_name}"]'
-    text = cfg.read_text() if cfg.exists() else ""
-    if plugin_key not in text:
-        text = text.rstrip() + f"\n\n{plugin_key}\nenabled = true\n"
-        cfg.write_text(text)
-        print(f"updated {cfg}: added {plugin_key} (enabled = true)")
+    changed_p, cfg = _enable_plugin(enable=True)
+    if changed_p:
+        print(f"updated {cfg}: enabled [plugins.\"evo@{mkt_name}\"]")
     else:
-        print(f"{plugin_key} already present in {cfg}")
+        print(f"[plugins.\"evo@{mkt_name}\"] already enabled in {cfg}")
 
     # Hooks are codex's most security-sensitive surface (run on every
     # tool call). Codex installs them in `untrusted` state — they're
@@ -433,6 +437,8 @@ def _install_via_filecopy(from_path: str | None, *, trust_hooks: bool = True) ->
     if trust_hooks:
         _trust_plugin_hooks(nested_hooks, plugin_id=f"evo@{mkt_name}", cfg=cfg)
     else:
+        if _strip_plugin_hook_state(cfg, f"evo@{mkt_name}"):
+            print(f"updated {cfg}: removed stale hook trust for evo@{mkt_name}")
         print(
             "\nPlugin hooks installed UNTRUSTED (--no-trust-hooks). They "
             "register but never fire, so mid-run directives (`evo direct`) "
@@ -619,6 +625,19 @@ def _expected_hook_state(hooks_json_path: Path, plugin_id: str) -> dict[str, str
     return expected
 
 
+def _strip_plugin_hook_state(cfg: Path, plugin_id: str) -> bool:
+    text = cfg.read_text() if cfg.exists() else ""
+    stripped = _strip_toml_sections(
+        text,
+        lambda header: header.startswith(f'[hooks.state."{plugin_id}:'),
+    ).rstrip()
+    new_text = (stripped + "\n") if stripped else ""
+    if new_text == text:
+        return False
+    cfg.write_text(new_text)
+    return True
+
+
 def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> None:
     """Write `[hooks.state."<key>"] trusted_hash = "..."` entries to
     config.toml, same effect as `codex` → `/hooks` → Trust each.
@@ -636,15 +655,14 @@ def _trust_plugin_hooks(hooks_json_path: Path, plugin_id: str, cfg: Path) -> Non
 
     block = "\n\n".join(lines) + "\n"
     text = cfg.read_text() if cfg.exists() else ""
-    # Replace existing [hooks.state."..."] blocks for this plugin so
-    # repeated --trust-hooks calls don't accumulate stale entries.
-    import re as _re
-    pat = _re.compile(
-        rf'\[hooks\.state\."{_re.escape(plugin_id)}:[^"]+"\]\n'
-        rf'trusted_hash = "sha256:[a-f0-9]+"\s*',
-        _re.MULTILINE,
-    )
-    text = pat.sub("", text).rstrip() + "\n\n" + block
+    # Replace whole existing [hooks.state."..."] blocks for this plugin so
+    # repeated --trust-hooks calls don't accumulate stale or disabled entries.
+    # Codex may include additional keys such as `enabled = false`; a regex that
+    # only removes `trusted_hash` lines leaves duplicate TOML table headers.
+    text = _strip_toml_sections(
+        text,
+        lambda header: header.startswith(f'[hooks.state."{plugin_id}:'),
+    ).rstrip() + "\n\n" + block
     cfg.write_text(text)
     events = sorted({key.split(":")[-3] for key in expected})
     print(

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -282,6 +282,87 @@ class TestDisablePlugin(_Base):
         self.assertEqual(self._read_config(), original)
 
 
+class TestCodexConfigConvergence(_Base):
+
+    def test_enable_plugin_replaces_disabled_and_duplicate_blocks(self):
+        from evo.host_install.codex import _enable_plugin
+
+        self._write_config(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = false\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = true\n'
+        )
+        changed, _ = _enable_plugin(enable=True)
+        self.assertTrue(changed)
+        text = self._read_config()
+        self.assertEqual(text.count('[plugins."evo@evo-hq"]'), 1)
+        self.assertIn('[plugins."evo@evo-hq"]\nenabled = true', text)
+        self.assertNotIn('[plugins."evo@evo-hq"]\nenabled = false', text)
+        self.assertIn('[plugins."github@openai-curated"]', text)
+
+    def test_trust_hooks_replaces_disabled_duplicate_hook_state_blocks(self):
+        from evo.host_install.codex import _trust_plugin_hooks
+
+        hooks = self.codex_home / "plugins" / "cache" / "evo-hq" / "evo" / "0.6.2" / "hooks" / "hooks.json"
+        hooks.parent.mkdir(parents=True)
+        hooks.write_text(
+            '{"hooks":{"SessionStart":[{"hooks":[{"type":"command",'
+            '"command":"node -e \\"process.stdout.write(\\\\\\"{}\\\\\\\\n\\\\\\")\\""}]}]}}'
+        )
+        self._write_config(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:session_start:0:0"]\n'
+            'enabled = false\n'
+            'trusted_hash = "sha256:old"\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+            '\n'
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:session_start:0:0"]\n'
+            'enabled = true\n'
+            'trusted_hash = "sha256:also-old"\n'
+        )
+
+        _trust_plugin_hooks(hooks, plugin_id="evo@evo-hq", cfg=self.cfg_path)
+
+        text = self._read_config()
+        self.assertEqual(
+            text.count('[hooks.state."evo@evo-hq:hooks/hooks.json:session_start:0:0"]'),
+            1,
+        )
+        self.assertNotIn("enabled = false", text)
+        self.assertNotIn("sha256:old", text)
+        self.assertNotIn("sha256:also-old", text)
+        self.assertIn('trusted_hash = "sha256:', text)
+        self.assertIn('[plugins."github@openai-curated"]', text)
+
+    def test_no_trust_cleanup_removes_stale_hook_state(self):
+        from evo.host_install.codex import _strip_plugin_hook_state
+
+        self._write_config(
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:pre_tool_use:0:0"]\n'
+            'enabled = false\n'
+            'trusted_hash = "sha256:old"\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+        )
+        self.assertTrue(_strip_plugin_hook_state(self.cfg_path, "evo@evo-hq"))
+        text = self._read_config()
+        self.assertNotIn("[hooks.state.", text)
+        self.assertIn('[plugins."github@openai-curated"]', text)
+
+
 class TestDoctorHookBinary(_Base):
     """`doctor()` resolves the hook-drain binary at the cache dir codex
     actually loads. These exercise the version-dir selection (numeric, not

--- a/tests/unit/test_hook_drain_restage.py
+++ b/tests/unit/test_hook_drain_restage.py
@@ -407,6 +407,59 @@ class TestCodexMarketplaceRefresh(_CodexSandbox):
         self.assertTrue(cache_hooks.exists())
         self.assertNotIn("CLAUDE_PLUGIN_ROOT", cache_hooks.read_text())
 
+    def test_non_force_install_repairs_config_without_refreshing_marketplace(self):
+        import argparse
+        from unittest import mock
+
+        # Mirrors a real broken user config: duplicate canonical sections plus
+        # Codex-managed enabled keys inside hook-state tables. TOML parsing fails
+        # before Codex can start until these are collapsed to one canonical block.
+        (self.codex_home / "config.toml").write_text(
+            '[features]\n'
+            'plugin_hooks = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = false\n'
+            '\n'
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:pre_tool_use:0:0"]\n'
+            'enabled = false\n'
+            'trusted_hash = "sha256:old"\n'
+            '\n'
+            '[plugins."github@openai-curated"]\n'
+            'enabled = true\n'
+            '\n'
+            '[plugins."evo@evo-hq"]\n'
+            'enabled = true\n'
+            '\n'
+            '[hooks.state."evo@evo-hq:hooks/hooks.json:pre_tool_use:0:0"]\n'
+            'enabled = true\n'
+            'trusted_hash = "sha256:also-old"\n'
+        )
+        old_path = self._with_fake_codex_on_path()
+        try:
+            with mock.patch("subprocess.call") as call:
+                rc = codex.install(argparse.Namespace(
+                    from_path=None,
+                    trust_hooks=True,
+                    force=False,
+                    version=None,
+                ))
+        finally:
+            os.environ["PATH"] = old_path
+
+        self.assertEqual(rc, 0)
+        call.assert_not_called()
+        cfg = self._config()
+        self.assertEqual(cfg.count('[plugins."evo@evo-hq"]'), 1)
+        self.assertIn('[plugins."evo@evo-hq"]\nenabled = true', cfg)
+        self.assertEqual(
+            cfg.count('[hooks.state."evo@evo-hq:hooks/hooks.json:pre_tool_use:0:0"]'),
+            1,
+        )
+        self.assertNotIn('trusted_hash = "sha256:old"', cfg)
+        self.assertNotIn('trusted_hash = "sha256:also-old"', cfg)
+        self.assertIn('[plugins."github@openai-curated"]', cfg)
+
     def test_version_pin_fails_closed_when_snapshot_stays_stale(self):
         import argparse
         from unittest import mock


### PR DESCRIPTION
## What changed

- Make Codex install/update rewrite Evo's plugin block into one canonical `[plugins."evo@evo-hq"]` section with `enabled = true`.
- Replace whole Evo hook-state TOML sections before writing trusted hook hashes, including sections that contain Codex-managed `enabled` keys.
- Clean stale Evo hook trust even when installing with `--no-trust-hooks`.
- Update CLI help text so `--force` is described as source/marketplace refresh, not required for normal repair.

## Why

A user hit a Codex startup failure from duplicate Evo hook-state sections in `~/.codex/config.toml`. The previous trust rewrite only removed simple `trusted_hash` blocks, so sections with extra keys like `enabled = false` survived and a second identical TOML table was appended. The same path could leave the Evo plugin section present but disabled.

Plain `evo update codex` should repair this state. `--force` should only be needed when the marketplace/source itself needs refreshing.

## Validation

```sh
uv run --with pytest pytest ../../tests/unit/test_codex_install_migration.py ../../tests/unit/test_hook_drain_restage.py ../../tests/unit/test_cli_auto_sync.py -q
```

Result: `64 passed`.
