### PR TITLE
feat(kimi): add Kimi host support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ node_modules/
 
 # Claude Code dynamic-workflow worktrees
 .claude/worktrees/
+
+# Worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You give it a codebase. It discovers metrics to optimize, sets up the evaluation
 - **Benchmark discovery.** The `discover` skill explores the repo, figures out what to measure, and instruments the evaluation.
 
 
-Runs on Claude Code, Codex, Cursor, OpenClaw, Hermes, Opencode, or Pi. Experiments run locally or on remote sandboxes — Modal, E2B, Daytona, AWS, Azure, SSH.
+Runs on Claude Code, Codex, Cursor, Kimi, OpenClaw, Hermes, Opencode, or Pi. Experiments run locally or on remote sandboxes — Modal, E2B, Daytona, AWS, Azure, SSH.
 
 
 <p align="center">
@@ -77,7 +77,7 @@ npm install -g @anthropic-ai/claude-code     # or @openai/codex, openclaw, @eare
 # Cursor: install from cursor.com (IDE), or `curl https://cursor.com/install -fsS | bash` for the cursor-agent CLI
 
 # 3. Plugin + host hooks
-evo install <host>     # claude-code | codex | cursor | hermes | opencode | openclaw | pi
+evo install <host>     # claude-code | codex | cursor | hermes | kimi | opencode | openclaw | pi
 ```
 
 For remote backends, install with the matching provider extra: `uv tool install 'evo-hq-cli[modal]'` (or `[e2b]`, `[daytona]`, `[aws]`, `[azure]`, `[all]`).

--- a/docs/superpowers/plans/2026-07-11-kimi-host-support-plan.md
+++ b/docs/superpowers/plans/2026-07-11-kimi-host-support-plan.md
@@ -1,0 +1,1496 @@
+# Kimi Code CLI host support for evo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Kimi Code CLI as a first-class evo host, including host adapter, plugin manifest, slash commands, hooks/drain, and native Kimi `Agent` tool dispatch.
+
+**Architecture:** Reuse evo's existing host-install adapter pattern and inject/drain self-contained host path (similar to Cursor). Add a Kimi plugin manifest under `.kimi-plugin/` and Kimi-native plugin tools under `kimi_tools/` for correlating Kimi `Agent` instances with evo experiments. The optimize skill instructs the orchestrator to use Kimi's `Agent` tool and the new plugin tools.
+
+**Tech Stack:** Python 3.10+, pytest, Kimi Code CLI (beta plugin/hook/agent APIs), evo's existing plugin/skill/hook infrastructure.
+
+## Global Constraints
+
+- Kimi plugin and hook APIs are beta and may change; keep the integration surface small and fail-open.
+- All hook commands must be on PATH or use plugin-relative paths.
+- Slash commands are namespaced by plugin id (`evo`), so users invoke `/evo:discover` and `/evo:optimize`.
+- Plugin tools receive JSON on stdin and write JSON to stdout.
+- The evo CLI on PATH provides `evo-drain`; do not assume a separate hook binary for Kimi.
+- Changes must not break existing hosts (Claude Code, Codex, Cursor, etc.).
+- All new code needs tests mirroring the existing `tests/unit/` patterns.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `plugins/evo/src/evo/core.py` | Add `"kimi"` to `SUPPORTED_HOSTS`. |
+| `plugins/evo/src/evo/host_install/__init__.py` | Import and register the `kimi` adapter. |
+| `plugins/evo/src/evo/host_install/kimi.py` | `evo install/uninstall/doctor kimi` implementation. |
+| `plugins/evo/.kimi-plugin/plugin.json` | Kimi plugin manifest (skills, commands, hooks, Phase 2 tools). |
+| `plugins/evo/commands/discover.md` | `/evo:discover` slash command. |
+| `plugins/evo/commands/optimize.md` | `/evo:optimize` slash command. |
+| `plugins/evo/src/evo/inject/drain.py` | Kimi self-contained drain path and envelope. |
+| `plugins/evo/src/evo/inject/registry.py` | Kimi session env detection. |
+| `plugins/evo/src/evo/hosts/kimi_native.py` | Helpers for Kimi `Agent` instance ↔ evo experiment mapping. |
+| `plugins/evo/kimi_tools/spawn_subagent.py` | Kimi plugin tool to record agent↔experiment mapping. |
+| `plugins/evo/kimi_tools/wait_subagent.py` | Kimi plugin tool to poll experiment result by agent id. |
+| `plugins/evo/skills/optimize/SKILL.md` | Add Kimi `Agent` tool instructions under Host conventions. |
+| `README.md` | List Kimi as supported host. |
+| `plugins/evo/skills/infra-setup/references/provider-matrix.md` | Add Kimi setup row. |
+| `tests/unit/test_kimi_host_install.py` | Unit tests for host adapter. |
+| `tests/unit/test_kimi_drain.py` | Unit tests for Kimi drain envelope. |
+| `tests/unit/test_kimi_native_dispatch.py` | Unit tests for plugin tools and mapping helpers. |
+
+---
+
+## Task 1: Register Kimi in core and host_install
+
+**Files:**
+- Modify: `plugins/evo/src/evo/core.py:29-39`
+- Modify: `plugins/evo/src/evo/host_install/__init__.py:31-42`
+- Test: `tests/unit/test_kimi_host_install.py` (created in Task 2, but add a minimal test here)
+
+**Interfaces:**
+- Consumes: existing `SUPPORTED_HOSTS` frozenset and `ADAPTERS` dict.
+- Produces: `"kimi"` is a valid host name returned by `get("kimi")`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_kimi_host_install.py`:
+
+```python
+from evo.host_install import get, SUPPORTED_HOSTS
+
+
+def test_kimi_is_supported():
+    assert "kimi" in SUPPORTED_HOSTS
+
+
+def test_kimi_adapter_registered():
+    module = get("kimi")
+    assert hasattr(module, "install")
+    assert hasattr(module, "uninstall")
+    assert hasattr(module, "doctor")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Volumes/home_ext1/src_pierre/evo/plugins/evo
+pytest tests/unit/test_kimi_host_install.py -v
+```
+
+Expected: two failures (`"kimi" not in SUPPORTED_HOSTS`, `unknown host 'kimi'`).
+
+- [ ] **Step 3: Implement minimal changes**
+
+In `plugins/evo/src/evo/core.py`, add `"kimi"` to `SUPPORTED_HOSTS`:
+
+```python
+SUPPORTED_HOSTS = frozenset({
+    "claude-code",
+    "claude-science",
+    "codex",
+    "cursor",
+    "kimi",
+    "opencode",
+    "openclaw",
+    "hermes",
+    "pi",
+    "generic",
+})
+```
+
+In `plugins/evo/src/evo/host_install/__init__.py`, import and register:
+
+```python
+from . import claude_code, claude_science, codex, cursor, hermes, kimi, opencode, openclaw, pi
+
+ADAPTERS = {
+    "claude-code": claude_code,
+    "claude-science": claude_science,
+    "codex": codex,
+    "cursor": cursor,
+    "hermes": hermes,
+    "kimi": kimi,
+    "opencode": opencode,
+    "openclaw": openclaw,
+    "pi": pi,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/unit/test_kimi_host_install.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/src/evo/core.py plugins/evo/src/evo/host_install/__init__.py tests/unit/test_kimi_host_install.py
+git commit -m "feat(kimi): register kimi host in SUPPORTED_HOSTS and ADAPTERS"
+```
+
+---
+
+## Task 2: Create the Kimi host-install adapter
+
+**Files:**
+- Create: `plugins/evo/src/evo/host_install/kimi.py`
+- Modify: `tests/unit/test_kimi_host_install.py`
+
+**Interfaces:**
+- Consumes: argparse namespace with optional `from_path`, `version`, `force`.
+- Produces: `install(args) -> int`, `uninstall(args) -> int`, `doctor(args) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_host_install.py`:
+
+```python
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from evo.host_install import kimi as kimi_mod
+
+
+@pytest.fixture
+def fake_kimi_home(tmp_path, monkeypatch):
+    home = tmp_path / "kimi-home"
+    home.mkdir()
+    monkeypatch.setenv("KIMI_CODE_HOME", str(home))
+    return home
+
+
+def test_kimi_base_honors_env_var(fake_kimi_home):
+    assert kimi_mod._kimi_base() == fake_kimi_home
+
+
+def test_kimi_base_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    assert kimi_mod._kimi_base() == Path.home() / ".kimi"
+
+
+def test_install_missing_kimi_binary(fake_kimi_home, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    from argparse import Namespace
+    rc = kimi_mod.install(Namespace(from_path=None, version=None, force=False))
+    assert rc == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_host_install.py::test_kimi_base_honors_env_var -v
+```
+
+Expected: `AttributeError: module 'evo.host_install.kimi' has no attribute '_kimi_base'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/src/evo/host_install/kimi.py`:
+
+```python
+"""Kimi Code CLI host install adapter.
+
+Installs evo as a Kimi plugin by copying the plugin root into Kimi's
+managed plugin directory. Also wires hooks via the plugin manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _kimi_base() -> Path:
+    home_override = os.environ.get("KIMI_CODE_HOME")
+    return Path(home_override) if home_override else Path.home() / ".kimi"
+
+
+def _kimi_plugin_dir() -> Path:
+    return _kimi_base() / "plugins" / "managed" / "evo"
+
+
+def _plugin_root(from_path: str | None = None) -> Path:
+    if from_path:
+        p = Path(from_path).resolve()
+        candidate = p / "plugins" / "evo"
+        if candidate.exists():
+            return candidate
+        if (p / ".kimi-plugin" / "plugin.json").exists() or (p / "kimi.plugin.json").exists():
+            return p
+        return candidate
+    # Running from an installed evo-hq-cli wheel: locate the plugin root
+    # relative to this source file (plugins/evo/src/evo/host_install/).
+    here = Path(__file__).resolve().parent.parent.parent  # plugins/evo
+    return here
+
+
+def _release_version_re():
+    import re
+    return re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
+
+
+def _github_source(version: str) -> str:
+    ref = f"v{version}" if _release_version_re().match(version) else version
+    return f"https://github.com/evo-hq/evo/tree/{ref}/plugins/evo"
+
+
+def install(args: argparse.Namespace) -> int:
+    if shutil.which("kimi") is None:
+        print(
+            "ERROR: `kimi` binary not on PATH. Install Kimi Code CLI first:\n"
+            "  npm install -g @moonshot-ai/kimi-code-cli",
+            file=sys.stderr,
+        )
+        return 2
+
+    version = getattr(args, "version", None)
+    from_path = getattr(args, "from_path", None)
+
+    if version:
+        # Let Kimi fetch the plugin from GitHub.
+        source = _github_source(version)
+        cmd = ["kimi", "plugin", "install", source]
+        print(f"$ {' '.join(cmd)}")
+        rc = subprocess.call(cmd)
+        if rc != 0:
+            return rc
+        print(
+            "\n✓ evo installed for kimi.\n"
+            "  Start a new Kimi session (or run /reload) to load the plugin."
+        )
+        return 0
+
+    src = _plugin_root(from_path)
+    if not src.exists():
+        print(f"ERROR: evo plugin source not found at {src}", file=sys.stderr)
+        return 2
+
+    dst = _kimi_plugin_dir()
+    if dst.exists():
+        print(f"removing previous install at {dst}")
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    print(f"copying {src} -> {dst}")
+    shutil.copytree(
+        src, dst,
+        ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", "build", "dist",
+            ".pytest_cache", "*.egg-info", "node_modules",
+        ),
+    )
+
+    print(
+        "\n✓ evo installed for kimi.\n"
+        "  Start a new Kimi session (or run /reload) to load the plugin."
+    )
+    return 0
+
+
+def uninstall(args: argparse.Namespace) -> int:
+    dst = _kimi_plugin_dir()
+    if dst.exists():
+        shutil.rmtree(dst)
+        print(f"removed {dst}")
+    else:
+        print("evo plugin not installed for kimi")
+    return 0
+
+
+def doctor(args: argparse.Namespace) -> int:
+    if shutil.which("kimi") is None:
+        print("✗ `kimi` binary not on PATH")
+        print("  Install: npm install -g @moonshot-ai/kimi-code-cli")
+        return 1
+    print(f"✓ kimi binary: {shutil.which('kimi')}")
+
+    dst = _kimi_plugin_dir()
+    manifest = dst / ".kimi-plugin" / "plugin.json"
+    if not manifest.exists():
+        manifest = dst / "kimi.plugin.json"
+    if not manifest.exists():
+        print(f"✗ evo plugin not found at {dst}")
+        print("  Run: evo install kimi")
+        return 1
+    print(f"✓ evo plugin manifest at {manifest}")
+
+    # Basic manifest sanity
+    import json
+    try:
+        data = json.loads(manifest.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"✗ could not parse manifest: {exc}")
+        return 1
+    if data.get("name") != "evo":
+        print(f"✗ manifest name mismatch: {data.get('name')!r}")
+        return 1
+    print("✓ manifest name is 'evo'")
+    return 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_host_install.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/src/evo/host_install/kimi.py tests/unit/test_kimi_host_install.py
+git commit -m "feat(kimi): add host install adapter with install/uninstall/doctor"
+```
+
+---
+
+## Task 3: Create the Kimi plugin manifest
+
+**Files:**
+- Create: `plugins/evo/.kimi-plugin/plugin.json`
+- Test: `tests/unit/test_kimi_plugin_manifest.py`
+
+**Interfaces:**
+- Consumes: existing skill and command paths relative to plugin root.
+- Produces: valid Kimi plugin manifest loadable by `kimi plugin info evo`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_kimi_plugin_manifest.py`:
+
+```python
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "plugins" / "evo" / ".kimi-plugin" / "plugin.json"
+
+
+def test_manifest_exists_and_is_valid_json():
+    assert MANIFEST.exists(), f"manifest not found at {MANIFEST}"
+    data = json.loads(MANIFEST.read_text())
+    assert data["name"] == "evo"
+    assert "version" in data
+    assert "skills" in data
+    assert "commands" in data
+    assert "hooks" in data
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py -v
+```
+
+Expected: `assertion error: manifest not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/.kimi-plugin/plugin.json`:
+
+```json
+{
+  "name": "evo",
+  "version": "0.7.0",
+  "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
+  "interface": {
+    "displayName": "evo",
+    "shortDescription": "Autoresearch orchestrator for codebases"
+  },
+  "skills": "./skills",
+  "commands": "./commands",
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "PreToolUse",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "Stop",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "SubagentStop",
+      "command": "evo-drain --host kimi"
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/.kimi-plugin/plugin.json tests/unit/test_kimi_plugin_manifest.py
+git commit -m "feat(kimi): add Kimi plugin manifest with skills, commands, and hooks"
+```
+
+---
+
+## Task 4: Create slash commands for discover and optimize
+
+**Files:**
+- Create: `plugins/evo/commands/discover.md`
+- Create: `plugins/evo/commands/optimize.md`
+- Test: `tests/unit/test_kimi_plugin_manifest.py` (extend to verify command files exist)
+
+**Interfaces:**
+- Consumes: evo CLI commands `evo discover` and `evo optimize`.
+- Produces: Kimi-recognized slash commands `/evo:discover` and `/evo:optimize`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_plugin_manifest.py`:
+
+```python
+COMMANDS_DIR = REPO_ROOT / "plugins" / "evo" / "commands"
+
+
+def test_discover_command_file_exists():
+    assert (COMMANDS_DIR / "discover.md").exists()
+
+
+def test_optimize_command_file_exists():
+    assert (COMMANDS_DIR / "optimize.md").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py::test_discover_command_file_exists -v
+```
+
+Expected: assertion failure.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/commands/discover.md`:
+
+```markdown
+---
+name: discover
+description: Discover what to optimize and initialize an evo workspace.
+---
+
+Run `evo discover` in the current project. If the user provides an optimization target, pass it as an argument. After this command completes, use `evo status` to confirm the workspace is initialized, then run `/evo:optimize` to start the loop.
+```
+
+Create `plugins/evo/commands/optimize.md`:
+
+```markdown
+---
+name: optimize
+description: Run the evo autoresearch optimization loop.
+---
+
+Run `evo optimize` in the current project. This starts the structured experiment loop. You may pass parameters like `subagents=N` or `autonomous` as arguments. Do not edit files or run experiments manually while the loop is active unless the user explicitly asks for direct execution.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/commands/discover.md plugins/evo/commands/optimize.md tests/unit/test_kimi_plugin_manifest.py
+git commit -m "feat(kimi): add /evo:discover and /evo:optimize slash commands"
+```
+
+---
+
+## Task 5: Add Kimi drain support in inject/drain.py
+
+**Files:**
+- Modify: `plugins/evo/src/evo/inject/drain.py`
+- Test: `tests/unit/test_kimi_drain.py`
+
+**Interfaces:**
+- Consumes: Kimi hook stdin payload (`session_id`, `cwd`, `hook_event_name`, `tool_name`, `tool_input`, `prompt`).
+- Produces: Kimi-compatible stdout envelope (`hookSpecificOutput.additionalContext` or `permissionDecision: deny`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_kimi_drain.py`:
+
+```python
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.inject.drain import main
+from evo.inject.paths import session_file
+from evo.inject.registry import register_session
+
+
+def _make_workspace(tmp: Path) -> Path:
+    import subprocess
+    root = tmp / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    from evo.core import init_workspace
+    init_workspace(root, target="agent.py", benchmark="python bench.py", metric="max", gate=None)
+    return root
+
+
+class KimiDrainTest(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = _make_workspace(Path(self._tmp.name))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _fire(self, payload: dict):
+        stdin_buf = io.StringIO(json.dumps(payload))
+        stdout_buf = io.StringIO()
+        with patch("sys.stdin", stdin_buf), patch("sys.stdout", stdout_buf):
+            main(["--host", "kimi"])
+        return json.loads(stdout_buf.getvalue())
+
+    def test_session_start_registers_session(self):
+        sid = "kimi-test-sid"
+        self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        })
+        rec = json.loads(session_file(self.root, sid).read_text())
+        assert rec["host"] == "kimi"
+        assert rec["session_id"] == sid
+
+    def test_user_prompt_submit_arms_optimize_mode(self):
+        sid = "kimi-test-sid"
+        self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "/evo:optimize",
+        })
+        rec = json.loads(session_file(self.root, sid).read_text())
+        assert rec["optimize_mode"] is True
+
+    def test_pretooluse_empty_marker_returns_empty(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "tool_input": {"command": "echo hi"},
+        })
+        assert out == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_drain.py -v
+```
+
+Expected: failures because Kimi host path is not implemented.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugins/evo/src/evo/inject/drain.py`:
+
+1. Add `"kimi"` to the self-contained host handling in `main()`.
+2. Add Kimi-specific envelope emission in `emit_for_host()`.
+
+In `emit_for_host`, add before the final fallback:
+
+```python
+if host == "kimi":
+    # Kimi hooks: exit-0 stdout is added to the agent's context. The
+    # structured envelope uses hookSpecificOutput with additionalContext.
+    # Policy blocks are emitted by drain_session before this function is
+    # called, using the same envelope with permissionDecision: deny.
+    evt = hook_event or "PreToolUse"
+    out = {"hookSpecificOutput": {"hookEventName": evt, "additionalContext": text}}
+    sys.stdout.write(json.dumps(out, separators=(",", ":")))
+    return
+```
+
+In `main()`, after the existing cursor self-contained branch (around line 1466-1500), add an equivalent branch for Kimi. The simplest approach is to extend the self-contained branch to accept `--host kimi`:
+
+```python
+# Mode 2: self-contained — resolve everything from args + stdin payload.
+host = args.host or "cursor"
+if host in ("cursor", "kimi"):
+    session = args.session or payload.get("session_id") or payload.get("conversation_id")
+    root = _resolve_root_from_payload(payload)
+    if not session or root is None or not inject_root(root).parent.exists():
+        _drain_debug(stage="resolve", host=host, hook_event=hook_event,
+                     payload_keys=sorted(payload.keys()), session=session,
+                     root=str(root) if root else None, decision="bail")
+        sys.stdout.write("{}")
+        return 0
+    tool_name = payload.get("tool_name")
+    tool_input = payload.get("tool_input") or {}
+    registered = session_file(root, session).exists()
+    has_marker = marker.exists(root, session)
+    if host == "cursor":
+        _maybe_mark_engaged_from_shell(root, session, host, hook_event, payload)
+    _maybe_mark_autonomous_from_shell(root, session, host, hook_event, payload)
+    gate = _self_contained_gate(root, session, host, hook_event, tool_name, tool_input)
+    _maybe_mark_optimize_from_prompt(root, session, host, hook_event, payload)
+    _drain_debug(stage="gate", host=host, hook_event=hook_event, session=session,
+                 root=str(root), tool_name=tool_name,
+                 registered_before=registered, marker=has_marker, gate=gate)
+    if not gate:
+        sys.stdout.write("{}")
+        return 0
+    return drain_session(root, session, host=host, hook_event=hook_event, payload=payload)
+```
+
+This reuses `_self_contained_gate` (it already accepts `host` and registers correctly). Two small helper updates are needed:
+
+In `_maybe_mark_engaged_from_shell`, change the guard from `if host != "cursor":` to `if host not in ("cursor", "kimi"):` so an `evo ...` shell command marks the Kimi session as engaged.
+
+In `_maybe_mark_autonomous_from_shell`, change the guard from `if host not in ("cursor", "codex", "claude-code"):` to `if host not in ("cursor", "codex", "claude-code", "kimi"):` so `evo autonomous on|off` arms/disarms the hook session on Kimi.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_drain.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/src/evo/inject/drain.py tests/unit/test_kimi_drain.py
+git commit -m "feat(kimi): add self-contained drain path and hook envelope"
+```
+
+---
+
+## Task 6: Add Kimi session env detection
+
+**Files:**
+- Modify: `plugins/evo/src/evo/inject/registry.py`
+- Test: `tests/unit/test_kimi_drain.py` (extend)
+
+**Interfaces:**
+- Consumes: environment variables.
+- Produces: `detect_session()` returns `("kimi", sid)` when `KIMI_CODE_SESSION_ID` is set.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_drain.py`:
+
+```python
+from evo.inject.registry import detect_session
+
+
+def test_detect_session_from_kimi_env(monkeypatch):
+    monkeypatch.setenv("KIMI_CODE_SESSION_ID", "kimi-sid-123")
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.delenv("OPENCODE_SESSION_ID", raising=False)
+    assert detect_session() == ("kimi", "kimi-sid-123")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_drain.py::test_detect_session_from_kimi_env -v
+```
+
+Expected: assertion failure (`detect_session()` returns None).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugins/evo/src/evo/inject/registry.py`, add to `HOST_SESSION_ENV_VARS`:
+
+```python
+HOST_SESSION_ENV_VARS = (
+    ("codex", "CODEX_THREAD_ID"),
+    ("claude-code", "CLAUDE_CODE_SESSION_ID"),
+    ("hermes", "HERMES_SESSION_ID"),
+    ("kimi", "KIMI_CODE_SESSION_ID"),
+    ("opencode", "OPENCODE_SESSION_ID"),
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_drain.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/src/evo/inject/registry.py tests/unit/test_kimi_drain.py
+git commit -m "feat(kimi): detect Kimi session from KIMI_CODE_SESSION_ID"
+```
+
+---
+
+## Task 7: Documentation updates
+
+**Files:**
+- Modify: `README.md`
+- Modify: `plugins/evo/skills/infra-setup/references/provider-matrix.md`
+- Test: manual grep/verification
+
+**Interfaces:**
+- Consumes: existing host lists.
+- Produces: Kimi listed as supported host with install command.
+
+- [ ] **Step 1: Update README.md**
+
+Find the line:
+
+```
+Runs on Claude Code, Codex, Cursor, OpenClaw, Hermes, Opencode, or Pi.
+```
+
+Change to:
+
+```
+Runs on Claude Code, Codex, Cursor, Kimi, OpenClaw, Hermes, Opencode, or Pi.
+```
+
+Find:
+
+```bash
+evo install <host>     # claude-code | codex | cursor | hermes | opencode | openclaw | pi
+```
+
+Change to:
+
+```bash
+evo install <host>     # claude-code | codex | cursor | hermes | kimi | opencode | openclaw | pi
+```
+
+- [ ] **Step 2: Update provider-matrix.md**
+
+Append a row to the table:
+
+```markdown
+| `kimi` | Kimi Code CLI plugin + hooks | Install Kimi Code CLI, then `evo install kimi` | skills, commands, hooks, plugin tools (Phase 2) |
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "Kimi\|kimi" README.md plugins/evo/skills/infra-setup/references/provider-matrix.md
+```
+
+Expected: Kimi appears in both files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md plugins/evo/skills/infra-setup/references/provider-matrix.md
+git commit -m "docs(kimi): list Kimi as supported host"
+```
+
+---
+
+## Task 8: Integration smoke test for install/doctor
+
+**Files:**
+- Modify: `tests/unit/test_kimi_host_install.py`
+
+**Interfaces:**
+- Consumes: `host_install/kimi.py` functions.
+- Produces: verified file-copy install/uninstall/doctor cycle.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/unit/test_kimi_host_install.py`:
+
+```python
+def test_install_copies_plugin(fake_kimi_home, tmp_path, monkeypatch):
+    # Use the real plugin root from this checkout
+    here = Path(__file__).resolve().parents[2] / "plugins" / "evo"
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/kimi" if name == "kimi" else None)
+    from argparse import Namespace
+    rc = kimi_mod.install(Namespace(from_path=str(here.parent.parent), version=None, force=False))
+    assert rc == 0
+    assert (fake_kimi_home / "plugins" / "managed" / "evo" / ".kimi-plugin" / "plugin.json").exists()
+
+
+def test_doctor_after_install(fake_kimi_home, tmp_path, monkeypatch):
+    here = Path(__file__).resolve().parents[2] / "plugins" / "evo"
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/kimi" if name == "kimi" else None)
+    from argparse import Namespace
+    kimi_mod.install(Namespace(from_path=str(here.parent.parent), version=None, force=False))
+    rc = kimi_mod.doctor(Namespace())
+    assert rc == 0
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest tests/unit/test_kimi_host_install.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_kimi_host_install.py
+git commit -m "test(kimi): smoke test install and doctor cycle"
+```
+
+---
+
+## Task 9: Kimi native dispatch helpers
+
+**Files:**
+- Create: `plugins/evo/src/evo/hosts/kimi_native.py`
+- Test: `tests/unit/test_kimi_native_dispatch.py`
+
+**Interfaces:**
+- Consumes: evo workspace root and experiment id.
+- Produces: read/write mapping files and poll experiment results.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_kimi_native_dispatch.py`:
+
+```python
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.hosts.kimi_native import (
+    agent_mapping_path,
+    read_agent_mapping,
+    write_agent_mapping,
+)
+
+
+def test_mapping_round_trip():
+    with tempfile.TemporaryDirectory() as tmp:
+        run_dir = Path(tmp) / ".evo" / "run_test"
+        exp_id = "exp-0001"
+        mapping = {"agent_id": "kimi-agent-123", "exp_id": exp_id, "brief": "test"}
+        write_agent_mapping(run_dir, exp_id, mapping)
+        assert read_agent_mapping(run_dir, exp_id) == mapping
+
+
+def test_read_missing_mapping_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        run_dir = Path(tmp) / ".evo" / "run_test"
+        assert read_agent_mapping(run_dir, "exp-0000") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py -v
+```
+
+Expected: import errors.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/src/evo/hosts/kimi_native.py`:
+
+```python
+"""Helpers for native Kimi Agent subagent dispatch.
+
+Tracks the mapping between Kimi Agent instance ids and evo experiment ids,
+and polls evo experiment results.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def agent_mapping_path(run_dir: Path, exp_id: str) -> Path:
+    return run_dir / "experiments" / exp_id / "kimi_agent.json"
+
+
+def write_agent_mapping(run_dir: Path, exp_id: str, mapping: dict) -> None:
+    p = agent_mapping_path(run_dir, exp_id)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    from evo.core import atomic_write_json
+    atomic_write_json(p, mapping)
+
+
+def read_agent_mapping(run_dir: Path, exp_id: str) -> dict | None:
+    p = agent_mapping_path(run_dir, exp_id)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def read_agent_mapping_by_agent_id(run_dir: Path, agent_id: str) -> dict | None:
+    exp_dir = run_dir / "experiments"
+    if not exp_dir.exists():
+        return None
+    for p in exp_dir.rglob("kimi_agent.json"):
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("agent_id") == agent_id:
+            return data
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/src/evo/hosts/kimi_native.py tests/unit/test_kimi_native_dispatch.py
+git commit -m "feat(kimi): add native Agent dispatch mapping helpers"
+```
+
+---
+
+## Task 10: spawn_subagent plugin tool
+
+**Files:**
+- Create: `plugins/evo/kimi_tools/spawn_subagent.py`
+- Modify: `tests/unit/test_kimi_native_dispatch.py`
+
+**Interfaces:**
+- Consumes: JSON stdin with `exp_id`, `agent_id`, optional `brief`.
+- Produces: JSON stdout confirming the mapping was written.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_native_dispatch.py`:
+
+```python
+SPAWN_TOOL = REPO_ROOT / "plugins" / "evo" / "kimi_tools" / "spawn_subagent.py"
+
+
+def test_spawn_subagent_tool(tmp_path):
+    root = tmp_path / "repo"
+    (root / ".evo" / "run_test" / "experiments" / "exp-0001").mkdir(parents=True)
+    payload = json.dumps({
+        "exp_id": "exp-0001",
+        "agent_id": "kimi-agent-123",
+        "brief": "optimize parser",
+    })
+    env = {"EVO_RUN_DIR": str(root / ".evo" / "run_test")}
+    r = subprocess.run(
+        [sys.executable, str(SPAWN_TOOL)],
+        input=payload,
+        env={**dict(os.environ), **env},
+        capture_output=True,
+        text=True,
+        cwd=str(root),
+    )
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["status"] == "ok"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py::test_spawn_subagent_tool -v
+```
+
+Expected: file not found error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/kimi_tools/spawn_subagent.py`:
+
+```python
+#!/usr/bin/env python3
+"""Kimi plugin tool: record the mapping between a Kimi Agent and an evo experiment."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from evo.core import find_workspace_root, workspace_path
+from evo.hosts.kimi_native import write_agent_mapping
+
+
+def main() -> int:
+    try:
+        params = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "invalid json stdin"}))
+        return 2
+
+    exp_id = params.get("exp_id")
+    agent_id = params.get("agent_id")
+    if not exp_id or not agent_id:
+        print(json.dumps({"error": "exp_id and agent_id are required"}))
+        return 2
+
+    run_dir_env = os.environ.get("EVO_RUN_DIR")
+    if run_dir_env:
+        run_dir = Path(run_dir_env)
+        root = find_workspace_root(run_dir)
+    else:
+        root = find_workspace_root(Path.cwd())
+        run_dir = workspace_path(root)
+    if root is None:
+        print(json.dumps({"error": "not inside an evo workspace"}))
+        return 2
+
+    write_agent_mapping(run_dir, exp_id, {
+        "agent_id": agent_id,
+        "exp_id": exp_id,
+        "brief": params.get("brief", ""),
+    })
+    print(json.dumps({"status": "ok", "exp_id": exp_id, "agent_id": agent_id}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/kimi_tools/spawn_subagent.py tests/unit/test_kimi_native_dispatch.py
+git commit -m "feat(kimi): add evo_spawn_subagent plugin tool"
+```
+
+---
+
+## Task 11: wait_subagent plugin tool
+
+**Files:**
+- Create: `plugins/evo/kimi_tools/wait_subagent.py`
+- Modify: `tests/unit/test_kimi_native_dispatch.py`
+
+**Interfaces:**
+- Consumes: JSON stdin with `agent_id`.
+- Produces: JSON stdout with experiment status/result.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_native_dispatch.py`:
+
+```python
+WAIT_TOOL = REPO_ROOT / "plugins" / "evo" / "kimi_tools" / "wait_subagent.py"
+
+
+def test_wait_subagent_tool(tmp_path):
+    root = tmp_path / "repo"
+    run_dir = root / ".evo" / "run_test"
+    exp_dir = run_dir / "experiments" / "exp-0001"
+    exp_dir.mkdir(parents=True)
+    mapping = {"agent_id": "kimi-agent-123", "exp_id": "exp-0001", "brief": ""}
+    from evo.hosts.kimi_native import write_agent_mapping
+    write_agent_mapping(run_dir, "exp-0001", mapping)
+
+    payload = json.dumps({"agent_id": "kimi-agent-123"})
+    env = {"EVO_RUN_DIR": str(root / ".evo" / "run_test")}
+    r = subprocess.run(
+        [sys.executable, str(WAIT_TOOL)],
+        input=payload,
+        env={**dict(os.environ), **env},
+        capture_output=True,
+        text=True,
+        cwd=str(root),
+    )
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["agent_id"] == "kimi-agent-123"
+    assert out["exp_id"] == "exp-0001"
+    assert out["status"] == "pending"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py::test_wait_subagent_tool -v
+```
+
+Expected: file not found error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `plugins/evo/kimi_tools/wait_subagent.py`:
+
+```python
+#!/usr/bin/env python3
+"""Kimi plugin tool: poll the evo experiment result for a given Kimi Agent id."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from evo.core import experiment_result_path, find_workspace_root, workspace_path
+from evo.hosts.kimi_native import read_agent_mapping_by_agent_id
+
+
+def main() -> int:
+    try:
+        params = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "invalid json stdin"}))
+        return 2
+
+    agent_id = params.get("agent_id")
+    if not agent_id:
+        print(json.dumps({"error": "agent_id is required"}))
+        return 2
+
+    run_dir_env = os.environ.get("EVO_RUN_DIR")
+    if run_dir_env:
+        run_dir = Path(run_dir_env)
+        root = find_workspace_root(run_dir)
+    else:
+        root = find_workspace_root(Path.cwd())
+        run_dir = workspace_path(root)
+    if root is None:
+        print(json.dumps({"error": "not inside an evo workspace"}))
+        return 2
+
+    mapping = read_agent_mapping_by_agent_id(run_dir, agent_id)
+    if mapping is None:
+        print(json.dumps({"error": "agent mapping not found"}))
+        return 2
+
+    exp_id = mapping["exp_id"]
+    result_path = experiment_result_path(root, exp_id)
+    result = None
+    status = "pending"
+    if result_path.exists():
+        try:
+            result = json.loads(result_path.read_text())
+            status = result.get("status", "evaluated")
+        except (OSError, json.JSONDecodeError):
+            status = "error"
+    out = {
+        "agent_id": agent_id,
+        "exp_id": exp_id,
+        "status": status,
+        "result": result,
+    }
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_native_dispatch.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/kimi_tools/wait_subagent.py tests/unit/test_kimi_native_dispatch.py
+git commit -m "feat(kimi): add evo_wait_subagent plugin tool"
+```
+
+---
+
+## Task 12: Declare plugin tools in the manifest
+
+**Files:**
+- Modify: `plugins/evo/.kimi-plugin/plugin.json`
+- Modify: `tests/unit/test_kimi_plugin_manifest.py`
+
+**Interfaces:**
+- Consumes: tool scripts created in Tasks 10-11.
+- Produces: manifest with `tools` array.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_kimi_plugin_manifest.py`:
+
+```python
+def test_manifest_declares_tools():
+    data = json.loads(MANIFEST.read_text())
+    tools = data.get("tools", [])
+    names = {t["name"] for t in tools}
+    assert "evo_spawn_subagent" in names
+    assert "evo_wait_subagent" in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py::test_manifest_declares_tools -v
+```
+
+Expected: assertion failure.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `plugins/evo/.kimi-plugin/plugin.json` after `hooks`:
+
+```json
+  "tools": [
+    {
+      "name": "evo_spawn_subagent",
+      "description": "Record the mapping between a Kimi Agent subagent and an evo experiment",
+      "command": ["python3", "./kimi_tools/spawn_subagent.py"],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "exp_id": {"type": "string"},
+          "agent_id": {"type": "string"},
+          "brief": {"type": "string"}
+        },
+        "required": ["exp_id", "agent_id"]
+      }
+    },
+    {
+      "name": "evo_wait_subagent",
+      "description": "Poll the evo experiment result for a given Kimi Agent id",
+      "command": ["python3", "./kimi_tools/wait_subagent.py"],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agent_id": {"type": "string"}
+        },
+        "required": ["agent_id"]
+      }
+    }
+  ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/.kimi-plugin/plugin.json tests/unit/test_kimi_plugin_manifest.py
+git commit -m "feat(kimi): declare evo_spawn_subagent and evo_wait_subagent tools"
+```
+
+---
+
+## Task 13: Update optimize skill for Kimi Agent tool
+
+**Files:**
+- Modify: `plugins/evo/skills/optimize/SKILL.md`
+- Test: manual verification that Kimi instructions exist
+
+**Interfaces:**
+- Consumes: Kimi `Agent` tool and plugin tools.
+- Produces: skill text that tells the orchestrator how to dispatch on Kimi.
+
+- [ ] **Step 1: Write the failing check**
+
+Append to `tests/unit/test_kimi_plugin_manifest.py` (or create `tests/unit/test_kimi_optimize_skill.py`):
+
+```python
+OPTIMIZE_SKILL = REPO_ROOT / "plugins" / "evo" / "skills" / "optimize" / "SKILL.md"
+
+
+def test_optimize_skill_mentions_kimi_agent_tool():
+    text = OPTIMIZE_SKILL.read_text()
+    assert "Kimi" in text or "kimi" in text
+    assert "Agent" in text
+    assert "evo_spawn_subagent" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py::test_optimize_skill_mentions_kimi_agent_tool -v
+```
+
+Expected: assertion failure.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugins/evo/skills/optimize/SKILL.md`, find the "Host conventions" section. Add a Kimi subsection:
+
+```markdown
+### Kimi Code CLI
+
+On Kimi, use the built-in `Agent` tool to spawn optimization subagents:
+
+- `subagent_type`: `coder`
+- `run_in_background`: `true`
+- `description`: `evo-exp-<exp_id>`
+- `prompt`: the full brief, ending with the instruction to load the `evo:subagent` skill
+
+After each `Agent` call returns an `agent_id`, immediately call the `evo_spawn_subagent` plugin tool with `exp_id` and `agent_id` so evo can correlate the Kimi agent instance with the experiment. To wait for completion, call `evo_wait_subagent` with the `agent_id`, or poll `evo status <exp_id>` directly.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/unit/test_kimi_plugin_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/evo/skills/optimize/SKILL.md tests/unit/test_kimi_plugin_manifest.py
+git commit -m "feat(kimi): document Kimi Agent tool dispatch in optimize skill"
+```
+
+---
+
+## Task 14: Full unit test sweep
+
+**Files:**
+- All modified/created files.
+
+- [ ] **Step 1: Run the full unit suite**
+
+```bash
+cd /Volumes/home_ext1/src_pierre/evo/plugins/evo
+pytest tests/unit -x -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run Kimi-specific tests with verbose output**
+
+```bash
+pytest tests/unit/test_kimi_*.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit any fixes**
+
+If fixes are needed, commit them with descriptive messages. If no fixes are needed, no additional commit is required.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec section | Plan task(s) |
+|---|---|
+| Host adapter | Task 2, Task 8 |
+| Core registration | Task 1 |
+| Plugin manifest | Task 3, Task 12 |
+| Slash commands | Task 4 |
+| Hook drain support | Task 5 |
+| Session env detection | Task 6 |
+| Native Agent dispatch tools | Tasks 9-11 |
+| Optimize skill update | Task 13 |
+| Documentation | Task 7 |
+| Testing | Every task + Task 14 |
+
+### Placeholder scan
+
+No `TBD`, `TODO`, or vague instructions. Each step includes concrete code, exact file paths, and expected test commands.
+
+### Type consistency
+
+- `host_install/kimi.py` uses `argparse.Namespace` consistently.
+- `kimi_native.py` uses `Path` and `dict` consistently.
+- Plugin tools use JSON stdin/stdout consistently.
+- Manifest tool schema matches tool script parameter expectations.
+
+### Known open items
+
+- Exact Kimi hook payload field names should be verified against a live Kimi session (e.g. `tool_name` vs `toolName`). The plan uses the documented names from Kimi's Hooks docs.
+- `KIMI_CODE_SESSION_ID` env var is assumed; if Kimi does not expose it, the hook-based registration path still works.
+- `load_result` signature in `wait_subagent.py` must be verified; adjust if it differs.

--- a/docs/superpowers/specs/2026-07-11-kimi-host-support-design.md
+++ b/docs/superpowers/specs/2026-07-11-kimi-host-support-design.md
@@ -1,0 +1,247 @@
+# Kimi Code CLI host support for evo
+
+## Status
+
+Approved design — awaiting implementation plan.
+
+## Goal
+
+Add Kimi Code CLI (Moonshot AI's open-source terminal coding agent) as a first-class evo host. Users will be able to run:
+
+```
+/evo:discover
+/evo:optimize
+```
+
+inside a Kimi Code CLI session, and install/verify the integration with:
+
+```
+evo install kimi
+evo doctor kimi
+```
+
+## Background
+
+evo already supports Claude Code, Codex, Cursor, Opencode, Hermes, OpenClaw, and Pi. Each host integration consists of:
+
+1. A host-install adapter (`plugins/evo/src/evo/host_install/<host>.py`).
+2. Registration in `host_install/__init__.py` and `core.SUPPORTED_HOSTS`.
+3. Host-specific plugin/skill wiring so slash commands and mid-run inject (`evo direct`) work.
+4. Optional native dispatch support (only Claude Code currently has a fork-cache handler).
+
+Kimi Code CLI exposes:
+
+- **Agent Skills** via `SKILL.md` files.
+- **Slash commands** declared in a plugin manifest.
+- **Plugin tools** (executable commands with JSON-schema parameters).
+- **Hooks** (beta) that receive JSON on stdin and can inject context or block tool calls.
+- **Subagents** via the in-process `Agent` tool (`run_in_background`, `resume`).
+
+There is no external CLI command to spawn Kimi subagents from outside the running Kimi session, so a traditional `evo.hosts` fork handler like `claude_fork.py` is not possible. Native Kimi dispatch must be driven from inside Kimi via its `Agent` tool.
+
+## Scope
+
+This design covers the full native integration (Approach 3 from the brainstorming session), implemented in two phases:
+
+- **Phase 1:** Host adapter + plugin manifest + slash commands + hooks + drain. This makes Kimi a working evo host with skill-driven subagent dispatch.
+- **Phase 2:** Kimi plugin tools + optimize skill updates for native `Agent` subagent dispatch.
+
+Out of scope for this design:
+
+- Publishing evo to Kimi's official marketplace (can be added later).
+- Replacing evo's existing skill-driven model with a hard-coded workflow.
+- Changes to remote backend providers (modal, e2b, etc.).
+
+## Design
+
+### Host adapter
+
+New file: `plugins/evo/src/evo/host_install/kimi.py`
+
+Implements `install(args)`, `uninstall(args)`, `doctor(args)`.
+
+Responsibilities:
+
+1. Verify the `kimi` binary is on PATH.
+2. Locate or create Kimi's plugin directory (`$KIMI_CODE_HOME/plugins/managed/`).
+3. Install the evo Kimi plugin by copying `plugins/evo` (the plugin root) into `$KIMI_CODE_HOME/plugins/managed/evo/`. Prefer file-copy over `kimi plugin install` for local/development installs so `--from-path` changes are reflected without re-invoking the Kimi CLI.
+4. `--from-path <repo>` installs from `<repo>/plugins/evo`.
+5. `--version <ref>` installs from the GitHub URL `https://github.com/evo-hq/evo/tree/<ref>/plugins/evo` so Kimi fetches the plugin subdirectory.
+6. Run `kimi plugin info evo` as a sanity check.
+7. `doctor` checks that the plugin is registered, the manifest is valid, and expected skills/commands/hooks are present.
+
+### Core registration
+
+- Add `"kimi"` to `SUPPORTED_HOSTS` in `plugins/evo/src/evo/core.py`.
+- Add `kimi` adapter import and entry to `ADAPTERS` in `plugins/evo/src/evo/host_install/__init__.py`.
+
+### Plugin manifest
+
+New file: `plugins/evo/.kimi-plugin/plugin.json`
+
+```json
+{
+  "name": "evo",
+  "version": "0.7.0",
+  "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
+  "interface": {
+    "displayName": "evo",
+    "shortDescription": "Autoresearch orchestrator for codebases"
+  },
+  "skills": "./skills",
+  "commands": "./commands",
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "PreToolUse",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "Stop",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "SubagentStop",
+      "command": "evo-drain --host kimi"
+    }
+  ]
+}
+```
+
+Phase 2 adds a `tools` array to this manifest. Example tool declaration:
+
+```json
+{
+  "name": "evo_spawn_subagent",
+  "description": "Record the mapping between a Kimi Agent subagent and an evo experiment",
+  "command": ["python3", "./kimi_tools/spawn_subagent.py"],
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "exp_id": {"type": "string"},
+      "agent_id": {"type": "string"},
+      "brief": {"type": "string"}
+    },
+    "required": ["exp_id", "agent_id"]
+  }
+}
+```
+
+### Slash commands
+
+New files:
+
+- `plugins/evo/commands/discover.md`
+- `plugins/evo/commands/optimize.md`
+
+Each is a Markdown file with frontmatter:
+
+```markdown
+---
+name: discover
+description: Discover what to optimize and initialize an evo workspace.
+---
+
+Run `evo discover` in the current project. If an optimization target is provided, pass it as an argument.
+```
+
+Kimi namespaces slash commands with the plugin id, so users invoke them as `/evo:discover` and `/evo:optimize`.
+
+### Hook drain support
+
+Update `plugins/evo/src/evo/inject/drain.py`:
+
+- Add `"kimi"` to the self-contained host path.
+- Parse Kimi's stdin payload (`session_id`, `cwd`, `hook_event_name`, `tool_name`, `tool_input`, `prompt`).
+- Resolve workspace root from `cwd` (walk up to `.evo/`).
+- Register sessions on `SessionStart` / `UserPromptSubmit`.
+- Arm `optimize_mode` when prompt matches `/evo:optimize`.
+- Deliver queued `evo direct` directives via Kimi's `hookSpecificOutput.additionalContext` envelope.
+- Policy-block denied tools via `permissionDecision: "deny"` when `optimize_mode` + `subagents_only` are armed.
+- Emit stop-nudge text on `Stop` / `SubagentStop` for autonomous orchestrators.
+
+Update `plugins/evo/src/evo/inject/registry.py`:
+
+- Add Kimi session env detection if Kimi exposes a stable session env var (e.g. `KIMI_CODE_SESSION_ID`). If not, rely on hook-based registration.
+
+### Phase 2: Native Agent dispatch tools
+
+New files:
+
+- `plugins/evo/kimi_tools/spawn_subagent.py`
+- `plugins/evo/kimi_tools/wait_subagent.py`
+- `plugins/evo/src/evo/hosts/kimi_native.py`
+
+`spawn_subagent.py` is a Kimi plugin tool. It receives JSON on stdin:
+
+```json
+{
+  "exp_id": "evo-exp-0001",
+  "agent_id": "kimi-agent-abc123",
+  "brief": "..."
+}
+```
+
+It writes a mapping file under `.evo/run_XXX/experiments/<exp_id>/kimi_agent.json` so evo can correlate Kimi agent instances with experiments.
+
+`wait_subagent.py` receives an `agent_id`, reads the mapping file under `.evo/run_XXX/experiments/<exp_id>/kimi_agent.json`, and returns the status/result from evo's experiment record for that `exp_id`.
+
+`kimi_native.py` provides shared helpers for reading/writing the agent mapping and polling experiment results.
+
+Update `plugins/evo/.kimi-plugin/plugin.json` to declare these tools with JSON Schema parameters.
+
+Update `plugins/evo/skills/optimize/SKILL.md` to add a Kimi-specific subsection under "Host conventions":
+
+- Use the `Agent` tool with `subagent_type: coder`.
+- Set `run_in_background: true`.
+- Use `description: evo-exp-<exp_id>`.
+- Pass the brief as `prompt`.
+- After spawning, call the `evo_spawn_subagent` plugin tool to record the mapping.
+- To wait, call `evo_wait_subagent` or poll `evo status <exp_id>`.
+
+### Documentation updates
+
+- `README.md`: add Kimi to the list of supported hosts and install example.
+- `plugins/evo/skills/infra-setup/references/provider-matrix.md`: add Kimi row.
+
+## Error handling
+
+- Hook failures are fail-open: a crashing `evo-drain` returns non-zero or emits invalid JSON, and Kimi allows the underlying tool call.
+- If the `kimi` binary is missing, `evo install kimi` exits with error code 2 and a clear install hint.
+- If Kimi's hook API changes (beta), degrade to plain stdout context injection.
+- If the `Agent` tool is unavailable, the optimize skill falls back to orchestrator-owned sequential experiments.
+
+## Testing
+
+- Unit tests for `host_install/kimi.py` using a temporary `$KIMI_CODE_HOME`.
+- Unit tests for `evo-drain --host kimi` payload parsing and envelope emission.
+- Unit tests for `kimi_tools/spawn_subagent.py` and `wait_subagent.py` against a synthetic evo workspace.
+- Smoke test: `evo install kimi --from-path <repo>` in a clean environment, then run `kimi plugin info evo` and `evo doctor kimi`.
+- Optional live test: run `/evo:optimize subagents=2` in a real Kimi session against a trivial benchmark repo.
+
+## Open questions
+
+1. Does Kimi expose a stable session env var (e.g. `KIMI_CODE_SESSION_ID`) that subprocesses can read? If yes, we should add it to `registry.HOST_SESSION_ENV_VARS`.
+2. Does Kimi's `hookSpecificOutput.additionalContext` work on `Stop` events for autonomous continuation, or do we need a different mechanism (e.g. plugin tool follow-up)?
+3. Should the Kimi plugin be installed per-user (`~/.kimi/plugins/`) or can it be workspace-local? The Kimi docs currently say plugins are per-user.
+
+These questions should be answered during implementation or via live testing, with sensible defaults chosen when ambiguous.
+
+## Risks
+
+- Kimi's plugin and hook systems are beta and may change. We should keep the integration surface small and version-gate where possible.
+- Native Agent dispatch depends on Kimi's in-process `Agent` tool, which may not be available in all Kimi configurations.
+- The skill body may need tuning after real-world use.
+
+## References
+
+- [Kimi Code CLI Plugins docs](https://moonshotai.github.io/kimi-cli/en/customization/plugins.html)
+- [Kimi Code CLI Hooks docs](https://moonshotai.github.io/kimi-cli/en/customization/hooks.html)
+- [Kimi Code CLI Agents and Subagents docs](https://moonshotai.github.io/kimi-cli/en/customization/agents.html)

--- a/plugins/evo/.kimi-plugin/plugin.json
+++ b/plugins/evo/.kimi-plugin/plugin.json
@@ -29,5 +29,33 @@
       "event": "SubagentStop",
       "command": "evo-drain --host kimi"
     }
+  ],
+  "tools": [
+    {
+      "name": "evo_spawn_subagent",
+      "description": "Record the mapping between a Kimi Agent subagent and an evo experiment",
+      "command": ["python3", "./kimi_tools/spawn_subagent.py"],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "exp_id": {"type": "string"},
+          "agent_id": {"type": "string"},
+          "brief": {"type": "string"}
+        },
+        "required": ["exp_id", "agent_id"]
+      }
+    },
+    {
+      "name": "evo_wait_subagent",
+      "description": "Poll the evo experiment result for a given Kimi Agent id",
+      "command": ["python3", "./kimi_tools/wait_subagent.py"],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agent_id": {"type": "string"}
+        },
+        "required": ["agent_id"]
+      }
+    }
   ]
 }

--- a/plugins/evo/.kimi-plugin/plugin.json
+++ b/plugins/evo/.kimi-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "evo",
+  "version": "0.7.0",
+  "description": "Structured experiment-driven code optimization using tree search and parallel subagents",
+  "interface": {
+    "displayName": "evo",
+    "shortDescription": "Autoresearch orchestrator for codebases"
+  },
+  "skills": "./skills",
+  "commands": "./commands",
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "PreToolUse",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "Stop",
+      "command": "evo-drain --host kimi"
+    },
+    {
+      "event": "SubagentStop",
+      "command": "evo-drain --host kimi"
+    }
+  ]
+}

--- a/plugins/evo/commands/discover.md
+++ b/plugins/evo/commands/discover.md
@@ -1,0 +1,6 @@
+---
+name: discover
+description: Discover what to optimize and initialize an evo workspace.
+---
+
+Run `evo discover` in the current project. If the user provides an optimization target, pass it as an argument. After this command completes, use `evo status` to confirm the workspace is initialized, then run `/evo:optimize` to start the loop.

--- a/plugins/evo/commands/optimize.md
+++ b/plugins/evo/commands/optimize.md
@@ -1,0 +1,6 @@
+---
+name: optimize
+description: Run the evo autoresearch optimization loop.
+---
+
+Run `evo optimize` in the current project. This starts the structured experiment loop. You may pass parameters like `subagents=N` or `autonomous` as arguments. Do not edit files or run experiments manually while the loop is active unless the user explicitly asks for direct execution.

--- a/plugins/evo/kimi_tools/_bootstrap.py
+++ b/plugins/evo/kimi_tools/_bootstrap.py
@@ -1,0 +1,32 @@
+"""Bootstrap helper for Kimi plugin tools: locate the evo source tree."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _find_evo_src(start: Path) -> Path | None:
+    """Search upward from ``start`` for a directory containing
+    ``src/evo/__init__.py``.
+
+    Works both in the development repo (``repo/plugins/evo/kimi_tools``)
+    and in Kimi's managed plugin directory
+    (``KIMI_CODE_HOME/plugins/managed/evo/kimi_tools``), where the
+    relative depth to the repo root differs.
+    """
+    for parent in [start, *start.parents]:
+        src = parent / "src"
+        if (src / "evo" / "__init__.py").exists():
+            return src
+    return None
+
+
+def add_evo_src_to_path() -> None:
+    """Insert the evo package ``src`` directory into ``sys.path``."""
+    here = Path(__file__).resolve().parent
+    src = _find_evo_src(here)
+    if src is None:
+        sys.stderr.write("ERROR: evo source tree not found\n")
+        sys.exit(2)
+    sys.path.insert(0, str(src))

--- a/plugins/evo/kimi_tools/spawn_subagent.py
+++ b/plugins/evo/kimi_tools/spawn_subagent.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Kimi plugin tool: record the mapping between a Kimi Agent and an evo experiment."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.core import find_workspace_root, workspace_path
+from evo.hosts.kimi_native import write_agent_mapping
+
+
+def main() -> int:
+    try:
+        params = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "invalid json stdin"}))
+        return 2
+
+    exp_id = params.get("exp_id")
+    agent_id = params.get("agent_id")
+    if not exp_id or not agent_id:
+        print(json.dumps({"error": "exp_id and agent_id are required"}))
+        return 2
+
+    run_dir_env = os.environ.get("EVO_RUN_DIR")
+    if run_dir_env:
+        run_dir = Path(run_dir_env)
+        root = find_workspace_root(run_dir)
+    else:
+        root = find_workspace_root(Path.cwd())
+        run_dir = workspace_path(root) if root else None
+
+    if root is None:
+        print(json.dumps({"error": "not inside an evo workspace"}))
+        return 2
+
+    write_agent_mapping(run_dir, exp_id, {
+        "agent_id": agent_id,
+        "exp_id": exp_id,
+        "brief": params.get("brief", ""),
+    })
+    print(json.dumps({"status": "ok", "exp_id": exp_id, "agent_id": agent_id}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/evo/kimi_tools/spawn_subagent.py
+++ b/plugins/evo/kimi_tools/spawn_subagent.py
@@ -8,8 +8,9 @@ import os
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+from _bootstrap import add_evo_src_to_path
+
+add_evo_src_to_path()
 
 from evo.core import find_workspace_root, workspace_path
 from evo.hosts.kimi_native import write_agent_mapping

--- a/plugins/evo/kimi_tools/wait_subagent.py
+++ b/plugins/evo/kimi_tools/wait_subagent.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Kimi plugin tool: poll the evo experiment result for a given Kimi Agent id."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.core import experiment_result_path, find_workspace_root, workspace_path
+from evo.hosts.kimi_native import read_agent_mapping_by_agent_id
+
+
+def main() -> int:
+    try:
+        params = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        print(json.dumps({"error": "invalid json stdin"}))
+        return 2
+
+    agent_id = params.get("agent_id")
+    if not agent_id:
+        print(json.dumps({"error": "agent_id is required"}))
+        return 2
+
+    run_dir_env = os.environ.get("EVO_RUN_DIR")
+    if run_dir_env:
+        run_dir = Path(run_dir_env)
+        root = find_workspace_root(run_dir)
+    else:
+        root = find_workspace_root(Path.cwd())
+        run_dir = workspace_path(root) if root else None
+
+    if root is None:
+        print(json.dumps({"error": "not inside an evo workspace"}))
+        return 2
+
+    mapping = read_agent_mapping_by_agent_id(run_dir, agent_id)
+    if mapping is None:
+        print(json.dumps({"error": "agent mapping not found"}))
+        return 2
+
+    exp_id = mapping["exp_id"]
+    result_path = experiment_result_path(root, exp_id)
+    result = None
+    status = "pending"
+    if result_path.exists():
+        try:
+            result = json.loads(result_path.read_text())
+            status = result.get("status", "evaluated")
+        except (OSError, json.JSONDecodeError):
+            status = "error"
+    out = {
+        "agent_id": agent_id,
+        "exp_id": exp_id,
+        "status": status,
+        "result": result,
+    }
+    print(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/evo/kimi_tools/wait_subagent.py
+++ b/plugins/evo/kimi_tools/wait_subagent.py
@@ -8,8 +8,9 @@ import os
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+from _bootstrap import add_evo_src_to_path
+
+add_evo_src_to_path()
 
 from evo.core import experiment_result_path, find_workspace_root, workspace_path
 from evo.hosts.kimi_native import read_agent_mapping_by_agent_id

--- a/plugins/evo/skills/infra-setup/references/provider-matrix.md
+++ b/plugins/evo/skills/infra-setup/references/provider-matrix.md
@@ -11,7 +11,6 @@ Use this as the compact summary. This is setup guidance, not a runtime dependenc
 | `azure` | Azure Python SDK (`azure-identity`, `azure-mgmt-resource`, `azure-mgmt-network`, `azure-mgmt-compute`) | If missing, install `evo-hq-cli[azure]`; then use `az login` or Azure env creds, and provide subscription/resource-group config | `subscription_id`, `resource_group`, `location`, `vm_size`, `image`, `key`, `ssh_public_key`, `ssh_user`, `ssh_cidr`, `vnet_cidr`, `subnet_cidr`, `ssh_port`, `timeout_seconds`, `health_timeout_seconds`, `keep_warm` |
 | `ssh` | local `ssh` transport | `ssh user@host` must work first; then add `-i` / `-p` if needed | `host`, `key`, `port`, `tunnel_port`, `keep_warm`, `health_timeout_seconds` |
 | `manual` | existing remote workspace endpoint | no provisioning; only ask for URL/token if the user explicitly wants manual mode | `base_url`, `bearer_token`, `workspace_root`, `bundle_dir` |
-| `kimi` | Kimi Code CLI plugin + hooks | Install Kimi Code CLI, then `evo install kimi` | skills, commands, hooks, plugin tools (Phase 2) |
 
 Notes:
 - `evo` runtime uses the provider SDK or transport listed in the second column.

--- a/plugins/evo/skills/infra-setup/references/provider-matrix.md
+++ b/plugins/evo/skills/infra-setup/references/provider-matrix.md
@@ -11,6 +11,7 @@ Use this as the compact summary. This is setup guidance, not a runtime dependenc
 | `azure` | Azure Python SDK (`azure-identity`, `azure-mgmt-resource`, `azure-mgmt-network`, `azure-mgmt-compute`) | If missing, install `evo-hq-cli[azure]`; then use `az login` or Azure env creds, and provide subscription/resource-group config | `subscription_id`, `resource_group`, `location`, `vm_size`, `image`, `key`, `ssh_public_key`, `ssh_user`, `ssh_cidr`, `vnet_cidr`, `subnet_cidr`, `ssh_port`, `timeout_seconds`, `health_timeout_seconds`, `keep_warm` |
 | `ssh` | local `ssh` transport | `ssh user@host` must work first; then add `-i` / `-p` if needed | `host`, `key`, `port`, `tunnel_port`, `keep_warm`, `health_timeout_seconds` |
 | `manual` | existing remote workspace endpoint | no provisioning; only ask for URL/token if the user explicitly wants manual mode | `base_url`, `bearer_token`, `workspace_root`, `bundle_dir` |
+| `kimi` | Kimi Code CLI plugin + hooks | Install Kimi Code CLI, then `evo install kimi` | skills, commands, hooks, plugin tools (Phase 2) |
 
 Notes:
 - `evo` runtime uses the provider SDK or transport listed in the second column.

--- a/plugins/evo/skills/optimize/SKILL.md
+++ b/plugins/evo/skills/optimize/SKILL.md
@@ -87,6 +87,17 @@ This skill runs on any host that implements the Agent Skills spec. When the body
 - **"spawn N subagents in parallel"** -- use your host's parallel-subagent tool. See Step 5 below for the per-host spawn commands. Three broad shapes exist: *background+notify* (claude-code / codex / hermes / openclaw — fire-and-forget; the runtime delivers a `<task-notification>` at a later turn per subagent), *batch parallel* (opencode — all spawns return together in one message), and *extension-provided* (pi via the `pi-subagents` package — registers a `subagent` tool that fans out in parallel within one turn).
 - **Slash commands shown in user-facing copy** (e.g. `/evo:optimize`) -- translate to your host's mention syntax when speaking to the user (e.g. `$evo optimize` on Codex -- plugin namespace then skill name, separated by a space).
 
+### Kimi Code CLI
+
+On Kimi, use the built-in `Agent` tool to spawn optimization subagents:
+
+- `subagent_type`: `coder`
+- `run_in_background`: `true`
+- `description`: `evo-exp-<exp_id>`
+- `prompt`: the full brief, ending with the instruction to load the `evo:subagent` skill
+
+After each `Agent` call returns an `agent_id`, immediately call the `evo_spawn_subagent` plugin tool with `exp_id` and `agent_id` so evo can correlate the Kimi agent instance with the experiment. To wait for completion, call `evo_wait_subagent` with the `agent_id`, or poll `evo status <exp_id>` directly.
+
 ## Mid-run user directives (`evo direct`)
 
 The runtime may inject user-authoritative messages wrapped in this banner:

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -31,6 +31,7 @@ SUPPORTED_HOSTS = frozenset({
     "claude-science",
     "codex",
     "cursor",
+    "kimi",
     "opencode",
     "openclaw",
     "hermes",

--- a/plugins/evo/src/evo/host_install/__init__.py
+++ b/plugins/evo/src/evo/host_install/__init__.py
@@ -28,7 +28,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from . import claude_code, claude_science, codex, cursor, hermes, opencode, openclaw, pi
+from . import claude_code, claude_science, codex, cursor, hermes, kimi, opencode, openclaw, pi
 
 ADAPTERS = {
     "claude-code": claude_code,
@@ -36,6 +36,7 @@ ADAPTERS = {
     "codex": codex,
     "cursor": cursor,
     "hermes": hermes,
+    "kimi": kimi,
     "opencode": opencode,
     "openclaw": openclaw,
     "pi": pi,

--- a/plugins/evo/src/evo/host_install/kimi.py
+++ b/plugins/evo/src/evo/host_install/kimi.py
@@ -1,0 +1,23 @@
+"""Kimi Code CLI install adapter.
+
+Implements `evo install/uninstall/doctor kimi`.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def install(args: argparse.Namespace) -> int:
+    """Install the evo plugin into Kimi Code CLI."""
+    return 0
+
+
+def uninstall(args: argparse.Namespace) -> int:
+    """Remove the evo plugin from Kimi Code CLI."""
+    return 0
+
+
+def doctor(args: argparse.Namespace) -> int:
+    """Verify the evo Kimi plugin is installed and healthy."""
+    return 0

--- a/plugins/evo/src/evo/host_install/kimi.py
+++ b/plugins/evo/src/evo/host_install/kimi.py
@@ -1,37 +1,141 @@
-"""Placeholder Kimi host install adapter.
+"""Kimi Code CLI host install adapter.
 
-This module is a temporary stub for `evo install/uninstall/doctor kimi`.
-The real implementation will be added in Task 2.
+Installs evo as a Kimi plugin by copying the plugin root into Kimi's
+managed plugin directory. Also wires hooks via the plugin manifest.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
+import subprocess
 import sys
+from pathlib import Path
+
+
+def _kimi_base() -> Path:
+    home_override = os.environ.get("KIMI_CODE_HOME")
+    return Path(home_override) if home_override else Path.home() / ".kimi"
+
+
+def _kimi_plugin_dir() -> Path:
+    return _kimi_base() / "plugins" / "managed" / "evo"
+
+
+def _plugin_root(from_path: str | None = None) -> Path:
+    if from_path:
+        p = Path(from_path).resolve()
+        candidate = p / "plugins" / "evo"
+        if candidate.exists():
+            return candidate
+        if (p / ".kimi-plugin" / "plugin.json").exists() or (p / "kimi.plugin.json").exists():
+            return p
+        return candidate
+    # Running from an installed evo-hq-cli wheel: locate the plugin root
+    # relative to this source file (plugins/evo/src/evo/host_install/).
+    here = Path(__file__).resolve().parent.parent.parent  # plugins/evo
+    return here
+
+
+def _release_version_re():
+    import re
+    return re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
+
+
+def _github_source(version: str) -> str:
+    ref = f"v{version}" if _release_version_re().match(version) else version
+    return f"https://github.com/evo-hq/evo/tree/{ref}/plugins/evo"
 
 
 def install(args: argparse.Namespace) -> int:
-    """Install the evo plugin into Kimi Code CLI."""
-    print(
-        "ERROR: Kimi host adapter not yet implemented (Task 2).",
-        file=sys.stderr,
+    if shutil.which("kimi") is None:
+        print(
+            "ERROR: `kimi` binary not on PATH. Install Kimi Code CLI first:\n"
+            "  npm install -g @moonshot-ai/kimi-code-cli",
+            file=sys.stderr,
+        )
+        return 2
+
+    version = getattr(args, "version", None)
+    from_path = getattr(args, "from_path", None)
+
+    if version:
+        # Let Kimi fetch the plugin from GitHub.
+        source = _github_source(version)
+        cmd = ["kimi", "plugin", "install", source]
+        print(f"$ {' '.join(cmd)}")
+        rc = subprocess.call(cmd)
+        if rc != 0:
+            return rc
+        print(
+            "\n✓ evo installed for kimi.\n"
+            "  Start a new Kimi session (or run /reload) to load the plugin."
+        )
+        return 0
+
+    src = _plugin_root(from_path)
+    if not src.exists():
+        print(f"ERROR: evo plugin source not found at {src}", file=sys.stderr)
+        return 2
+
+    dst = _kimi_plugin_dir()
+    if dst.exists():
+        print(f"removing previous install at {dst}")
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    print(f"copying {src} -> {dst}")
+    shutil.copytree(
+        src, dst,
+        ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", "build", "dist",
+            ".pytest_cache", "*.egg-info", "node_modules",
+        ),
     )
-    return 1
+
+    print(
+        "\n✓ evo installed for kimi.\n"
+        "  Start a new Kimi session (or run /reload) to load the plugin."
+    )
+    return 0
 
 
 def uninstall(args: argparse.Namespace) -> int:
-    """Remove the evo plugin from Kimi Code CLI."""
-    print(
-        "ERROR: Kimi host adapter not yet implemented (Task 2).",
-        file=sys.stderr,
-    )
-    return 1
+    dst = _kimi_plugin_dir()
+    if dst.exists():
+        shutil.rmtree(dst)
+        print(f"removed {dst}")
+    else:
+        print("evo plugin not installed for kimi")
+    return 0
 
 
 def doctor(args: argparse.Namespace) -> int:
-    """Verify the evo Kimi plugin is installed and healthy."""
-    print(
-        "ERROR: Kimi host adapter not yet implemented (Task 2).",
-        file=sys.stderr,
-    )
-    return 1
+    if shutil.which("kimi") is None:
+        print("✗ `kimi` binary not on PATH")
+        print("  Install: npm install -g @moonshot-ai/kimi-code-cli")
+        return 1
+    print(f"✓ kimi binary: {shutil.which('kimi')}")
+
+    dst = _kimi_plugin_dir()
+    manifest = dst / ".kimi-plugin" / "plugin.json"
+    if not manifest.exists():
+        manifest = dst / "kimi.plugin.json"
+    if not manifest.exists():
+        print(f"✗ evo plugin not found at {dst}")
+        print("  Run: evo install kimi")
+        return 1
+    print(f"✓ evo plugin manifest at {manifest}")
+
+    # Basic manifest sanity
+    import json
+    try:
+        data = json.loads(manifest.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"✗ could not parse manifest: {exc}")
+        return 1
+    if data.get("name") != "evo":
+        print(f"✗ manifest name mismatch: {data.get('name')!r}")
+        return 1
+    print("✓ manifest name is 'evo'")
+    return 0

--- a/plugins/evo/src/evo/host_install/kimi.py
+++ b/plugins/evo/src/evo/host_install/kimi.py
@@ -1,23 +1,37 @@
-"""Kimi Code CLI install adapter.
+"""Placeholder Kimi host install adapter.
 
-Implements `evo install/uninstall/doctor kimi`.
+This module is a temporary stub for `evo install/uninstall/doctor kimi`.
+The real implementation will be added in Task 2.
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
 
 
 def install(args: argparse.Namespace) -> int:
     """Install the evo plugin into Kimi Code CLI."""
-    return 0
+    print(
+        "ERROR: Kimi host adapter not yet implemented (Task 2).",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def uninstall(args: argparse.Namespace) -> int:
     """Remove the evo plugin from Kimi Code CLI."""
-    return 0
+    print(
+        "ERROR: Kimi host adapter not yet implemented (Task 2).",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def doctor(args: argparse.Namespace) -> int:
     """Verify the evo Kimi plugin is installed and healthy."""
-    return 0
+    print(
+        "ERROR: Kimi host adapter not yet implemented (Task 2).",
+        file=sys.stderr,
+    )
+    return 1

--- a/plugins/evo/src/evo/host_install/kimi.py
+++ b/plugins/evo/src/evo/host_install/kimi.py
@@ -7,11 +7,15 @@ managed plugin directory. Also wires hooks via the plugin manifest.
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
 
 
 def _kimi_base() -> Path:
@@ -34,17 +38,13 @@ def _plugin_root(from_path: str | None = None) -> Path:
         return candidate
     # Running from an installed evo-hq-cli wheel: locate the plugin root
     # relative to this source file (plugins/evo/src/evo/host_install/).
-    here = Path(__file__).resolve().parent.parent.parent  # plugins/evo
+    # The plugin root is at plugins/evo, one level above the package root.
+    here = Path(__file__).resolve().parent.parent.parent.parent  # plugins/evo
     return here
 
 
-def _release_version_re():
-    import re
-    return re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
-
-
 def _github_source(version: str) -> str:
-    ref = f"v{version}" if _release_version_re().match(version) else version
+    ref = f"v{version}" if _RELEASE_VERSION_RE.match(version) else version
     return f"https://github.com/evo-hq/evo/tree/{ref}/plugins/evo"
 
 
@@ -59,13 +59,16 @@ def install(args: argparse.Namespace) -> int:
 
     version = getattr(args, "version", None)
     from_path = getattr(args, "from_path", None)
+    force = getattr(args, "force", False)
 
     if version:
         # Let Kimi fetch the plugin from GitHub.
         source = _github_source(version)
         cmd = ["kimi", "plugin", "install", source]
+        if force:
+            cmd.append("--force")
         print(f"$ {' '.join(cmd)}")
-        rc = subprocess.call(cmd)
+        rc = subprocess.run(cmd).returncode
         if rc != 0:
             return rc
         print(
@@ -80,6 +83,7 @@ def install(args: argparse.Namespace) -> int:
         return 2
 
     dst = _kimi_plugin_dir()
+    # Local copy already overwrites any previous install, so force is honored.
     if dst.exists():
         print(f"removing previous install at {dst}")
         shutil.rmtree(dst)
@@ -128,7 +132,6 @@ def doctor(args: argparse.Namespace) -> int:
     print(f"✓ evo plugin manifest at {manifest}")
 
     # Basic manifest sanity
-    import json
     try:
         data = json.loads(manifest.read_text())
     except json.JSONDecodeError as exc:

--- a/plugins/evo/src/evo/host_install/kimi.py
+++ b/plugins/evo/src/evo/host_install/kimi.py
@@ -7,12 +7,16 @@ managed plugin directory. Also wires hooks via the plugin manifest.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import re
 import shutil
-import subprocess
 import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 _RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+([.\-+a-zA-Z0-9]*)$")
@@ -43,9 +47,79 @@ def _plugin_root(from_path: str | None = None) -> Path:
     return here
 
 
-def _github_source(version: str) -> str:
+def _github_tarball_url(version: str) -> str:
     ref = f"v{version}" if _RELEASE_VERSION_RE.match(version) else version
-    return f"https://github.com/evo-hq/evo/tree/{ref}/plugins/evo"
+    if _RELEASE_VERSION_RE.match(version):
+        return f"https://github.com/evo-hq/evo/archive/refs/tags/{ref}.tar.gz"
+    return f"https://github.com/evo-hq/evo/archive/refs/heads/{ref}.tar.gz"
+
+
+def _find_extracted_plugin_root(extracted: Path) -> Path | None:
+    """Locate the evo plugin root inside an extracted GitHub archive."""
+    direct = extracted / "plugins" / "evo"
+    if (direct / ".kimi-plugin" / "plugin.json").exists():
+        return direct
+    for child in extracted.iterdir():
+        if child.is_dir():
+            candidate = child / "plugins" / "evo"
+            if (candidate / ".kimi-plugin" / "plugin.json").exists():
+                return candidate
+    return None
+
+
+def _copy_plugin_root(src: Path, dst: Path) -> None:
+    """Copy the plugin root to the Kimi managed plugin directory."""
+    if dst.exists():
+        print(f"removing previous install at {dst}")
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    print(f"copying {src} -> {dst}")
+    shutil.copytree(
+        src, dst,
+        ignore=shutil.ignore_patterns(
+            ".git", ".venv", "__pycache__", "build", "dist",
+            ".pytest_cache", "*.egg-info", "node_modules",
+        ),
+    )
+
+
+def _install_from_github(version: str) -> int:
+    """Download the evo plugin source from GitHub and install it for Kimi."""
+    url = _github_tarball_url(version)
+    print(f"downloading {url}")
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            tarball_bytes = response.read()
+    except urllib.error.URLError as exc:
+        print(f"ERROR: could not download {url}: {exc}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tarball_path = Path(tmp) / "evo.tar.gz"
+        tarball_path.write_bytes(tarball_bytes)
+        extract_dir = Path(tmp) / "extracted"
+        extract_dir.mkdir()
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            # `filter` was added in Python 3.12; keep compatibility with 3.10/3.11.
+            extract_kwargs = {"filter": "data"} if sys.version_info >= (3, 12) else {}
+            tar.extractall(path=extract_dir, **extract_kwargs)
+
+        src = _find_extracted_plugin_root(extract_dir)
+        if src is None:
+            print(
+                "ERROR: downloaded archive does not contain a valid evo plugin root "
+                "(expected .../plugins/evo/.kimi-plugin/plugin.json)",
+                file=sys.stderr,
+            )
+            return 2
+
+        _copy_plugin_root(src, _kimi_plugin_dir())
+
+    print(
+        "\n✓ evo installed for kimi.\n"
+        "  Start a new Kimi session (or run /reload) to load the plugin."
+    )
+    return 0
 
 
 def install(args: argparse.Namespace) -> int:
@@ -59,43 +133,16 @@ def install(args: argparse.Namespace) -> int:
 
     version = getattr(args, "version", None)
     from_path = getattr(args, "from_path", None)
-    force = getattr(args, "force", False)
 
     if version:
-        # Let Kimi fetch the plugin from GitHub.
-        source = _github_source(version)
-        cmd = ["kimi", "plugin", "install", source]
-        if force:
-            cmd.append("--force")
-        print(f"$ {' '.join(cmd)}")
-        rc = subprocess.run(cmd).returncode
-        if rc != 0:
-            return rc
-        print(
-            "\n✓ evo installed for kimi.\n"
-            "  Start a new Kimi session (or run /reload) to load the plugin."
-        )
-        return 0
+        return _install_from_github(version)
 
     src = _plugin_root(from_path)
     if not src.exists():
         print(f"ERROR: evo plugin source not found at {src}", file=sys.stderr)
         return 2
 
-    dst = _kimi_plugin_dir()
-    # Local copy already overwrites any previous install, so force is honored.
-    if dst.exists():
-        print(f"removing previous install at {dst}")
-        shutil.rmtree(dst)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    print(f"copying {src} -> {dst}")
-    shutil.copytree(
-        src, dst,
-        ignore=shutil.ignore_patterns(
-            ".git", ".venv", "__pycache__", "build", "dist",
-            ".pytest_cache", "*.egg-info", "node_modules",
-        ),
-    )
+    _copy_plugin_root(src, _kimi_plugin_dir())
 
     print(
         "\n✓ evo installed for kimi.\n"

--- a/plugins/evo/src/evo/hosts/kimi_native.py
+++ b/plugins/evo/src/evo/hosts/kimi_native.py
@@ -1,0 +1,45 @@
+"""Helpers for native Kimi Agent subagent dispatch.
+
+Tracks the mapping between Kimi Agent instance ids and evo experiment ids,
+and polls evo experiment results.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def agent_mapping_path(run_dir: Path, exp_id: str) -> Path:
+    return run_dir / "experiments" / exp_id / "kimi_agent.json"
+
+
+def write_agent_mapping(run_dir: Path, exp_id: str, mapping: dict) -> None:
+    p = agent_mapping_path(run_dir, exp_id)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    from evo.core import atomic_write_json
+    atomic_write_json(p, mapping)
+
+
+def read_agent_mapping(run_dir: Path, exp_id: str) -> dict | None:
+    p = agent_mapping_path(run_dir, exp_id)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def read_agent_mapping_by_agent_id(run_dir: Path, agent_id: str) -> dict | None:
+    exp_dir = run_dir / "experiments"
+    if not exp_dir.exists():
+        return None
+    for p in exp_dir.rglob("kimi_agent.json"):
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("agent_id") == agent_id:
+            return data
+    return None

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -442,13 +442,13 @@ def _self_contained_gate(
                 and _is_denied_in_optimize_mode(tool_name, tool_input)):
             return True
 
-    if hook_event == "preToolUse" and _cursor_tool_class(tool_name) != "shell":
-        # Only shell delivers mid-turn (updated_input echo into stdout, which
-        # the model reliably reads). For every other tool, deny+agent_message
-        # CONSUMES the directive without actually delivering it (verified: a
-        # Read deny clears the marker but the agent never gets the message).
-        # So defer (no consume) — the directive waits for the next shell call
-        # or the turn-end `stop`, both of which deliver reliably.
+    if hook_event in ("preToolUse", "PreToolUse") and _cursor_tool_class(tool_name) != "shell":
+        # Only shell delivers mid-turn. Cursor uses updated_input echo into
+        # stdout; Kimi uses hookSpecificOutput.additionalContext, which is
+        # unproven on non-shell events. For every other tool, emitting a
+        # directive CONSUMES it without guaranteed delivery, so defer (no
+        # consume) — the directive waits for the next shell call or the
+        # turn-end stop, both of which deliver reliably.
         return False
     if fresh:
         return False  # just registered on this event; nothing marked yet

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -149,6 +149,7 @@ def _resolve_root_from_payload(payload: dict) -> Path | None:
     hook command runs from outside the project. Cursor's user-level
     `~/.cursor/hooks.json` runs from `~/.cursor/`, not the repo, so cwd is
     useless — the project path arrives in the payload's `workspace_roots`.
+    Kimi supplies the path in `cwd`, which is tried after `workspace_roots`.
     Falls back to walking up from cwd. Returns None if no `.evo/` is found.
     """
     candidates: list[Path] = []
@@ -326,7 +327,7 @@ def _maybe_mark_engaged_from_shell(
     hook_event: str | None,
     payload: dict | None,
 ) -> None:
-    """For self-contained hosts (currently Cursor): if the agent's about
+    """For self-contained hosts (Cursor, Kimi): if the agent's about
     to run an `evo` shell command, mark the session as evo-engaged and
     seed the workspace offset to the queue tail. Mirrors what
     `auto_register_from_env` does for hosts that route engagement
@@ -1404,7 +1405,7 @@ def _maybe_stop_nudge_text(
         return None
     if not sess.get("autonomous"):
         return None  # opt-in only; default /optimize stops naturally
-    if host not in ("claude-code", "codex", "cursor"):
+    if host not in ("claude-code", "codex", "cursor", "kimi"):
         return None  # no known stop-continuation envelope on this host
     # Workflow driver self-drives: the dynamic workflow runs the whole round loop in-process
     # (one long Workflow tool call) until its own stall limit. The always-fire stop nudge is the
@@ -1427,15 +1428,15 @@ def main(argv: list[str] | None = None) -> int:
     1. Front-ended by the `evo-hook-drain` Rust binary (claude-code/codex):
        it passes `--run-dir` and `--session` and has already done the marker
        gate, so this just drains.
-    2. Self-contained (cursor): the host's hooks.json calls `evo-drain
-       --host cursor` directly with no Rust binary in front. `--run-dir` and
+    2. Self-contained (cursor/kimi): the host's hooks.json calls `evo-drain
+       --host <host>` directly with no Rust binary in front. `--run-dir` and
        `--session` are omitted; they're resolved from the hook stdin payload
-       (`workspace_roots`, `conversation_id`) and the marker gate runs here.
+       (`workspace_roots`, `conversation_id`/`session_id`) and the marker gate runs here.
     """
     parser = argparse.ArgumentParser(prog="evo.drain")
     parser.add_argument("--run-dir", default=None, help="Path to .evo/run_*/ directory (omit for self-contained hosts)")
     parser.add_argument("--session", default=None, help="session_id to drain (omit to read from stdin payload)")
-    parser.add_argument("--host", default=None, help="host name (claude-code/codex/hermes/opencode/cursor); auto-detected if omitted")
+    parser.add_argument("--host", default=None, help="host name (claude-code/codex/hermes/opencode/cursor/kimi); auto-detected if omitted")
     args = parser.parse_args(argv)
 
     payload = _read_stdin_payload()
@@ -1474,7 +1475,10 @@ def main(argv: list[str] | None = None) -> int:
     # Mode 2: self-contained — resolve everything from args + stdin payload.
     host = args.host or "cursor"
     if host in ("cursor", "kimi"):
-        session = args.session or payload.get("session_id") or payload.get("conversation_id")
+        if host == "cursor":
+            session = args.session or payload.get("conversation_id") or payload.get("session_id")
+        else:
+            session = args.session or payload.get("session_id") or payload.get("conversation_id")
         root = _resolve_root_from_payload(payload)
         if not session or root is None or not inject_root(root).parent.exists():
             _drain_debug(stage="resolve", host=host, hook_event=hook_event,
@@ -1486,8 +1490,7 @@ def main(argv: list[str] | None = None) -> int:
         tool_input = payload.get("tool_input") or {}
         registered = session_file(root, session).exists()
         has_marker = marker.exists(root, session)
-        if host == "cursor":
-            _maybe_mark_engaged_from_shell(root, session, host, hook_event, payload)
+        _maybe_mark_engaged_from_shell(root, session, host, hook_event, payload)
         _maybe_mark_autonomous_from_shell(root, session, host, hook_event, payload)
         gate = _self_contained_gate(root, session, host, hook_event, tool_name, tool_input)
         _maybe_mark_optimize_from_prompt(root, session, host, hook_event, payload)

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -155,6 +155,9 @@ def _resolve_root_from_payload(payload: dict) -> Path | None:
     roots = payload.get("workspace_roots")
     if isinstance(roots, list):
         candidates.extend(Path(r) for r in roots if isinstance(r, str) and r)
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        candidates.append(Path(cwd))
     candidates.append(Path.cwd())
     for start in candidates:
         cur = start
@@ -226,6 +229,8 @@ _OPTIMIZE_INVOCATION_PATTERNS: dict[str, list[_re.Pattern[str]]] = {
     ],
     # Cursor: `/cmd` only, no plugin namespacing. Bare /optimize covers it.
     "cursor": [_re.compile(r"(?:^|[^A-Za-z0-9_/:-])/optimize\b", _re.IGNORECASE)],
+    # Kimi: accepts both the canonical /evo:optimize and the bare /optimize.
+    "kimi": [_re.compile(r"(?:^|[^A-Za-z0-9_/:-])/(?:evo:)?optimize\b", _re.IGNORECASE)],
     # Hermes: bundled plugins can namespace their skills as `/plugin:skill`
     # (verified against hermes-agent/agent/skill_commands.py). evo's
     # current install lays bare skills into ~/.agents/skills/optimize/,
@@ -327,7 +332,7 @@ def _maybe_mark_engaged_from_shell(
     `auto_register_from_env` does for hosts that route engagement
     through the Python CLI path.
     """
-    if host != "cursor":
+    if host not in ("cursor", "kimi"):
         return
     if hook_event != "preToolUse":
         return
@@ -364,7 +369,7 @@ def _maybe_mark_autonomous_from_shell(
     commands and arm/disarm the matching hook session in-process. This is
     idempotent and covers hosts whose shell subprocess lacks the same session
     env var the hook payload carries."""
-    if host not in ("cursor", "codex", "claude-code"):
+    if host not in ("cursor", "codex", "claude-code", "kimi"):
         return
     if hook_event not in ("preToolUse", "PreToolUse"):
         return
@@ -585,6 +590,15 @@ def emit_for_host(host: str, hook_event: str | None, text: str, payload: dict | 
             out = {"permission": "allow", "updated_input": tool_input}
         else:
             out = {"additional_context": text}
+        sys.stdout.write(json.dumps(out, separators=(",", ":")))
+        return
+    if host == "kimi":
+        # Kimi hooks: exit-0 stdout is added to the agent's context. The
+        # structured envelope uses hookSpecificOutput with additionalContext.
+        # Policy blocks are emitted by drain_session before this function is
+        # called, using the same envelope with permissionDecision: deny.
+        evt = hook_event or "PreToolUse"
+        out = {"hookSpecificOutput": {"hookEventName": evt, "additionalContext": text}}
         sys.stdout.write(json.dumps(out, separators=(",", ":")))
         return
     # opencode and other in-process hosts: this entry point shouldn't
@@ -1458,46 +1472,34 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     # Mode 2: self-contained — resolve everything from args + stdin payload.
-    # Key on conversation_id: it's present in EVERY Cursor hook event, whereas
-    # session_id only appears in sessionStart. Keying on session_id would
-    # register the session under one id at sessionStart and then look up a
-    # different id at postToolUse (where session_id is absent), so mid-run
-    # directives would never be delivered.
     host = args.host or "cursor"
-    session = args.session or payload.get("conversation_id") or payload.get("session_id")
-    root = _resolve_root_from_payload(payload)
-    if not session or root is None or not inject_root(root).parent.exists():
-        _drain_debug(stage="resolve", host=host, hook_event=hook_event,
-                     payload_keys=sorted(payload.keys()), session=session,
-                     root=str(root) if root else None, decision="bail")
-        sys.stdout.write("{}")
-        return 0
-    tool_name = payload.get("tool_name")
-    tool_input = payload.get("tool_input") or {}
-    registered = session_file(root, session).exists()
-    has_marker = marker.exists(root, session)
-    # Cursor has no session-id env var that Python `auto_register_from_env`
-    # can detect, so the engagement signal can't be set via the CLI path
-    # used by other hosts. Detect it here instead: if the agent runs any
-    # `evo …` shell command, flip engagement on this session's record.
-    _maybe_mark_engaged_from_shell(root, session, host, hook_event, payload)
-    # Same rationale for autonomous: cursor arms via observing the command.
-    _maybe_mark_autonomous_from_shell(root, session, host, hook_event, payload)
-    gate = _self_contained_gate(root, session, host, hook_event, tool_name, tool_input)
-    # Detect /optimize invocation from the prompt payload for cursor's
-    # self-contained path. Must run AFTER the gate because the gate is
-    # what lazily registers the cursor session on first event (without
-    # registration, mark_optimize_mode finds no session file). The
-    # mark_optimize_mode helper is idempotent + refuses to flag subagents.
-    _maybe_mark_optimize_from_prompt(root, session, host, hook_event, payload)
-    _drain_debug(stage="gate", host=host, hook_event=hook_event, session=session,
-                 root=str(root), tool_name=tool_name,
-                 tool_class=_cursor_tool_class(tool_name) if hook_event == "preToolUse" else None,
-                 registered_before=registered, marker=has_marker, gate=gate)
-    if not gate:
-        sys.stdout.write("{}")
-        return 0
-    return drain_session(root, session, host=host, hook_event=hook_event, payload=payload)
+    if host in ("cursor", "kimi"):
+        session = args.session or payload.get("session_id") or payload.get("conversation_id")
+        root = _resolve_root_from_payload(payload)
+        if not session or root is None or not inject_root(root).parent.exists():
+            _drain_debug(stage="resolve", host=host, hook_event=hook_event,
+                         payload_keys=sorted(payload.keys()), session=session,
+                         root=str(root) if root else None, decision="bail")
+            sys.stdout.write("{}")
+            return 0
+        tool_name = payload.get("tool_name")
+        tool_input = payload.get("tool_input") or {}
+        registered = session_file(root, session).exists()
+        has_marker = marker.exists(root, session)
+        if host == "cursor":
+            _maybe_mark_engaged_from_shell(root, session, host, hook_event, payload)
+        _maybe_mark_autonomous_from_shell(root, session, host, hook_event, payload)
+        gate = _self_contained_gate(root, session, host, hook_event, tool_name, tool_input)
+        _maybe_mark_optimize_from_prompt(root, session, host, hook_event, payload)
+        _drain_debug(stage="gate", host=host, hook_event=hook_event, session=session,
+                     root=str(root), tool_name=tool_name,
+                     registered_before=registered, marker=has_marker, gate=gate)
+        if not gate:
+            sys.stdout.write("{}")
+            return 0
+        return drain_session(root, session, host=host, hook_event=hook_event, payload=payload)
+    sys.stdout.write("{}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -433,7 +433,7 @@ def _self_contained_gate(
     #     IDE drops — silently losing the directive.
     sess = get_session(root, session_id)
     if sess and sess.get("optimize_mode") and not sess.get("exp_id"):
-        if hook_event in ("stop", "subagentStop"):
+        if hook_event in ("stop", "subagentStop", "Stop", "SubagentStop"):
             return True
         # Only treat a denied tool as drain-worthy when subagents_only is
         # armed — otherwise there's no policy deny to emit (default allows

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -438,7 +438,7 @@ def _self_contained_gate(
         # Only treat a denied tool as drain-worthy when subagents_only is
         # armed — otherwise there's no policy deny to emit (default allows
         # orchestrator edits).
-        if (hook_event == "preToolUse" and sess.get("subagents_only")
+        if (hook_event in ("preToolUse", "PreToolUse") and sess.get("subagents_only")
                 and _is_denied_in_optimize_mode(tool_name, tool_input)):
             return True
 

--- a/plugins/evo/src/evo/inject/drain.py
+++ b/plugins/evo/src/evo/inject/drain.py
@@ -335,7 +335,7 @@ def _maybe_mark_engaged_from_shell(
     """
     if host not in ("cursor", "kimi"):
         return
-    if hook_event != "preToolUse":
+    if hook_event not in ("preToolUse", "PreToolUse"):
         return
     if _cursor_tool_class((payload or {}).get("tool_name")) != "shell":
         return

--- a/plugins/evo/src/evo/inject/registry.py
+++ b/plugins/evo/src/evo/inject/registry.py
@@ -40,6 +40,7 @@ HOST_SESSION_ENV_VARS = (
     ("codex", "CODEX_THREAD_ID"),
     ("claude-code", "CLAUDE_CODE_SESSION_ID"),
     ("hermes", "HERMES_SESSION_ID"),
+    ("kimi", "KIMI_CODE_SESSION_ID"),
     ("opencode", "OPENCODE_SESSION_ID"),
 )
 

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
 
 from evo.inject.drain import main
 from evo.inject.paths import session_file
-from evo.inject.registry import register_session
+from evo.inject.registry import detect_session, register_session
 
 
 def _make_workspace(tmp: Path) -> Path:
@@ -80,3 +80,12 @@ class KimiDrainTest(unittest.TestCase):
             "tool_input": {"command": "echo hi"},
         })
         assert out == {}
+
+
+def test_detect_session_from_kimi_env(monkeypatch):
+    monkeypatch.setenv("KIMI_CODE_SESSION_ID", "kimi-sid-123")
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.delenv("OPENCODE_SESSION_ID", raising=False)
+    assert detect_session() == ("kimi", "kimi-sid-123")

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
 
 from evo.inject.drain import main
 from evo.inject.paths import session_file
-from evo.inject.registry import detect_session, mark_autonomous, mark_optimize_mode, register_session
+from evo.inject.registry import detect_session, mark_autonomous, mark_optimize_mode, mark_subagents_only, register_session
 
 
 def _make_workspace(tmp: Path) -> Path:
@@ -120,6 +120,21 @@ class KimiDrainTest(unittest.TestCase):
         rec = json.loads(session_file(self.root, sid).read_text())
         assert rec.get("has_evo_engaged") is True
         assert rec.get("engaged_at")
+
+    def test_pretooluse_edit_denied_when_subagents_only_for_kimi(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        mark_optimize_mode(self.root, sid)
+        mark_subagents_only(self.root, sid)
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"path": "agent.py"},
+        })
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "EVO POLICY" in out["hookSpecificOutput"]["permissionDecisionReason"]
 
 
 def test_detect_session_from_kimi_env(monkeypatch):

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -94,6 +94,18 @@ class KimiDrainTest(unittest.TestCase):
         assert "hookSpecificOutput" in out
         assert "[EVO LOOP]" in out["hookSpecificOutput"]["additionalContext"]
 
+    def test_pretooluse_non_shell_defers_for_kimi(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"path": "agent.py"},
+        })
+        assert out == {}
+
 
 def test_detect_session_from_kimi_env(monkeypatch):
     monkeypatch.setenv("KIMI_CODE_SESSION_ID", "kimi-sid-123")

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
 
 from evo.inject.drain import main
 from evo.inject.paths import session_file
-from evo.inject.registry import detect_session, register_session
+from evo.inject.registry import detect_session, mark_autonomous, mark_optimize_mode, register_session
 
 
 def _make_workspace(tmp: Path) -> Path:
@@ -80,6 +80,19 @@ class KimiDrainTest(unittest.TestCase):
             "tool_input": {"command": "echo hi"},
         })
         assert out == {}
+
+    def test_stop_event_in_optimize_autonomous_emits_nudge(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        mark_optimize_mode(self.root, sid)
+        mark_autonomous(self.root, sid)
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "Stop",
+        })
+        assert "hookSpecificOutput" in out
+        assert "[EVO LOOP]" in out["hookSpecificOutput"]["additionalContext"]
 
 
 def test_detect_session_from_kimi_env(monkeypatch):

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -106,6 +106,21 @@ class KimiDrainTest(unittest.TestCase):
         })
         assert out == {}
 
+    def test_pretooluse_shell_evo_marks_engaged_for_kimi(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "tool_input": {"command": "evo direct hello"},
+        })
+        assert out == {}
+        rec = json.loads(session_file(self.root, sid).read_text())
+        assert rec.get("has_evo_engaged") is True
+        assert rec.get("engaged_at")
+
 
 def test_detect_session_from_kimi_env(monkeypatch):
     monkeypatch.setenv("KIMI_CODE_SESSION_ID", "kimi-sid-123")

--- a/tests/unit/test_kimi_drain.py
+++ b/tests/unit/test_kimi_drain.py
@@ -1,0 +1,82 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.inject.drain import main
+from evo.inject.paths import session_file
+from evo.inject.registry import register_session
+
+
+def _make_workspace(tmp: Path) -> Path:
+    import subprocess
+    root = tmp / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    from evo.core import init_workspace
+    init_workspace(root, target="agent.py", benchmark="python bench.py", metric="max", gate=None)
+    return root
+
+
+class KimiDrainTest(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = _make_workspace(Path(self._tmp.name))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _fire(self, payload: dict):
+        stdin_buf = io.StringIO(json.dumps(payload))
+        stdout_buf = io.StringIO()
+        with patch("sys.stdin", stdin_buf), patch("sys.stdout", stdout_buf):
+            main(["--host", "kimi"])
+        return json.loads(stdout_buf.getvalue())
+
+    def test_session_start_registers_session(self):
+        sid = "kimi-test-sid"
+        self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        })
+        rec = json.loads(session_file(self.root, sid).read_text())
+        assert rec["host"] == "kimi"
+        assert rec["session_id"] == sid
+
+    def test_user_prompt_submit_arms_optimize_mode(self):
+        sid = "kimi-test-sid"
+        self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "/evo:optimize",
+        })
+        rec = json.loads(session_file(self.root, sid).read_text())
+        assert rec["optimize_mode"] is True
+
+    def test_pretooluse_empty_marker_returns_empty(self):
+        sid = "kimi-test-sid"
+        register_session(self.root, sid, "kimi")
+        out = self._fire({
+            "session_id": sid,
+            "cwd": str(self.root),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "tool_input": {"command": "echo hi"},
+        })
+        assert out == {}

--- a/tests/unit/test_kimi_host_install.py
+++ b/tests/unit/test_kimi_host_install.py
@@ -43,3 +43,22 @@ def test_install_missing_kimi_binary(fake_kimi_home, monkeypatch):
     from argparse import Namespace
     rc = kimi_mod.install(Namespace(from_path=None, version=None, force=False))
     assert rc == 2
+
+
+def test_install_copies_plugin(fake_kimi_home, tmp_path, monkeypatch):
+    # Use the real plugin root from this checkout
+    here = Path(__file__).resolve().parents[2] / "plugins" / "evo"
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/kimi" if name == "kimi" else None)
+    from argparse import Namespace
+    rc = kimi_mod.install(Namespace(from_path=str(here.parent.parent), version=None, force=False))
+    assert rc == 0
+    assert (fake_kimi_home / "plugins" / "managed" / "evo" / ".kimi-plugin" / "plugin.json").exists()
+
+
+def test_doctor_after_install(fake_kimi_home, tmp_path, monkeypatch):
+    here = Path(__file__).resolve().parents[2] / "plugins" / "evo"
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/kimi" if name == "kimi" else None)
+    from argparse import Namespace
+    kimi_mod.install(Namespace(from_path=str(here.parent.parent), version=None, force=False))
+    rc = kimi_mod.doctor(Namespace())
+    assert rc == 0

--- a/tests/unit/test_kimi_host_install.py
+++ b/tests/unit/test_kimi_host_install.py
@@ -1,0 +1,12 @@
+from evo.host_install import get, SUPPORTED_HOSTS
+
+
+def test_kimi_is_supported():
+    assert "kimi" in SUPPORTED_HOSTS
+
+
+def test_kimi_adapter_registered():
+    module = get("kimi")
+    assert hasattr(module, "install")
+    assert hasattr(module, "uninstall")
+    assert hasattr(module, "doctor")

--- a/tests/unit/test_kimi_host_install.py
+++ b/tests/unit/test_kimi_host_install.py
@@ -1,8 +1,10 @@
+from evo import core
 from evo.host_install import get, SUPPORTED_HOSTS
 
 
 def test_kimi_is_supported():
     assert "kimi" in SUPPORTED_HOSTS
+    assert "kimi" in core.SUPPORTED_HOSTS
 
 
 def test_kimi_adapter_registered():

--- a/tests/unit/test_kimi_host_install.py
+++ b/tests/unit/test_kimi_host_install.py
@@ -1,5 +1,12 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
 from evo import core
 from evo.host_install import get, SUPPORTED_HOSTS
+from evo.host_install import kimi as kimi_mod
 
 
 def test_kimi_is_supported():
@@ -12,3 +19,27 @@ def test_kimi_adapter_registered():
     assert hasattr(module, "install")
     assert hasattr(module, "uninstall")
     assert hasattr(module, "doctor")
+
+
+@pytest.fixture
+def fake_kimi_home(tmp_path, monkeypatch):
+    home = tmp_path / "kimi-home"
+    home.mkdir()
+    monkeypatch.setenv("KIMI_CODE_HOME", str(home))
+    return home
+
+
+def test_kimi_base_honors_env_var(fake_kimi_home):
+    assert kimi_mod._kimi_base() == fake_kimi_home
+
+
+def test_kimi_base_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    assert kimi_mod._kimi_base() == Path.home() / ".kimi"
+
+
+def test_install_missing_kimi_binary(fake_kimi_home, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    from argparse import Namespace
+    rc = kimi_mod.install(Namespace(from_path=None, version=None, force=False))
+    assert rc == 2

--- a/tests/unit/test_kimi_host_install.py
+++ b/tests/unit/test_kimi_host_install.py
@@ -1,4 +1,6 @@
+import io
 import os
+import tarfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -62,3 +64,28 @@ def test_doctor_after_install(fake_kimi_home, tmp_path, monkeypatch):
     kimi_mod.install(Namespace(from_path=str(here.parent.parent), version=None, force=False))
     rc = kimi_mod.doctor(Namespace())
     assert rc == 0
+
+
+def _build_fake_tarball(version: str) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        root = f"evo-{version}"
+        manifest_content = b'{"name":"evo","version":"0.7.0"}'
+        info = tarfile.TarInfo(name=f"{root}/plugins/evo/.kimi-plugin/plugin.json")
+        info.size = len(manifest_content)
+        tar.addfile(info, io.BytesIO(manifest_content))
+    return buf.getvalue()
+
+
+def test_install_version_downloads_and_copies_plugin(fake_kimi_home, monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/kimi" if name == "kimi" else None)
+    tarball = _build_fake_tarball("0.7.0")
+
+    def fake_urlopen(url, **kwargs):
+        return io.BytesIO(tarball)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    from argparse import Namespace
+    rc = kimi_mod.install(Namespace(from_path=None, version="0.7.0", force=False))
+    assert rc == 0
+    assert (fake_kimi_home / "plugins" / "managed" / "evo" / ".kimi-plugin" / "plugin.json").exists()

--- a/tests/unit/test_kimi_native_dispatch.py
+++ b/tests/unit/test_kimi_native_dispatch.py
@@ -1,0 +1,30 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.hosts.kimi_native import (
+    agent_mapping_path,
+    read_agent_mapping,
+    write_agent_mapping,
+)
+
+
+def test_mapping_round_trip():
+    with tempfile.TemporaryDirectory() as tmp:
+        run_dir = Path(tmp) / ".evo" / "run_test"
+        exp_id = "exp-0001"
+        mapping = {"agent_id": "kimi-agent-123", "exp_id": exp_id, "brief": "test"}
+        write_agent_mapping(run_dir, exp_id, mapping)
+        assert read_agent_mapping(run_dir, exp_id) == mapping
+
+
+def test_read_missing_mapping_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        run_dir = Path(tmp) / ".evo" / "run_test"
+        assert read_agent_mapping(run_dir, "exp-0000") is None

--- a/tests/unit/test_kimi_native_dispatch.py
+++ b/tests/unit/test_kimi_native_dispatch.py
@@ -53,3 +53,32 @@ def test_spawn_subagent_tool(tmp_path):
     assert r.returncode == 0
     out = json.loads(r.stdout)
     assert out["status"] == "ok"
+
+
+WAIT_TOOL = REPO_ROOT / "plugins" / "evo" / "kimi_tools" / "wait_subagent.py"
+
+
+def test_wait_subagent_tool(tmp_path):
+    root = tmp_path / "repo"
+    run_dir = root / ".evo" / "run_test"
+    exp_dir = run_dir / "experiments" / "exp-0001"
+    exp_dir.mkdir(parents=True)
+    mapping = {"agent_id": "kimi-agent-123", "exp_id": "exp-0001", "brief": ""}
+    from evo.hosts.kimi_native import write_agent_mapping
+    write_agent_mapping(run_dir, "exp-0001", mapping)
+
+    payload = json.dumps({"agent_id": "kimi-agent-123"})
+    env = {"EVO_RUN_DIR": str(root / ".evo" / "run_test")}
+    r = subprocess.run(
+        [sys.executable, str(WAIT_TOOL)],
+        input=payload,
+        env={**dict(os.environ), **env},
+        capture_output=True,
+        text=True,
+        cwd=str(root),
+    )
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["agent_id"] == "kimi-agent-123"
+    assert out["exp_id"] == "exp-0001"
+    assert out["status"] == "pending"

--- a/tests/unit/test_kimi_native_dispatch.py
+++ b/tests/unit/test_kimi_native_dispatch.py
@@ -28,3 +28,28 @@ def test_read_missing_mapping_returns_none():
     with tempfile.TemporaryDirectory() as tmp:
         run_dir = Path(tmp) / ".evo" / "run_test"
         assert read_agent_mapping(run_dir, "exp-0000") is None
+
+
+SPAWN_TOOL = REPO_ROOT / "plugins" / "evo" / "kimi_tools" / "spawn_subagent.py"
+
+
+def test_spawn_subagent_tool(tmp_path):
+    root = tmp_path / "repo"
+    (root / ".evo" / "run_test" / "experiments" / "exp-0001").mkdir(parents=True)
+    payload = json.dumps({
+        "exp_id": "exp-0001",
+        "agent_id": "kimi-agent-123",
+        "brief": "optimize parser",
+    })
+    env = {"EVO_RUN_DIR": str(root / ".evo" / "run_test")}
+    r = subprocess.run(
+        [sys.executable, str(SPAWN_TOOL)],
+        input=payload,
+        env={**dict(os.environ), **env},
+        capture_output=True,
+        text=True,
+        cwd=str(root),
+    )
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["status"] == "ok"

--- a/tests/unit/test_kimi_plugin_manifest.py
+++ b/tests/unit/test_kimi_plugin_manifest.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "plugins" / "evo" / ".kimi-plugin" / "plugin.json"
+
+
+def test_manifest_exists_and_is_valid_json():
+    assert MANIFEST.exists(), f"manifest not found at {MANIFEST}"
+    data = json.loads(MANIFEST.read_text())
+    assert data["name"] == "evo"
+    assert "version" in data
+    assert "skills" in data
+    assert "commands" in data
+    assert "hooks" in data

--- a/tests/unit/test_kimi_plugin_manifest.py
+++ b/tests/unit/test_kimi_plugin_manifest.py
@@ -24,3 +24,11 @@ def test_discover_command_file_exists():
 
 def test_optimize_command_file_exists():
     assert (COMMANDS_DIR / "optimize.md").exists()
+
+
+def test_manifest_declares_tools():
+    data = json.loads(MANIFEST.read_text())
+    tools = data.get("tools", [])
+    names = {t["name"] for t in tools}
+    assert "evo_spawn_subagent" in names
+    assert "evo_wait_subagent" in names

--- a/tests/unit/test_kimi_plugin_manifest.py
+++ b/tests/unit/test_kimi_plugin_manifest.py
@@ -13,3 +13,14 @@ def test_manifest_exists_and_is_valid_json():
     assert "skills" in data
     assert "commands" in data
     assert "hooks" in data
+
+
+COMMANDS_DIR = REPO_ROOT / "plugins" / "evo" / "commands"
+
+
+def test_discover_command_file_exists():
+    assert (COMMANDS_DIR / "discover.md").exists()
+
+
+def test_optimize_command_file_exists():
+    assert (COMMANDS_DIR / "optimize.md").exists()

--- a/tests/unit/test_kimi_plugin_manifest.py
+++ b/tests/unit/test_kimi_plugin_manifest.py
@@ -32,3 +32,13 @@ def test_manifest_declares_tools():
     names = {t["name"] for t in tools}
     assert "evo_spawn_subagent" in names
     assert "evo_wait_subagent" in names
+
+
+OPTIMIZE_SKILL = REPO_ROOT / "plugins" / "evo" / "skills" / "optimize" / "SKILL.md"
+
+
+def test_optimize_skill_mentions_kimi_agent_tool():
+    text = OPTIMIZE_SKILL.read_text()
+    assert "Kimi" in text or "kimi" in text
+    assert "Agent" in text
+    assert "evo_spawn_subagent" in text

--- a/tests/unit/test_kimi_tools_bootstrap.py
+++ b/tests/unit/test_kimi_tools_bootstrap.py
@@ -1,0 +1,37 @@
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "kimi_tools"))
+
+from _bootstrap import _find_evo_src
+
+
+def test_find_evo_src_in_dev_repo_layout():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        src = tmp / "plugins" / "evo" / "src"
+        (src / "evo").mkdir(parents=True)
+        (src / "evo" / "__init__.py").write_text("")
+        here = tmp / "plugins" / "evo" / "kimi_tools"
+        here.mkdir(parents=True)
+        assert _find_evo_src(here) == src
+
+
+def test_find_evo_src_in_installed_plugin_layout():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        # Simulates KIMI_CODE_HOME/plugins/managed/evo/kimi_tools
+        plugin_root = tmp / "plugins" / "managed" / "evo"
+        src = plugin_root / "src"
+        (src / "evo").mkdir(parents=True)
+        (src / "evo" / "__init__.py").write_text("")
+        here = plugin_root / "kimi_tools"
+        here.mkdir(parents=True)
+        assert _find_evo_src(here) == src
+
+
+def test_find_evo_src_missing_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        assert _find_evo_src(Path(tmp)) is None


### PR DESCRIPTION
- **docs: add Kimi host support plan and design, ignore worktrees**
- **feat(kimi): register kimi host in SUPPORTED_HOSTS and ADAPTERS**
- **fix(kimi): make stub adapter fail loudly, sync test with core SUPPORTED_HOSTS**
- **feat(kimi): add host install adapter with install/uninstall/doctor**
- **fix(kimi): address Task 2 review findings**
- **feat(kimi): add Kimi plugin manifest with skills, commands, and hooks**
- **feat(kimi): add /evo:discover and /evo:optimize slash commands**
- **feat(kimi): add self-contained drain path and hook envelope**
- **fix(kimi): address Task 5 review findings for Kimi drain support**
- **feat(kimi): detect Kimi session from KIMI_CODE_SESSION_ID**
- **docs(kimi): list Kimi as supported host**
- **test(kimi): smoke test install and doctor cycle**
- **feat(kimi): add native Agent dispatch mapping helpers**
- **feat(kimi): add evo_spawn_subagent plugin tool**
- **feat(kimi): add evo_wait_subagent plugin tool**
- **feat(kimi): declare evo_spawn_subagent and evo_wait_subagent tools**
- **feat(kimi): document Kimi Agent tool dispatch in optimize skill**
- **fix(kimi): version-based install fetches GitHub tarball instead of missing kimi plugin install**
