### PR TITLE
Surface active experiment state during training (#59)

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -4560,14 +4560,19 @@ def cmd_metrics(args: argparse.Namespace) -> int:
             print("[]")
             return 0
     if args.tail:
+        fragment = b""
+        seen_size = 0
+        fragment = _print_metrics_lines(target, offset=0, fragment=b"")
         seen_size = target.stat().st_size
-        _print_metrics_lines(target, offset=0)
         try:
             while True:
                 time.sleep(2)
                 current = target.stat().st_size
+                if current < seen_size:
+                    seen_size = 0
+                    fragment = b""
                 if current > seen_size:
-                    _print_metrics_lines(target, offset=seen_size)
+                    fragment = _print_metrics_lines(target, offset=seen_size, fragment=fragment)
                     seen_size = current
         except KeyboardInterrupt:
             pass
@@ -4576,14 +4581,27 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
-def _print_metrics_lines(path: Path, *, offset: int) -> None:
+def _print_metrics_lines(path: Path, *, offset: int, fragment: bytes = b"") -> bytes:
     size = path.stat().st_size
     if offset >= size:
-        return
+        return fragment
     with path.open("rb") as fh:
         fh.seek(offset)
-        raw = fh.read().decode("utf-8", errors="replace")
-    for line in raw.splitlines():
+        raw = fragment + fh.read()
+    last_nl = raw.rfind(b"\n")
+    if last_nl < 0:
+        if not fragment:
+            try:
+                parsed = json.loads(raw.decode("utf-8", errors="replace"))
+                print(json.dumps(parsed))
+                return b""
+            except json.JSONDecodeError:
+                pass
+        return raw
+    new_fragment = raw[last_nl + 1:]
+    complete = raw[:last_nl]
+    text = complete.decode("utf-8", errors="replace")
+    for line in text.splitlines():
         line = line.strip()
         if not line:
             continue
@@ -4592,6 +4610,14 @@ def _print_metrics_lines(path: Path, *, offset: int) -> None:
             print(json.dumps(parsed))
         except json.JSONDecodeError:
             pass
+    if new_fragment:
+        try:
+            parsed = json.loads(new_fragment.decode("utf-8", errors="replace"))
+            print(json.dumps(parsed))
+            return b""
+        except json.JSONDecodeError:
+            pass
+    return new_fragment
 
 
 def cmd_annotate(args: argparse.Namespace) -> int:

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -4415,6 +4415,24 @@ def cmd_show(args: argparse.Namespace) -> int:
                 pass
         attempts.append(attempt_payload)
 
+    active_attempt = None
+    if node.get("status") == "active":
+        current = int(node.get("current_attempt", 0))
+        if current > 0:
+            state = _read_attempt_state(root, args.exp_id, current)
+            if state is not None:
+                active_attempt = {"n": current, "state": state}
+                diff_path = attempt_log_path(root, args.exp_id, current, "diff.patch")
+                if diff_path.exists():
+                    try:
+                        active_attempt["diff"] = diff_path.read_text(encoding="utf-8")
+                        parsed = parse_diff_patch(root, args.exp_id, current)
+                        if parsed:
+                            active_attempt["diff_added"] = parsed["added"]
+                            active_attempt["diff_removed"] = parsed["removed"]
+                    except OSError:
+                        pass
+
     # Annotations filtered to this exp.
     all_annotations = load_annotations(root).get("annotations", [])
     annotations = [a for a in all_annotations if a.get("experiment_id") == args.exp_id]
@@ -4432,6 +4450,7 @@ def cmd_show(args: argparse.Namespace) -> int:
         "children": list(node.get("children", [])),
         "effective_gates": collect_gates_from_path(graph, args.exp_id),
         "attempts": attempts,
+        "active_attempt": active_attempt,
         "annotations": annotations,
         "notes": list(node.get("notes", [])),
         "tags": list(node.get("tags", [])),
@@ -4522,6 +4541,57 @@ def cmd_traces(args: argparse.Namespace) -> int:
             payload[path.name] = json.loads(path.read_text(encoding="utf-8"))
     print(json.dumps(payload, indent=2))
     return 0
+
+
+def cmd_metrics(args: argparse.Namespace) -> int:
+    """Read metrics.jsonl from the latest attempt. With --tail, follow new lines."""
+    root = repo_root()
+    node = _read_node(root, args.exp_id)
+    attempt = int(node.get("current_attempt", 0))
+    if attempt == 0:
+        print("[]")
+        return 0
+    target = attempt_log_path(root, args.exp_id, attempt, "metrics.jsonl")
+    if not target.exists():
+        fallback = Path(node.get("worktree", "")) / "metrics.jsonl"
+        if fallback.exists():
+            target = fallback
+        else:
+            print("[]")
+            return 0
+    if args.tail:
+        seen_size = target.stat().st_size
+        _print_metrics_lines(target, offset=0)
+        try:
+            while True:
+                time.sleep(2)
+                current = target.stat().st_size
+                if current > seen_size:
+                    _print_metrics_lines(target, offset=seen_size)
+                    seen_size = current
+        except KeyboardInterrupt:
+            pass
+        return 0
+    _print_metrics_lines(target, offset=0)
+    return 0
+
+
+def _print_metrics_lines(path: Path, *, offset: int) -> None:
+    size = path.stat().st_size
+    if offset >= size:
+        return
+    with path.open("rb") as fh:
+        fh.seek(offset)
+        raw = fh.read().decode("utf-8", errors="replace")
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+            print(json.dumps(parsed))
+        except json.JSONDecodeError:
+            pass
 
 
 def cmd_annotate(args: argparse.Namespace) -> int:
@@ -6690,6 +6760,17 @@ def build_parser() -> argparse.ArgumentParser:
     traces_p.add_argument("exp_id")
     traces_p.add_argument("task", nargs="?")
     traces_p.set_defaults(func=cmd_traces)
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="live-training metrics from metrics.jsonl (loss, reward, lr, ...)",
+    )
+    metrics_p.add_argument("exp_id")
+    metrics_p.add_argument(
+        "--tail", action="store_true",
+        help="follow new lines every 2 seconds (like tail -f)",
+    )
+    metrics_p.set_defaults(func=cmd_metrics)
 
     annotate_p = sub.add_parser("annotate")
     annotate_p.add_argument("exp_id")

