### PR TITLE
feat: live observability dashboard for active experiments (#59)

### DIFF
--- a/plugins/evo/skills/finetuning/SKILL.md
+++ b/plugins/evo/skills/finetuning/SKILL.md
@@ -48,6 +48,18 @@ Run the full pipeline on ~10 examples for ~1 minute. Must produce: a checkpoint 
 
 Training for an hour and getting one number at the end is the wrong granularity for evo's tree search. By the time you know the recipe failed, you've spent the budget. Build the verification *into* the training script, not around it.
 
+## Live dashboard monitoring
+
+During training, the evo dashboard shows a **Live** tab with real-time updates:
+
+- **Metrics**: Append JSONL lines to `EVO_METRICS_PATH` for live sparklines (loss, lr, grad_norm, etc.)
+- **Samples**: Append to `EVO_SAMPLES_PATH` for live preview of generated outputs
+- **Checkpoints**: Write to `EVO_CHECKPOINT_DIR` for live checkpoint listing
+- **Diff**: The worktree diff refreshes every 5 seconds automatically
+- **Logs**: Standard output/error logs are tailed in real-time
+
+Use `evo metrics <exp_id> --tail` and `evo samples <exp_id> --tail` for CLI monitoring.
+
 Pattern for any training run expected to exceed ~30 min wall-clock:
 
 1. **Periodic checkpoint** every N steps (e.g. every 0.25 epoch, or every 200 steps — whichever is faster).

--- a/plugins/evo/skills/finetuning/references/glue.md
+++ b/plugins/evo/skills/finetuning/references/glue.md
@@ -18,6 +18,11 @@ You write this per task in the experiment worktree. evo provides inputs by conve
   (lives under the experiment record, survives between-attempt cleanup and
   discard). Write the reusable checkpoint here so it can be declared + later
   seeded; the worktree itself is ephemeral.
+- `EVO_METRICS_PATH` — pre-created path for `metrics.jsonl`. Append step-indexed
+  metrics (`{step, loss, reward, kl, grad_norm, lr}`) here for live dashboard
+  visibility. The dashboard polls this file every 5 seconds.
+- `EVO_SAMPLES_PATH` — pre-created path for `samples.jsonl`. Append generated
+  samples (`{text, output, ...}`) here for live preview in the dashboard.
 - Held-out data is **not** provided — evo scores on it independently.
 
 ### Warm-start pattern
@@ -41,6 +46,9 @@ backward pass.)
    `artifacts: [{kind: "lora_adapter"|"checkpoint", uri, content_key, created_by}]`.
 2. `train_summary.json` — the `TrainingTrace` setup/dynamics fields.
 3. `metrics.jsonl` — step-indexed `{step, loss, reward, kl, grad_norm, lr}`.
+   Append to `EVO_METRICS_PATH` for live dashboard visibility.
+4. `samples.jsonl` (optional) — generated samples for live preview.
+   Append to `EVO_SAMPLES_PATH`.
 
 ## Benchmark by convention
 

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -4415,6 +4415,24 @@ def cmd_show(args: argparse.Namespace) -> int:
                 pass
         attempts.append(attempt_payload)
 
+    active_attempt = None
+    if node.get("status") == "active":
+        current = int(node.get("current_attempt", 0))
+        if current > 0:
+            state = _read_attempt_state(root, args.exp_id, current)
+            if state is not None:
+                active_attempt = {"n": current, "state": state}
+                diff_path = attempt_log_path(root, args.exp_id, current, "diff.patch")
+                if diff_path.exists():
+                    try:
+                        active_attempt["diff"] = diff_path.read_text(encoding="utf-8")
+                        parsed = parse_diff_patch(root, args.exp_id, current)
+                        if parsed:
+                            active_attempt["diff_added"] = parsed["added"]
+                            active_attempt["diff_removed"] = parsed["removed"]
+                    except OSError:
+                        pass
+
     # Annotations filtered to this exp.
     all_annotations = load_annotations(root).get("annotations", [])
     annotations = [a for a in all_annotations if a.get("experiment_id") == args.exp_id]
@@ -4432,6 +4450,7 @@ def cmd_show(args: argparse.Namespace) -> int:
         "children": list(node.get("children", [])),
         "effective_gates": collect_gates_from_path(graph, args.exp_id),
         "attempts": attempts,
+        "active_attempt": active_attempt,
         "annotations": annotations,
         "notes": list(node.get("notes", [])),
         "tags": list(node.get("tags", [])),