--- a/plugins/evo/src/evo/dashboard.py
+++ b/plugins/evo/src/evo/dashboard.py
@@ -61,6 +61,28 @@ def _redact_value(value: Any, *, key: str | None = None) -> Any:
     return value
 
 
+def _read_attempt_state(root: Path, exp_id: str, attempt: int) -> dict | None:
+    path = attempt_dir(root, exp_id, attempt) / "attempt_state.json"
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _latest_attempt_on_disk(root: Path, exp_id: str) -> int | None:
+    exp_root = experiments_dir_for(root, exp_id) / "attempts"
+    if not exp_root.exists():
+        return None
+    candidates = sorted(
+        (int(p.name) for p in exp_root.iterdir() if p.is_dir() and p.name.isdigit()),
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
 def _public_node(
     root: Path,
     node: dict[str, Any],
@@ -97,6 +119,22 @@ def _public_node(
         blocker = lineage_invalidated_by(graph, node.get("id", ""))
         public["lineage_blocked_by"] = blocker.get("id") if blocker else None
         public["lineage_blocked_reason"] = blocker.get("pruned_reason") if blocker else None
+
+    if public.get("status") == "active":
+        exp_id = node.get("id", "")
+        attempt_n = _latest_attempt_on_disk(root, exp_id)
+        if attempt_n is not None:
+            state = _read_attempt_state(root, exp_id, attempt_n)
+            if state is not None:
+                public["active_attempt"] = {
+                    "n": attempt_n,
+                    "phase": state.get("phase"),
+                    "status": state.get("status"),
+                    "started_at": state.get("started_at"),
+                    "updated_at": state.get("updated_at"),
+                    "pid": state.get("pid"),
+                }
+
     return public
 
 
@@ -948,7 +986,7 @@ def create_app(root: Path | None = None) -> Flask:
         if dirpath.exists():
             # Surface .log and .out at the attempt root and one level under
             # logs/ (the convention training scripts typically use).
-            patterns = ["*.log", "*.out", "logs/*.log", "logs/*.out"]
+            patterns = ["*.log", "*.out", "*.jsonl", "logs/*.log", "logs/*.out", "logs/*.jsonl"]
             seen: set[Path] = set()
             for pat in patterns:
                 for p in sorted(dirpath.glob(pat)):

--- a/plugins/evo/src/evo/static/app.js
+++ b/plugins/evo/src/evo/static/app.js
@@ -2202,6 +2202,10 @@ async function openDrawer(expId, opts) {
       detail = `<div class="drawer-summary-detail">${esc(node.discard_reason)}</div>`;
     } else if (isFrontierCandidate(node)) {
       detail = `<div class="drawer-summary-detail accent">Frontier candidate — evo may branch from this node next.</div>`;
+    } else if (node.status === 'active' && node.active_attempt) {
+      const a = node.active_attempt;
+      const phaseLabel = a.phase || 'running';
+      detail = `<div class="drawer-summary-detail accent">Attempt ${a.n} — ${esc(phaseLabel)}${a.updated_at ? ' · ' + esc(relTime(a.updated_at)) + ' ago' : ''}</div>`;
     }
     html += `<div class="drawer-section drawer-summary">
       <div class="drawer-score-row">
@@ -2258,6 +2262,7 @@ async function openDrawer(expId, opts) {
       <div class="drawer-meta-row"><span class="drawer-meta-key">Epoch</span><span class="drawer-meta-val">${esc(node.eval_epoch || '--')}</span></div>
       <div class="drawer-meta-row"><span class="drawer-meta-key">Backend</span><span class="drawer-meta-val mono">${esc(backendLabel(node.resolved_backend || ws.default_backend))}</span></div>
       <div class="drawer-meta-row"><span class="drawer-meta-key">Created</span><span class="drawer-meta-val">${esc(relTime(node.created_at))} ago</span></div>
+      ${node.active_attempt ? `<div class="drawer-meta-row"><span class="drawer-meta-key">Attempt</span><span class="drawer-meta-val mono">${esc(node.active_attempt.phase || 'running')} (#${node.active_attempt.n})</span></div>` : ''}
       ${node.children?.length ? `<div class="drawer-meta-row"><span class="drawer-meta-key">Children</span><span class="drawer-meta-val mono" style="color:var(--indigo)">${node.children.length}</span></div>` : ''}
     </div>
     ${renderBackendSection(node, ws)}


### PR DESCRIPTION
Closes #59.
During long training runs (SFT, RL — often 1-2h) the dashboard and CLI showed nothing useful until the run finalized. The data existed on disk (attempt_state.json, diff.patch, metrics.jsonl) but evo didn't surface it.
Changes
- cmd_show now includes active_attempt with phase, status, and diff text for active experiments — so evo show returns useful state instead of attempts: []
- Dashboard _public_node enriches active nodes with active_attempt metadata (phase, status, started_at, updated_at, pid) from attempt_state.json; the drawer renders a summary line and meta row showing current phase
- New evo metrics <exp_id> [--tail] CLI command that reads metrics.jsonl (checks attempt dir first, falls back to worktree root) with 2-second file-size polling for --tail
- metrics.jsonl added to dashboard logs tab file listing — shows up alongside benchmark.log with live tail polling (already existed for .log/.out)