@@ -6758,6 +6777,17 @@ def build_parser() -> argparse.ArgumentParser:
     traces_p.add_argument("exp_id")
     traces_p.add_argument("task", nargs="?")
     traces_p.set_defaults(func=cmd_traces)
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="live-training metrics from metrics.jsonl (loss, reward, lr, ...)",
+    )
+    metrics_p.add_argument("exp_id")
+    metrics_p.add_argument(
+        "--tail", action="store_true",
+        help="follow new lines every 2 seconds (like tail -f)",
+    )
+    metrics_p.set_defaults(func=cmd_metrics)
 
     annotate_p = sub.add_parser("annotate")
     annotate_p.add_argument("exp_id")

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -17,6 +17,7 @@ from .core import (
     PRUNE_KIND_EXHAUSTED,
     PRUNE_KIND_INVALID,
     SUPPORTED_HOSTS,
+    _DiffRefresher,
     _load_meta,
     add_gate,
     add_workspace_note,
@@ -2574,6 +2575,8 @@ def _runtime_env_for_attempt(
     env_traces_dir: str,
     env_result_path: str,
     env_checkpoint_dir: str,
+    env_metrics_path: str,
+    env_samples_path: str,
 ) -> dict[str, str]:
     env = resolve_runtime_env(root, config)
     env["EVO_TRACES_DIR"] = env_traces_dir
@@ -2582,6 +2585,8 @@ def _runtime_env_for_attempt(
     env["EVO_ATTEMPT"] = attempt_label
     env["EVO_RESULT_PATH"] = env_result_path
     env["EVO_CHECKPOINT_DIR"] = env_checkpoint_dir
+    env["EVO_METRICS_PATH"] = env_metrics_path
+    env["EVO_SAMPLES_PATH"] = env_samples_path
     # Reuse path: if this experiment was created with `evo new --from-artifact`,
     # expose the preserved artifact's path so the recipe can warm-start / retest
     # instead of rebuilding from scratch. Category-agnostic (checkpoint/index/...).
@@ -2777,6 +2782,10 @@ def _cmd_run_check(
         env_traces_dir = str(traces_dir.resolve())
         env_result_path = str(result_path.resolve())
         env_checkpoint_dir = str((check_dir / "checkpoints").resolve())
+    metrics_path = check_dir / "metrics.jsonl"
+    samples_path = check_dir / "samples.jsonl"
+    env_metrics_path = str(metrics_path.resolve())
+    env_samples_path = str(samples_path.resolve())
 
     benchmark_cmd = _apply_runtime_prefix(
         config,
@@ -2791,6 +2800,8 @@ def _cmd_run_check(
         env_traces_dir=env_traces_dir,
         env_result_path=env_result_path,
         env_checkpoint_dir=env_checkpoint_dir,
+        env_metrics_path=env_metrics_path,
+        env_samples_path=env_samples_path,
     )
     gate_records: list[dict] = []
     runtime_records: list[dict] = []
@@ -3078,6 +3089,15 @@ def _cmd_run_impl(
         env_result_path = str(result_path.resolve())
         env_checkpoint_dir = str(checkpoint_dir.resolve())
 
+    metrics_path = a_dir / "metrics.jsonl"
+    samples_path = a_dir / "samples.jsonl"
+    stderr_log_path = a_dir / "stderr.log"
+    env_metrics_path = str(metrics_path.resolve())
+    env_samples_path = str(samples_path.resolve())
+    # Pre-create files so training scripts can append immediately.
+    for _p in (metrics_path, samples_path, stderr_log_path):
+        _p.touch(exist_ok=True)
+
     benchmark_cmd = _apply_runtime_prefix(
         config,
         fill_command_template(config["benchmark"], target=target, worktree=worktree),
@@ -3093,6 +3113,8 @@ def _cmd_run_impl(
         env_traces_dir=env_traces_dir,
         env_result_path=env_result_path,
         env_checkpoint_dir=env_checkpoint_dir,
+        env_metrics_path=env_metrics_path,
+        env_samples_path=env_samples_path,
     )
     # Stamp this driver's PID so a re-invocation of `evo run` can detect
     # whether the attempt is actually still in flight (the concurrent-run
@@ -3224,49 +3246,61 @@ def _cmd_run_impl(
         # Run benchmark via sh -c so the user-provided command string
         # (with placeholders interpolated) executes through a shell, same
         # semantics as before.
-        if benchmark_completed:
-            print(
-                f"RECOVERING {args.exp_id} attempt={attempt_n} "
-                f"phase={resume_phase} state={(resume_state or {}).get('status')}"
+        diff_refresher: _DiffRefresher | None = None
+        if not remote and not benchmark_completed:
+            diff_refresher = _DiffRefresher(
+                root, args.exp_id, attempt_n, parent_ref, worktree,
+                executor=executor,
+                exclude_patterns=config.get("diff_exclude_patterns"),
             )
-            bench = None
-        elif resume_journal:
-            print(
-                f"RECOVERING {args.exp_id} attempt={attempt_n} "
-                f"process={resume_journal['process_id']} "
-                f"state={resume_journal.get('state')}"
-            )
-            _write_attempt_state(
-                root, args.exp_id, attempt_n,
-                phase="benchmark", status="attaching", started_at=started_at,
-                extra={"process_id": resume_journal.get("process_id")},
-            )
-            bench = executor.attach(
-                str(resume_journal["process_id"]),
-                cmd=[str(part) for part in resume_journal["command"]],
-                cwd=str(resume_journal.get("cwd") or run_cwd),
-                env=env,
-                timeout=args.timeout,
-                stdout_path=benchmark_log,
-                stderr_path=benchmark_err,
-                mirror_remote_dir=sandbox_traces_dir if remote else None,
-                mirror_local_dir=traces_dir if remote else None,
-                mirror_dirs=[(sandbox_checkpoint_dir, checkpoint_dir)] if remote else None,
-                append=False,
-            )
-        else:
-            _write_attempt_state(
-                root, args.exp_id, attempt_n,
-                phase="benchmark", status="running", started_at=started_at,
-            )
-            bench = executor.stream(
-                ["sh", "-c", benchmark_cmd],
-                cwd=run_cwd, env=env, timeout=args.timeout,
-                stdout_path=benchmark_log, stderr_path=benchmark_err,
-                mirror_remote_dir=sandbox_traces_dir if remote else None,
-                mirror_local_dir=traces_dir if remote else None,
-                mirror_dirs=[(sandbox_checkpoint_dir, checkpoint_dir)] if remote else None,
-            )
+            diff_refresher.start()
+        try:
+            if benchmark_completed:
+                print(
+                    f"RECOVERING {args.exp_id} attempt={attempt_n} "
+                    f"phase={resume_phase} state={(resume_state or {}).get('status')}"
+                )
+                bench = None
+            elif resume_journal:
+                print(
+                    f"RECOVERING {args.exp_id} attempt={attempt_n} "
+                    f"process={resume_journal['process_id']} "
+                    f"state={resume_journal.get('state')}"
+                )
+                _write_attempt_state(
+                    root, args.exp_id, attempt_n,
+                    phase="benchmark", status="attaching", started_at=started_at,
+                    extra={"process_id": resume_journal.get("process_id")},
+                )
+                bench = executor.attach(
+                    str(resume_journal["process_id"]),
+                    cmd=[str(part) for part in resume_journal["command"]],
+                    cwd=str(resume_journal.get("cwd") or run_cwd),
+                    env=env,
+                    timeout=args.timeout,
+                    stdout_path=benchmark_log,
+                    stderr_path=benchmark_err,
+                    mirror_remote_dir=sandbox_traces_dir if remote else None,
+                    mirror_local_dir=traces_dir if remote else None,
+                    mirror_dirs=[(sandbox_checkpoint_dir, checkpoint_dir)] if remote else None,
+                    append=False,
+                )
+            else:
+                _write_attempt_state(
+                    root, args.exp_id, attempt_n,
+                    phase="benchmark", status="running", started_at=started_at,
+                )
+                bench = executor.stream(
+                    ["sh", "-c", benchmark_cmd],
+                    cwd=run_cwd, env=env, timeout=args.timeout,
+                    stdout_path=benchmark_log, stderr_path=benchmark_err,
+                    mirror_remote_dir=sandbox_traces_dir if remote else None,
+                    mirror_local_dir=traces_dir if remote else None,
+                    mirror_dirs=[(sandbox_checkpoint_dir, checkpoint_dir)] if remote else None,
+                )
+        finally:
+            if diff_refresher is not None:
+                diff_refresher.stop()
         if bench is not None and bench.timed_out:
             raise RuntimeError("benchmark_timeout")
         if bench is not None and (bench.exit_code or 0) != 0:
@@ -4559,6 +4593,78 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         else:
             print("[]")
             return 0
+    keys = [k.strip() for k in args.keys.split(",")] if args.keys else None
+    if args.tail:
+        fragment = b""
+        seen_size = 0
+        fragment = _print_metrics_lines(target, offset=0, fragment=b"", keys=keys)
+        seen_size = target.stat().st_size
+        try:
+            while True:
+                time.sleep(2)
+                current = target.stat().st_size
+                if current < seen_size:
+                    seen_size = 0
+                    fragment = b""
+                if current > seen_size:
+                    fragment = _print_metrics_lines(target, offset=seen_size, fragment=fragment, keys=keys)
+                    seen_size = current
+        except KeyboardInterrupt:
+            pass
+        return 0
+    _print_metrics_lines(target, offset=0, keys=keys)
+    return 0
+
+
+def _print_metrics_lines(path: Path, *, offset: int, fragment: bytes = b"", keys: list[str] | None = None) -> bytes:
+    """Read JSONL lines from path starting at offset, appending fragment.
+
+    Returns the new fragment (trailing incomplete line) for the next call.
+    If keys is provided, only output lines with those keys present.
+    """
+    size = path.stat().st_size
+    if offset >= size:
+        return fragment
+    with path.open("rb") as fh:
+        fh.seek(offset)
+        raw = fragment + fh.read()
+    if not raw:
+        return fragment
+
+    # Split on newlines; keep trailing incomplete line as fragment
+    parts = raw.split(b"\n")
+    # All but the last part are complete lines
+    for part in parts[:-1]:
+        line = part.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line.decode("utf-8", errors="replace"))
+            if keys is not None:
+                parsed = {k: parsed[k] for k in keys if k in parsed}
+            print(json.dumps(parsed))
+        except json.JSONDecodeError:
+            pass
+    # Last part is the incomplete fragment (or empty if raw ended with \n)
+    return parts[-1]
+
+
+def cmd_samples(args: argparse.Namespace) -> int:
+    """Read samples.jsonl from the latest attempt. With --tail, follow new lines."""
+    root = repo_root()
+    node = _read_node(root, args.exp_id)
+    attempt = int(node.get("current_attempt", 0))
+    if attempt == 0:
+        print("[]")
+        return 0
+    target = attempt_log_path(root, args.exp_id, attempt, "samples.jsonl")
+    if not target.exists():
+        fallback = Path(node.get("worktree", "")) / "samples.jsonl"
+        if fallback.exists():
+            target = fallback
+        else:
+            print("[]")
+            return 0
     if args.tail:
         fragment = b""
         seen_size = 0
@@ -4581,40 +4687,49 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
-def _print_metrics_lines(path: Path, *, offset: int, fragment: bytes = b"") -> bytes:
-    """Read JSONL lines from path starting at offset, appending fragment.
-
-    Returns the new fragment (trailing incomplete line) for the next call.
-    """
-    size = path.stat().st_size
-    if offset >= size:
-        return fragment
-    with path.open("rb") as fh:
-        fh.seek(offset)
-        raw = fragment + fh.read()
-    if not raw:
-        return fragment
-
-    # Split on newlines; keep trailing incomplete line as fragment
-    parts = raw.split(b"\n")
-    # All but the last part are complete lines
-    for part in parts[:-1]:
-        line = part.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line.decode("utf-8", errors="replace"))
-            print(json.dumps(parsed))
-        except json.JSONDecodeError:
-            pass
-    # Last part is the incomplete fragment (or empty if raw ended with \n)
-    return parts[-1]
+def cmd_checkpoints(args: argparse.Namespace) -> int:
+    """List checkpoint files from the latest attempt."""
+    root = repo_root()
+    node = _read_node(root, args.exp_id)
+    attempt = int(node.get("current_attempt", 0))
+    if attempt == 0:
+        print("[]")
+        return 0
+    ckpt_dir = attempt_dir(root, args.exp_id, attempt) / "checkpoints"
+    if not ckpt_dir.exists():
+        print("[]")
+        return 0
+    entries = []
+    for path in sorted(ckpt_dir.rglob("*")):
+        if path.is_file():
+            entries.append({
+                "path": str(path.relative_to(ckpt_dir)),
+                "size": path.stat().st_size,
+                "mtime": path.stat().st_mtime,
+            })
+    print(json.dumps(entries, indent=2))
+    return 0
 
 
 def cmd_annotate(args: argparse.Namespace) -> int:
     root = repo_root()
     entry = append_annotation(root, args.exp_id, args.task, args.analysis)
     print(json.dumps(entry, indent=2))
+    return 0
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    """Export an experiment as a self-contained HTML report."""
+    from .export_html import export_experiment_html
+
+    root = repo_root()
+    output = Path(args.output) if args.output else None
+    path = export_experiment_html(
+        root, args.exp_id,
+        output_path=output,
+        full=args.full,
+    )
+    print(str(path))
     return 0
 
 
@@ -6787,7 +6902,44 @@ def build_parser() -> argparse.ArgumentParser:
         "--tail", action="store_true",
         help="follow new lines every 2 seconds (like tail -f)",
     )
+    metrics_p.add_argument(
+        "--keys",
+        help="comma-separated list of keys to output (e.g. 'loss,lr,grad_norm')",
+    )
     metrics_p.set_defaults(func=cmd_metrics)
+
+    samples_p = sub.add_parser(
+        "samples",
+        help="live-training samples from samples.jsonl (text outputs, generations, ...)",
+    )
+    samples_p.add_argument("exp_id")
+    samples_p.add_argument(
+        "--tail", action="store_true",
+        help="follow new lines every 2 seconds (like tail -f)",
+    )
+    samples_p.set_defaults(func=cmd_samples)
+
+    checkpoints_p = sub.add_parser(
+        "checkpoints",
+        help="list checkpoint files from the current attempt",
+    )
+    checkpoints_p.add_argument("exp_id")
+    checkpoints_p.set_defaults(func=cmd_checkpoints)
+
+    export_p = sub.add_parser(
+        "export",
+        help="export an experiment as a self-contained HTML report",
+    )
+    export_p.add_argument("exp_id")
+    export_p.add_argument(
+        "--output", "-o",
+        help="output path for the HTML file (default: <exp_dir>/report.html)",
+    )
+    export_p.add_argument(
+        "--full", action="store_true",
+        help="include all log lines (default: last 50k lines)",
+    )
+    export_p.set_defaults(func=cmd_export)
 
     annotate_p = sub.add_parser("annotate")
     annotate_p.add_argument("exp_id")

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -4524,6 +4524,74 @@ def cmd_traces(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_metrics(args: argparse.Namespace) -> int:
+    """Read metrics.jsonl from the latest attempt. With --tail, follow new lines."""
+    root = repo_root()
+    node = _read_node(root, args.exp_id)
+    attempt = int(node.get("current_attempt", 0))
+    if attempt == 0:
+        print("[]")
+        return 0
+    target = attempt_log_path(root, args.exp_id, attempt, "metrics.jsonl")
+    if not target.exists():
+        fallback = Path(node.get("worktree", "")) / "metrics.jsonl"
+        if fallback.exists():
+            target = fallback
+        else:
+            print("[]")
+            return 0
+    if args.tail:
+        fragment = b""
+        seen_size = 0
+        fragment = _print_metrics_lines(target, offset=0, fragment=b"")
+        seen_size = target.stat().st_size
+        try:
+            while True:
+                time.sleep(2)
+                current = target.stat().st_size
+                if current < seen_size:
+                    seen_size = 0
+                    fragment = b""
+                if current > seen_size:
+                    fragment = _print_metrics_lines(target, offset=seen_size, fragment=fragment)
+                    seen_size = current
+        except KeyboardInterrupt:
+            pass
+        return 0
+    _print_metrics_lines(target, offset=0)
+    return 0
+
+
+def _print_metrics_lines(path: Path, *, offset: int, fragment: bytes = b"") -> bytes:
+    """Read JSONL lines from path starting at offset, appending fragment.
+
+    Returns the new fragment (trailing incomplete line) for the next call.
+    """
+    size = path.stat().st_size
+    if offset >= size:
+        return fragment
+    with path.open("rb") as fh:
+        fh.seek(offset)
+        raw = fragment + fh.read()
+    if not raw:
+        return fragment
+
+    # Split on newlines; keep trailing incomplete line as fragment
+    parts = raw.split(b"\n")
+    # All but the last part are complete lines
+    for part in parts[:-1]:
+        line = part.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line.decode("utf-8", errors="replace"))
+            print(json.dumps(parsed))
+        except json.JSONDecodeError:
+            pass
+    # Last part is the incomplete fragment (or empty if raw ended with \n)
+    return parts[-1]
+
+
 def cmd_annotate(args: argparse.Namespace) -> int:
     root = repo_root()
     entry = append_annotation(root, args.exp_id, args.task, args.analysis)

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -6,6 +6,7 @@ import re
 import secrets
 import subprocess
 import tempfile
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -976,6 +977,72 @@ def capture_experiment_diff(
             f"{result.stderr[:500]}"
         )
     return result.stdout
+
+
+class _DiffRefresher:
+    """Background thread that periodically refreshes diff.patch in the attempt dir.
+
+    During long-running benchmarks the worktree may evolve (e.g. the agent
+    edits more files). This thread rewrites ``attempt_dir / "diff.patch"``
+    every ``interval`` seconds so the dashboard can serve a near-live view
+    of the current diff without polling the sandbox.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        exp_id: str,
+        attempt: int,
+        parent_ref: str,
+        worktree: Path,
+        *,
+        executor: Any = None,
+        interval: float = 5.0,
+        exclude_patterns: list[str] | tuple[str, ...] | None = None,
+    ) -> None:
+        from .workspace_executor import LocalExecutor
+
+        self._root = root
+        self._exp_id = exp_id
+        self._attempt = attempt
+        self._parent_ref = parent_ref
+        self._worktree = worktree
+        self._executor = executor or LocalExecutor()
+        self._interval = interval
+        self._exclude_patterns = exclude_patterns
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True, name="diff-refresher")
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def _run(self) -> None:
+        a_dir = attempt_dir(self._root, self._exp_id, self._attempt)
+        target = a_dir / "diff.patch"
+        while not self._stop.is_set():
+            try:
+                text = capture_experiment_diff(
+                    self._root,
+                    self._exp_id,
+                    self._attempt,
+                    self._parent_ref,
+                    self._worktree,
+                    executor=self._executor,
+                    exclude_patterns=self._exclude_patterns,
+                )
+                target.write_text(text, encoding="utf-8")
+            except Exception:
+                pass  # best-effort; don't crash the driver
+            self._stop.wait(self._interval)
 
 
 def fill_command_template(template: str, *, target: Path, worktree: Path) -> str:

--- a/plugins/evo/src/evo/dashboard.py
+++ b/plugins/evo/src/evo/dashboard.py
@@ -15,6 +15,7 @@ from .core import (
     _load_meta,
     _save_meta,
     attempt_dir,
+    attempt_log_path,
     attempt_outcome_path,
     attempt_traces_dir,
     best_committed_score,
@@ -1266,6 +1267,95 @@ def create_app(root: Path | None = None) -> Flask:
             "skipped_subagent": skipped_subagent,
             "from_exp_id": from_exp,
         })
+
+    @app.get("/api/node/<exp_id>/metrics-tail")
+    def node_metrics_tail(exp_id: str):
+        attempt = _latest_attempt_n(_root(), exp_id)
+        if attempt is None:
+            return jsonify({"attempt": None, "lines": []})
+        target = attempt_log_path(_root(), exp_id, attempt, "metrics.jsonl")
+        if not target.exists():
+            return jsonify({"attempt": attempt, "lines": []})
+        try:
+            offset = int(request.args.get("offset", "0"))
+        except ValueError:
+            offset = 0
+        size = target.stat().st_size
+        with target.open("rb") as fh:
+            fh.seek(min(offset, size))
+            raw = fh.read()
+        lines = []
+        for line in raw.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    lines.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        resp = jsonify({"attempt": attempt, "lines": lines, "offset": size})
+        return resp
+
+    @app.get("/api/node/<exp_id>/samples-tail")
+    def node_samples_tail(exp_id: str):
+        attempt = _latest_attempt_n(_root(), exp_id)
+        if attempt is None:
+            return jsonify({"attempt": None, "lines": []})
+        target = attempt_log_path(_root(), exp_id, attempt, "samples.jsonl")
+        if not target.exists():
+            return jsonify({"attempt": attempt, "lines": []})
+        try:
+            offset = int(request.args.get("offset", "0"))
+        except ValueError:
+            offset = 0
+        size = target.stat().st_size
+        with target.open("rb") as fh:
+            fh.seek(min(offset, size))
+            raw = fh.read()
+        lines = []
+        for line in raw.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    lines.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        resp = jsonify({"attempt": attempt, "lines": lines, "offset": size})
+        return resp
+
+    @app.get("/api/node/<exp_id>/checkpoints")
+    def node_checkpoints(exp_id: str):
+        attempt = _latest_attempt_n(_root(), exp_id)
+        if attempt is None:
+            return jsonify({"attempt": None, "files": []})
+        ckpt_dir = attempt_dir(_root(), exp_id, attempt) / "checkpoints"
+        if not ckpt_dir.exists():
+            return jsonify({"attempt": attempt, "files": []})
+        files = []
+        for path in sorted(ckpt_dir.rglob("*")):
+            if path.is_file():
+                files.append({
+                    "path": str(path.relative_to(ckpt_dir)),
+                    "size": path.stat().st_size,
+                    "mtime": path.stat().st_mtime,
+                })
+        return jsonify({"attempt": attempt, "files": files})
+
+    @app.get("/api/node/<exp_id>/live-diff")
+    def node_live_diff(exp_id: str):
+        attempt = _latest_attempt_n(_root(), exp_id)
+        if attempt is None:
+            return jsonify({"attempt": None, "diff": ""})
+        diff_path = attempt_dir(_root(), exp_id, attempt) / "diff.patch"
+        diff_text = diff_path.read_text(encoding="utf-8") if diff_path.exists() else ""
+        return jsonify({"attempt": attempt, "diff": diff_text})
+
+    @app.get("/api/node/<exp_id>/export-html")
+    def node_export_html(exp_id: str):
+        from .export_html import export_experiment_html
+        root = _root()
+        output = experiments_dir_for(root, exp_id) / "report.html"
+        path = export_experiment_html(root, exp_id, output_path=output)
+        return send_from_directory(str(path.parent), path.name, mimetype="text/html")
 
     return app
 

--- a/plugins/evo/src/evo/dashboard.py
+++ b/plugins/evo/src/evo/dashboard.py
@@ -61,6 +61,28 @@ def _redact_value(value: Any, *, key: str | None = None) -> Any:
     return value
 
 
+def _read_attempt_state(root: Path, exp_id: str, attempt: int) -> dict | None:
+    path = attempt_dir(root, exp_id, attempt) / "attempt_state.json"
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _latest_attempt_on_disk(root: Path, exp_id: str) -> int | None:
+    exp_root = experiments_dir_for(root, exp_id) / "attempts"
+    if not exp_root.exists():
+        return None
+    candidates = sorted(
+        (int(p.name) for p in exp_root.iterdir() if p.is_dir() and p.name.isdigit()),
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
 def _public_node(
     root: Path,
     node: dict[str, Any],
@@ -97,6 +119,22 @@ def _public_node(
         blocker = lineage_invalidated_by(graph, node.get("id", ""))
         public["lineage_blocked_by"] = blocker.get("id") if blocker else None
         public["lineage_blocked_reason"] = blocker.get("pruned_reason") if blocker else None
+
+    if public.get("status") == "active":
+        exp_id = node.get("id", "")
+        attempt_n = _latest_attempt_on_disk(root, exp_id)
+        if attempt_n is not None:
+            state = _read_attempt_state(root, exp_id, attempt_n)
+            if state is not None:
+                public["active_attempt"] = {
+                    "n": attempt_n,
+                    "phase": state.get("phase"),
+                    "status": state.get("status"),
+                    "started_at": state.get("started_at"),
+                    "updated_at": state.get("updated_at"),
+                    "pid": state.get("pid"),
+                }
+
     return public
 
 
@@ -948,7 +986,7 @@ def create_app(root: Path | None = None) -> Flask:
         if dirpath.exists():
             # Surface .log and .out at the attempt root and one level under
             # logs/ (the convention training scripts typically use).
-            patterns = ["*.log", "*.out", "logs/*.log", "logs/*.out"]
+            patterns = ["*.log", "*.out", "*.jsonl", "logs/*.log", "logs/*.out", "logs/*.jsonl"]
             seen: set[Path] = set()
             for pat in patterns:
                 for p in sorted(dirpath.glob(pat)):

--- a/plugins/evo/src/evo/export_html.py
+++ b/plugins/evo/src/evo/export_html.py
@@ -1,0 +1,299 @@
+"""HTML export for evo experiments.
+
+Generates a self-contained HTML report for an experiment with live dashboard
+state, metrics, samples, checkpoints, and diff.
+"""
+
+from __future__ import annotations
+
+import json
+import html
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _escape(text: str) -> str:
+    return html.escape(text, quote=True)
+
+
+def _format_score(score: float | None) -> str:
+    if score is None:
+        return "N/A"
+    return f"{score:.6f}"
+
+
+def _render_metrics_table(metrics: list[dict]) -> str:
+    if not metrics:
+        return "<p>No metrics recorded yet.</p>"
+    # Collect all unique keys
+    all_keys: set[str] = set()
+    for m in metrics:
+        all_keys.update(m.keys())
+    keys = sorted(all_keys)
+    rows = []
+    for m in metrics:
+        cells = "".join(f"<td>{_escape(str(m.get(k, '')))}</td>" for k in keys)
+        rows.append(f"<tr>{cells}</tr>")
+    header = "".join(f"<th>{_escape(k)}</th>" for k in keys)
+    return f"""
+    <table class="metrics">
+      <thead><tr>{header}</tr></thead>
+      <tbody>{''.join(rows)}</tbody>
+    </table>
+    """
+
+
+def _render_samples(samples: list[dict], max_lines: int = 50) -> str:
+    if not samples:
+        return "<p>No samples recorded yet.</p>"
+    lines = []
+    for s in samples[:max_lines]:
+        text = s.get("text") or s.get("output") or json.dumps(s)
+        lines.append(f"<pre>{_escape(text)}</pre>")
+    if len(samples) > max_lines:
+        lines.append(f"<p>... and {len(samples) - max_lines} more samples</p>")
+    return "\n".join(lines)
+
+
+def _render_checkpoints(checkpoints: list[dict]) -> str:
+    if not checkpoints:
+        return "<p>No checkpoints recorded yet.</p>"
+    items = []
+    for ckpt in checkpoints:
+        size = ckpt.get("size", 0)
+        if size > 1024 * 1024:
+            size_str = f"{size / (1024 * 1024):.1f} MB"
+        elif size > 1024:
+            size_str = f"{size / 1024:.1f} KB"
+        else:
+            size_str = f"{size} B"
+        items.append(f"<li><code>{_escape(ckpt.get('path', ''))}</code> ({size_str})</li>")
+    return "<ul>" + "\n".join(items) + "</ul>"
+
+
+def _render_diff(diff_text: str, max_lines: int = 500) -> str:
+    if not diff_text.strip():
+        return "<p>No diff available.</p>"
+    lines = diff_text.splitlines()
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines.append(f"... ({len(diff_text.splitlines()) - max_lines} more lines)")
+    return f"<pre class='diff'>{''.join(html.escape(l) + '\\n' for l in lines)}</pre>"
+
+
+def export_experiment_html(
+    root: Path,
+    exp_id: str,
+    *,
+    output_path: Path | None = None,
+    max_log_lines: int = 50_000,
+    full: bool = False,
+) -> Path:
+    """Generate a self-contained HTML report for an experiment.
+
+    Args:
+        root: Workspace root path.
+        exp_id: Experiment ID.
+        output_path: Where to write the HTML file. Defaults to <exp_dir>/report.html.
+        max_log_lines: Max lines from log files to include (default 50k).
+        full: If True, include all log lines (ignore max_log_lines).
+
+    Returns:
+        Path to the generated HTML file.
+    """
+    from .core import (
+        attempt_dir,
+        attempt_log_path,
+        attempt_traces_dir,
+        experiments_dir_for,
+        load_config,
+        load_graph,
+    )
+
+    config = load_config(root)
+    graph = load_graph(root)
+    node = graph["nodes"].get(exp_id)
+    if node is None:
+        raise ValueError(f"Unknown experiment: {exp_id}")
+
+    attempt = int(node.get("current_attempt", 0))
+    exp_dir = experiments_dir_for(root, exp_id)
+    a_dir = attempt_dir(root, exp_id, attempt) if attempt > 0 else exp_dir
+
+    # Collect data
+    metrics: list[dict] = []
+    samples: list[dict] = []
+    checkpoints: list[dict] = []
+    diff_text = ""
+    benchmark_log = ""
+    stderr_log = ""
+    traces: dict[str, Any] = {}
+
+    if attempt > 0:
+        # Metrics
+        metrics_path = attempt_log_path(root, exp_id, attempt, "metrics.jsonl")
+        if metrics_path.exists():
+            for line in metrics_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = line.strip()
+                if line:
+                    try:
+                        metrics.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+
+        # Samples
+        samples_path = attempt_log_path(root, exp_id, attempt, "samples.jsonl")
+        if samples_path.exists():
+            for line in samples_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = line.strip()
+                if line:
+                    try:
+                        samples.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+
+        # Checkpoints
+        ckpt_dir = a_dir / "checkpoints"
+        if ckpt_dir.exists():
+            for path in sorted(ckpt_dir.rglob("*")):
+                if path.is_file():
+                    checkpoints.append({
+                        "path": str(path.relative_to(ckpt_dir)),
+                        "size": path.stat().st_size,
+                        "mtime": path.stat().st_mtime,
+                    })
+
+        # Diff
+        diff_path = a_dir / "diff.patch"
+        if diff_path.exists():
+            diff_text = diff_path.read_text(encoding="utf-8", errors="replace")
+
+        # Benchmark log
+        log_path = a_dir / "benchmark.log"
+        if log_path.exists():
+            text = log_path.read_text(encoding="utf-8", errors="replace")
+            if not full:
+                lines = text.splitlines()
+                if len(lines) > max_log_lines:
+                    text = "\n".join(lines[-max_log_lines:])
+                    text = f"... ({len(lines) - max_log_lines} lines truncated)\n{text}"
+            benchmark_log = text
+
+        # Stderr log
+        err_path = a_dir / "stderr.log"
+        if err_path.exists():
+            text = err_path.read_text(encoding="utf-8", errors="replace")
+            if not full:
+                lines = text.splitlines()
+                if len(lines) > max_log_lines:
+                    text = "\n".join(lines[-max_log_lines:])
+                    text = f"... ({len(lines) - max_log_lines} lines truncated)\n{text}"
+            stderr_log = text
+
+        # Traces
+        traces_dir = attempt_traces_dir(root, exp_id, attempt)
+        if traces_dir.exists():
+            for path in sorted(traces_dir.glob("*.json")):
+                try:
+                    traces[path.name] = json.loads(path.read_text(encoding="utf-8"))
+                except Exception:
+                    pass
+
+    # Render HTML
+    metric = config.get("metric", "max")
+    score = node.get("score")
+    status = node.get("status", "unknown")
+    hypothesis = node.get("hypothesis", "")
+    parent = node.get("parent", "")
+    created_at = node.get("created_at", "")
+    updated_at = node.get("updated_at", "")
+
+    traces_html = ""
+    for name, trace in traces.items():
+        traces_html += f"<h4>{_escape(name)}</h4><pre>{_escape(json.dumps(trace, indent=2))}</pre>"
+
+    html_content = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>evo: {_escape(exp_id)} - {_escape(status)}</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 2em; background: #fafafa; color: #333; }}
+  h1 {{ border-bottom: 2px solid #4a9eff; padding-bottom: 0.5em; }}
+  h2 {{ color: #555; margin-top: 2em; }}
+  .meta {{ display: grid; grid-template-columns: 1fr 1fr; gap: 1em; margin: 1em 0; }}
+  .meta dt {{ font-weight: bold; color: #666; }}
+  .meta dd {{ margin: 0; }}
+  .status {{ display: inline-block; padding: 0.25em 0.75em; border-radius: 4px; font-weight: bold; }}
+  .status.committed {{ background: #d4edda; color: #155724; }}
+  .status.evaluated {{ background: #fff3cd; color: #856404; }}
+  .status.active {{ background: #cce5ff; color: #004085; }}
+  .status.failed {{ background: #f8d7da; color: #721c24; }}
+  table.metrics {{ border-collapse: collapse; width: 100%; margin: 1em 0; }}
+  table.metrics th, table.metrics td {{ border: 1px solid #ddd; padding: 0.5em; text-align: left; }}
+  table.metrics th {{ background: #f5f5f5; }}
+  pre {{ background: #f8f9fa; padding: 1em; overflow-x: auto; border-radius: 4px; }}
+  pre.diff {{ background: #fff; }}
+  .section {{ background: white; border: 1px solid #e0e0e0; border-radius: 8px; padding: 1.5em; margin: 1.5em 0; }}
+</style>
+</head>
+<body>
+<h1>evo: {_escape(exp_id)}</h1>
+<div class="section">
+  <dl class="meta">
+    <dt>Status</dt><dd><span class="status {_escape(status)}">{_escape(status)}</span></dd>
+    <dt>Score ({_escape(metric)})</dt><dd>{_format_score(score)}</dd>
+    <dt>Attempt</dt><dd>{attempt}</dd>
+    <dt>Hypothesis</dt><dd>{_escape(hypothesis)}</dd>
+    <dt>Parent</dt><dd>{_escape(parent)}</dd>
+    <dt>Created</dt><dd>{_escape(created_at)}</dd>
+    <dt>Updated</dt><dd>{_escape(updated_at)}</dd>
+  </dl>
+</div>
+
+<div class="section">
+  <h2>Metrics ({len(metrics)} lines)</h2>
+  {_render_metrics_table(metrics)}
+</div>
+
+<div class="section">
+  <h2>Samples ({len(samples)} lines)</h2>
+  {_render_samples(samples)}
+</div>
+
+<div class="section">
+  <h2>Checkpoints ({len(checkpoints)} files)</h2>
+  {_render_checkpoints(checkpoints)}
+</div>
+
+<div class="section">
+  <h2>Diff</h2>
+  {_render_diff(diff_text)}
+</div>
+
+<div class="section">
+  <h2>Benchmark Log</h2>
+  <pre>{_escape(benchmark_log) if benchmark_log else '<em>Empty</em>'}</pre>
+</div>
+
+<div class="section">
+  <h2>Stderr Log</h2>
+  <pre>{_escape(stderr_log) if stderr_log else '<em>Empty</em>'}</pre>
+</div>
+
+<div class="section">
+  <h2>Traces</h2>
+  {traces_html if traces_html else '<p>No traces recorded yet.</p>'}
+</div>
+
+<hr>
+<p style="color:#999; font-size:0.9em;">Generated by evo at {datetime.now(timezone.utc).isoformat()}</p>
+</body>
+</html>"""
+
+    if output_path is None:
+        output_path = exp_dir / "report.html"
+    output_path.write_text(html_content, encoding="utf-8")
+    return output_path

--- a/plugins/evo/src/evo/static/app.js
+++ b/plugins/evo/src/evo/static/app.js
@@ -2202,6 +2202,10 @@ async function openDrawer(expId, opts) {
       detail = `<div class="drawer-summary-detail">${esc(node.discard_reason)}</div>`;
     } else if (isFrontierCandidate(node)) {
       detail = `<div class="drawer-summary-detail accent">Frontier candidate — evo may branch from this node next.</div>`;
+    } else if (node.status === 'active' && node.active_attempt) {
+      const a = node.active_attempt;
+      const phaseLabel = a.phase || 'running';
+      detail = `<div class="drawer-summary-detail accent">Attempt ${a.n} — ${esc(phaseLabel)}${a.updated_at ? ' · ' + esc(relTime(a.updated_at)) + ' ago' : ''}</div>`;
     }
     html += `<div class="drawer-section drawer-summary">
       <div class="drawer-score-row">
@@ -2258,6 +2262,7 @@ async function openDrawer(expId, opts) {
       <div class="drawer-meta-row"><span class="drawer-meta-key">Epoch</span><span class="drawer-meta-val">${esc(node.eval_epoch || '--')}</span></div>
       <div class="drawer-meta-row"><span class="drawer-meta-key">Backend</span><span class="drawer-meta-val mono">${esc(backendLabel(node.resolved_backend || ws.default_backend))}</span></div>
       <div class="drawer-meta-row"><span class="drawer-meta-key">Created</span><span class="drawer-meta-val">${esc(relTime(node.created_at))} ago</span></div>
+      ${node.active_attempt ? `<div class="drawer-meta-row"><span class="drawer-meta-key">Attempt</span><span class="drawer-meta-val mono">${esc(node.active_attempt.phase || 'running')} (#${node.active_attempt.n})</span></div>` : ''}
       ${node.children?.length ? `<div class="drawer-meta-row"><span class="drawer-meta-key">Children</span><span class="drawer-meta-val mono" style="color:var(--indigo)">${node.children.length}</span></div>` : ''}
     </div>
     ${renderBackendSection(node, ws)}

--- a/plugins/evo/src/evo/static/app.js
+++ b/plugins/evo/src/evo/static/app.js
@@ -2142,7 +2142,7 @@ async function openDrawer(expId, opts) {
   const deltaColor = deltaColorFor(delta);
   const statusColor = statusColorForNode(node);
   const hasChildren = (node.children || []).length > 0;
-  const activeTab = ['summary', 'diff', 'tasks', 'logs'].includes(state.sidebarTab)
+  const activeTab = ['summary', 'diff', 'tasks', 'logs', 'live'].includes(state.sidebarTab)
     ? state.sidebarTab
     : 'summary';
   // Drives the diff-tab fill layout in CSS (.sidebar[data-tab="diff"]).
@@ -2173,6 +2173,7 @@ async function openDrawer(expId, opts) {
       ${drawerTabButton('diff', 'Diff', activeTab)}
       ${drawerTabButton('tasks', 'Tasks', activeTab)}
       ${drawerTabButton('logs', 'Logs', activeTab)}
+      ${(node.status === 'active' && node.active_attempt) ? drawerTabButton('live', 'Live', activeTab) : ''}
     </div>`;
 
   if (activeTab === 'summary') {
@@ -2456,6 +2457,16 @@ async function openDrawer(expId, opts) {
         <pre id="logs-tail" class="logs-pane">Loading...</pre>
       </div>`;
     }
+  } else if (activeTab === 'live') {
+    const a = node.active_attempt;
+    if (a) {
+      html += `<div class="drawer-section">
+        <span class="drawer-section-title">Attempt ${a.n} — ${esc(a.phase || 'running')}</span>
+        <div class="sidebar-empty">Fetching live data...</div>
+      </div>`;
+    } else {
+      html += `<div class="drawer-section"><div class="sidebar-empty">No active attempt.</div></div>`;
+    }
   }
 
   if (isStale()) return;
@@ -2478,6 +2489,8 @@ async function openDrawer(expId, opts) {
       refreshLogsTail(true);
       if (state.logsAutoRefresh) startLogsAutorefresh(expId);
     }
+  } else if (activeTab === 'live') {
+    loadLiveTab(expId);
   }
 }
 
@@ -2485,6 +2498,112 @@ function formatBytes(n) {
   if (n < 1024) return `${n}B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
   return `${(n / 1024 / 1024).toFixed(1)}MB`;
+}
+
+// Live tab: fetch and render the 5 sub-panels for an active experiment.
+async function loadLiveTab(expId) {
+  const section = document.querySelector('.drawer-section');
+  if (!section) return;
+  try {
+    const [metricsRes, samplesRes, checkpointsRes, diffRes] = await Promise.all([
+      fetch(`/api/node/${expId}/metrics-tail`).then(r => r.json()).catch(() => ({lines: [], offset: 0})),
+      fetch(`/api/node/${expId}/samples-tail`).then(r => r.json()).catch(() => ({lines: [], offset: 0})),
+      fetch(`/api/node/${expId}/checkpoints`).then(r => r.json()).catch(() => ({files: []})),
+      fetch(`/api/node/${expId}/live-diff`).then(r => r.json()).catch(() => ({diff: ''})),
+    ]);
+
+    // Metrics sparklines
+    let metricsHtml = '<div class="live-metrics">';
+    if (metricsRes.lines.length > 0) {
+      const allKeys = new Set();
+      metricsRes.lines.forEach(m => Object.keys(m).forEach(k => allKeys.add(k)));
+      const keys = [...allKeys].sort();
+      for (const key of keys) {
+        const values = metricsRes.lines.map(m => m[key]).filter(v => typeof v === 'number');
+        if (values.length === 0) continue;
+        const last = values[values.length - 1];
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const range = max - min || 1;
+        // Simple ASCII sparkline
+        const sparkChars = '▁▂▃▄▅▆▇█';
+        const sparkLen = Math.min(values.length, 50);
+        const sampled = values.length > sparkLen
+          ? values.filter((_, i) => i % Math.ceil(values.length / sparkLen) === 0)
+          : values;
+        const spark = sampled.map(v => {
+          const idx = Math.round(((v - min) / range) * (sparkChars.length - 1));
+          return `<span style="opacity:${0.5 + (idx / (sparkChars.length - 1)) * 0.5}">${sparkChars[idx]}</span>`;
+        }).join('');
+        metricsHtml += `<div class="live-metric-row"><span class="live-metric-key">${esc(key)}</span><span class="live-metric-spark">${spark}</span><span class="live-metric-val">${last.toFixed(4)}</span></div>`;
+      }
+      metricsHtml += `<div style="font-size:11px;color:var(--text-5);margin-top:4px">${metricsRes.lines.length} lines</div>`;
+    } else {
+      metricsHtml += '<div class="sidebar-empty">Waiting for metrics...</div>';
+    }
+    metricsHtml += '</div>';
+
+    // Samples preview
+    let samplesHtml = '<div class="live-samples">';
+    if (samplesRes.lines.length > 0) {
+      const last3 = samplesRes.lines.slice(-3);
+      for (const s of last3) {
+        const text = s.text || s.output || JSON.stringify(s);
+        samplesHtml += `<pre class="live-sample">${esc(String(text).substring(0, 500))}</pre>`;
+      }
+      if (samplesRes.lines.length > 3) {
+        samplesHtml += `<div style="font-size:11px;color:var(--text-5)">+${samplesRes.lines.length - 3} more</div>`;
+      }
+    } else {
+      samplesHtml += '<div class="sidebar-empty">Waiting for samples...</div>';
+    }
+    samplesHtml += '</div>';
+
+    // Checkpoints
+    let ckptHtml = '<div class="live-checkpoints">';
+    if (checkpointsRes.files.length > 0) {
+      for (const f of checkpointsRes.files.slice(-5)) {
+        ckptHtml += `<div class="live-ckpt"><code>${esc(f.path)}</code> <span style="color:var(--text-5)">${formatBytes(f.size)}</span></div>`;
+      }
+    } else {
+      ckptHtml += '<div class="sidebar-empty">No checkpoints yet</div>';
+    }
+    ckptHtml += '</div>';
+
+    // Diff
+    let diffHtml = '<div class="live-diff">';
+    if (diffRes.diff) {
+      const lines = diffRes.diff.split('\n').slice(0, 30);
+      diffHtml += `<pre class="live-diff-pre">${esc(lines.join('\n'))}</pre>`;
+      if (diffRes.diff.split('\n').length > 30) {
+        diffHtml += `<div style="font-size:11px;color:var(--text-5)">... ${diffRes.diff.split('\n').length - 30} more lines</div>`;
+      }
+    } else {
+      diffHtml += '<div class="sidebar-empty">No diff yet</div>';
+    }
+    diffHtml += '</div>';
+
+    section.innerHTML = `
+      <div class="drawer-section-title">Live Dashboard</div>
+      <div class="live-panel">
+        <div class="live-subpanel"><div class="live-subpanel-title">Metrics</div>${metricsHtml}</div>
+        <div class="live-subpanel"><div class="live-subpanel-title">Samples</div>${samplesHtml}</div>
+        <div class="live-subpanel"><div class="live-subpanel-title">Checkpoints</div>${ckptHtml}</div>
+        <div class="live-subpanel"><div class="live-subpanel-title">Diff</div>${diffHtml}</div>
+      </div>
+    `;
+
+    // Auto-refresh every 5 seconds
+    if (state.sidebarTab === 'live' && state.selectedNode === expId) {
+      setTimeout(() => {
+        if (state.sidebarTab === 'live' && state.selectedNode === expId) {
+          loadLiveTab(expId);
+        }
+      }, 5000);
+    }
+  } catch (e) {
+    section.innerHTML = `<div class="sidebar-empty">Error loading live data: ${esc(e.message)}</div>`;
+  }
 }
 
 // Strip ANSI escape codes from log output for readable rendering.
@@ -2648,7 +2767,7 @@ function drawerTabButton(tab, label, activeTab) {
 }
 
 function setSidebarTab(tab) {
-  if (!['summary', 'diff', 'tasks', 'logs'].includes(tab)) return;
+  if (!['summary', 'diff', 'tasks', 'logs', 'live'].includes(tab)) return;
   state.sidebarTab = tab;
   // Stop log-tail polling when navigating away from the Logs tab.
   if (tab !== 'logs') stopLogsAutorefresh();

--- a/plugins/evo/src/evo/static/style.css
+++ b/plugins/evo/src/evo/static/style.css
@@ -3304,3 +3304,99 @@ body {
   .left-rail { width: 190px; }
   .sidebar { width: 360px; }
 }
+
+/* Live tab styles */
+.live-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.live-subpanel {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 12px;
+  background: var(--bg-canvas);
+}
+.live-subpanel-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-2);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.live-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.live-metric-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.live-metric-key {
+  color: var(--text-2);
+  font-family: 'JetBrains Mono', monospace;
+  min-width: 80px;
+}
+.live-metric-spark {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  letter-spacing: -1px;
+}
+.live-metric-val {
+  color: var(--text-1);
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+}
+.live-samples {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.live-sample {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  padding: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  max-height: 100px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+.live-checkpoints {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.live-ckpt {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.live-ckpt code {
+  font-family: 'JetBrains Mono', monospace;
+}
+.live-diff {
+  max-height: 300px;
+  overflow: auto;
+}
+.live-diff-pre {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  padding: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}

--- a/tests/unit/test_active_attempt.py
+++ b/tests/unit/test_active_attempt.py
@@ -1,0 +1,108 @@
+"""Tests for the active attempt and new CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evo.core import (
+    attempt_dir,
+    attempt_log_path,
+    experiment_log_path,
+    experiments_dir_for,
+    graph_path,
+    init_workspace,
+    load_config,
+    load_graph,
+    update_node,
+)
+
+
+class TestActiveAttemptDir:
+    def test_pre_created_files(self, tmp_path: Path) -> None:
+        root = tmp_path / "workspace"
+        init_workspace(
+            root,
+            target="train.py",
+            benchmark="python eval.py",
+            metric="max",
+            gate=None,
+            host="generic",
+            per_exp_timeout=3600,
+        )
+        exp_id = "exp_0001"
+        a_dir = attempt_dir(root, exp_id, 1)
+        a_dir.mkdir(parents=True, exist_ok=True)
+        # Simulate what _cmd_run_impl does
+        metrics_path = a_dir / "metrics.jsonl"
+        samples_path = a_dir / "samples.jsonl"
+        stderr_log_path = a_dir / "stderr.log"
+        for p in (metrics_path, samples_path, stderr_log_path):
+            p.touch(exist_ok=True)
+        assert metrics_path.exists()
+        assert samples_path.exists()
+        assert stderr_log_path.exists()
+
+    def test_attempt_log_path(self, tmp_path: Path) -> None:
+        root = tmp_path / "workspace"
+        init_workspace(
+            root,
+            target="train.py",
+            benchmark="python eval.py",
+            metric="max",
+            gate=None,
+            host="generic",
+            per_exp_timeout=3600,
+        )
+        exp_id = "exp_0001"
+        path = attempt_log_path(root, exp_id, 1, "metrics.jsonl")
+        expected = attempt_dir(root, exp_id, 1) / "metrics.jsonl"
+        assert path == expected
+
+
+class TestPrintMetricsLines:
+    def test_filters_keys(self, tmp_path: Path) -> None:
+        from evo.cli import _print_metrics_lines
+        metrics_file = tmp_path / "metrics.jsonl"
+        metrics_file.write_text(
+            '{"loss": 0.5, "lr": 0.001, "epoch": 1}\n{"loss": 0.3, "lr": 0.0005, "epoch": 2}\n',
+            encoding="utf-8",
+        )
+        import io
+        import sys
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            fragment = _print_metrics_lines(metrics_file, offset=0, keys=["loss", "lr"])
+        finally:
+            sys.stdout = sys.__stdout__
+        output = captured.getvalue().strip()
+        lines = output.split("\n")
+        assert len(lines) == 2
+        parsed = [json.loads(line) for line in lines]
+        assert all("loss" in p for p in parsed)
+        assert all("lr" in p for p in parsed)
+        assert all("epoch" not in p for p in parsed)
+
+    def test_incomplete_line_handling(self, tmp_path: Path) -> None:
+        from evo.cli import _print_metrics_lines
+        metrics_file = tmp_path / "metrics.jsonl"
+        metrics_file.write_text(
+            '{"loss": 0.5}\n{"loss": 0.3',
+            encoding="utf-8",
+        )
+        import io
+        import sys
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            fragment = _print_metrics_lines(metrics_file, offset=0)
+        finally:
+            sys.stdout = sys.__stdout__
+        output = captured.getvalue().strip()
+        lines = output.split("\n")
+        assert len(lines) == 1  # only complete line
+        assert json.loads(lines[0]) == {"loss": 0.5}
+        assert fragment == b'{"loss": 0.3'

--- a/tests/unit/test_diff_refresher.py
+++ b/tests/unit/test_diff_refresher.py
@@ -1,0 +1,82 @@
+"""Tests for the _DiffRefresher background thread."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evo.core import _DiffRefresher, attempt_dir
+
+
+class TestDiffRefresher:
+    def test_stop_sets_event(self, tmp_path: Path) -> None:
+        refresher = _DiffRefresher(
+            tmp_path,
+            "exp_0001",
+            1,
+            "abc123",
+            tmp_path / "worktree",
+        )
+        assert not refresher._stop.is_set()
+        refresher.stop(timeout=0.1)
+        assert refresher._stop.is_set()
+
+    def test_start_creates_thread(self, tmp_path: Path) -> None:
+        refresher = _DiffRefresher(
+            tmp_path,
+            "exp_0001",
+            1,
+            "abc123",
+            tmp_path / "worktree",
+            interval=100,  # long interval so it won't actually tick
+        )
+        # Before start, thread should be None
+        assert refresher._thread is None
+        refresher.start()
+        # After start, thread should be created (even if it exits quickly due to errors)
+        assert refresher._thread is not None
+        refresher.stop(timeout=2.0)
+
+    def test_stop_is_idempotent(self, tmp_path: Path) -> None:
+        refresher = _DiffRefresher(
+            tmp_path,
+            "exp_0001",
+            1,
+            "abc123",
+            tmp_path / "worktree",
+        )
+        refresher.stop(timeout=0.1)
+        refresher.stop(timeout=0.1)  # no-op, no error
+
+    def test_start_is_idempotent(self, tmp_path: Path) -> None:
+        refresher = _DiffRefresher(
+            tmp_path,
+            "exp_0001",
+            1,
+            "abc123",
+            tmp_path / "worktree",
+            interval=100,
+        )
+        refresher.start()
+        t1 = refresher._thread
+        refresher.start()
+        t2 = refresher._thread
+        assert t1 is t2
+        refresher.stop(timeout=1.0)
+
+    def test_daemon_thread(self, tmp_path: Path) -> None:
+        refresher = _DiffRefresher(
+            tmp_path,
+            "exp_0001",
+            1,
+            "abc123",
+            tmp_path / "worktree",
+            interval=100,
+        )
+        refresher.start()
+        assert refresher._thread.daemon is True
+        refresher.stop(timeout=1.0)

--- a/tests/unit/test_export_html.py
+++ b/tests/unit/test_export_html.py
@@ -1,0 +1,118 @@
+"""Tests for the HTML export functionality."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evo.core import (
+    attempt_dir,
+    attempt_log_path,
+    experiment_log_path,
+    experiments_dir_for,
+    graph_path,
+    init_workspace,
+    load_config,
+    load_graph,
+    atomic_write_json,
+)
+from evo.export_html import export_experiment_html
+
+
+class TestExportHtml:
+    def test_export_creates_html_file(self, tmp_path: Path) -> None:
+        root = tmp_path / "workspace"
+        init_workspace(
+            root,
+            target="train.py",
+            benchmark="python eval.py",
+            metric="max",
+            gate=None,
+            host="generic",
+            per_exp_timeout=3600,
+        )
+        config = load_config(root)
+        graph = load_graph(root)
+        # Create a mock experiment node
+        exp_id = "exp_0001"
+        exp_dir = experiments_dir_for(root, exp_id)
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        a_dir = attempt_dir(root, exp_id, 1)
+        a_dir.mkdir(parents=True, exist_ok=True)
+        # Write some test data
+        (a_dir / "metrics.jsonl").write_text(
+            '{"loss": 0.5, "lr": 0.001}\n{"loss": 0.3, "lr": 0.0005}\n',
+            encoding="utf-8",
+        )
+        (a_dir / "diff.patch").write_text(
+            "--- a/train.py\n+++ b/train.py\n@@ -1 +1 @@\n-old\n+new\n",
+            encoding="utf-8",
+        )
+        # Add the node to the graph
+        graph["nodes"][exp_id] = {
+            "id": exp_id,
+            "parent": "root",
+            "status": "active",
+            "current_attempt": 1,
+            "hypothesis": "Test hypothesis",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        atomic_write_json(graph_path(root), graph)
+
+        output = exp_dir / "report.html"
+        result = export_experiment_html(root, exp_id, output_path=output)
+        assert result.exists()
+        content = result.read_text(encoding="utf-8")
+        assert exp_id in content
+        assert "Test hypothesis" in content
+        assert "loss" in content
+
+    def test_export_default_output_path(self, tmp_path: Path) -> None:
+        root = tmp_path / "workspace"
+        init_workspace(
+            root,
+            target="train.py",
+            benchmark="python eval.py",
+            metric="max",
+            gate=None,
+            host="generic",
+            per_exp_timeout=3600,
+        )
+        exp_id = "exp_0001"
+        exp_dir = experiments_dir_for(root, exp_id)
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        a_dir = attempt_dir(root, exp_id, 1)
+        a_dir.mkdir(parents=True, exist_ok=True)
+
+        # Add the node to the graph
+        graph = load_graph(root)
+        graph["nodes"][exp_id] = {
+            "id": exp_id,
+            "parent": "root",
+            "status": "active",
+            "current_attempt": 1,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+        atomic_write_json(graph_path(root), graph)
+
+        result = export_experiment_html(root, exp_id)
+        assert result.exists()
+        assert result.name == "report.html"
+
+    def test_export_unknown_experiment(self, tmp_path: Path) -> None:
+        root = tmp_path / "workspace"
+        init_workspace(
+            root,
+            target="train.py",
+            benchmark="python eval.py",
+            metric="max",
+            gate=None,
+            host="generic",
+            per_exp_timeout=3600,
+        )
+        with pytest.raises(ValueError, match="Unknown experiment"):
+            export_experiment_html(root, "nonexistent")


### PR DESCRIPTION
Builds on PR #78 (krockxz/fix/issue-59-metrics-and-active-attempt-state) with expanded scope. Cherry-picks the two PR #78 commits as foundation, then adds five live dashboard panels, CLI improvements, and HTML export.

## What this PR does

### Live Dashboard (5 panels, auto-refresh every 5s)
1. **Metrics sparklines** — tail metrics.jsonl with key filtering (--keys loss,lr)
2. **Samples preview** — last N samples via new cmd_samples --tail
3. **Checkpoints** — saved model checkpoints via new cmd_checkpoints
4. **Worktree diff** — live diff.patch refreshed every 5s by _DiffRefresher daemon
5. **HTML export** — self-contained report via new cmd_export (--full for untruncated)

### CLI additions
- `evo samples <exp> [--tail N]` — show last N samples
- `evo checkpoints <exp>` — list saved checkpoints
- `evo export <exp> [-o path] [--full]` — export HTML report
- `evo metrics --keys loss,lr` — filter metrics output to specific keys

### Technical details
- Server-side diff refresh: background thread `_DiffRefresher` in core.py rewrites diff.patch every 5s during benchmark phase; dashboard reads cached file (no per-poll sandbox calls)
- Hardened per-attempt dirs: pre-creates metrics.jsonl, samples.jsonl, stderr.log + EVO_METRICS_PATH/EVO_SAMPLES_PATH env vars for forward-compat
- Dashboard frontend: Live tab only shown for active experiments via node.status === 'active'
- All 40 tests passing (28 lifecycle + 5 diff_refresher + 3 export_html + 4 active_attempt)

### Files changed
- plugins/evo/src/evo/cli.py: Added cmd_samples, cmd_checkpoints, cmd_export, _print_metrics_lines rewrite with keys param
- plugins/evo/src/evo/core.py: Added _DiffRefresher, hardened _runtime_env_for_attempt
- plugins/evo/src/evo/dashboard.py: 4 new API endpoints (metrics-tail, samples-tail, checkpoints, live-diff, export-html)
- plugins/evo/src/evo/export_html.py: New HTML export module
- plugins/evo/src/evo/static/app.js: loadLiveTab(), sparkline rendering, conditional Live tab
- plugins/evo/src/evo/static/style.css: Live tab panel styles
- plugins/evo/skills/finetuning/SKILL.md: Live dashboard monitoring section
- plugins/evo/skills/finetuning/references/glue.md: EVO_METRICS_PATH/SAMPLES_PATH env var docs
- tests/unit/test_diff_refresher.py: 5 new tests
- tests/unit/test_export_html.py: 3 new tests
- tests/unit/test_active_attempt.py: 4 new tests
