### PR TITLE
fix(codex): refresh encoded hook commands

### DIFF
--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -9,6 +9,7 @@ import base64
 import binascii
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -65,8 +66,25 @@ def _stable_hook_command() -> str:
 
 def _is_evo_hook_drain_command(command: str) -> bool:
     """Recognize source and already-materialized evo drain commands."""
-    if "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain" in command:
+    if command.strip() == "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain":
         return True
+
+    try:
+        tokens = shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        tokens = []
+    if len(tokens) == 1:
+        candidate = tokens[0]
+        if os.name == "nt" and len(candidate) >= 2:
+            if candidate[0] == candidate[-1] and candidate[0] in "'\"":
+                candidate = candidate[1:-1]
+        path = Path(candidate)
+        if (
+            path.is_absolute()
+            and path.parent.name.lower() == "bin"
+            and path.name.lower() in {"evo-hook-drain", "evo-hook-drain.exe"}
+        ):
+            return True
 
     prefix = "node -e \"eval(Buffer.from('"
     suffix = "','base64').toString())\""

--- a/plugins/evo/src/evo/host_install/codex.py
+++ b/plugins/evo/src/evo/host_install/codex.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import json
 import os
 import subprocess
@@ -62,6 +63,24 @@ def _stable_hook_command() -> str:
     return f"node -e \"eval(Buffer.from('{encoded}','base64').toString())\""
 
 
+def _is_evo_hook_drain_command(command: str) -> bool:
+    """Recognize source and already-materialized evo drain commands."""
+    if "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain" in command:
+        return True
+
+    prefix = "node -e \"eval(Buffer.from('"
+    suffix = "','base64').toString())\""
+    if not command.startswith(prefix) or not command.endswith(suffix):
+        return False
+
+    encoded = command[len(prefix):-len(suffix)]
+    try:
+        script = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return False
+    return "evo-hook-drain" in script
+
+
 def _materialize_codex_hooks(hooks_json_path: Path) -> bool:
     """Rewrite an installed Codex hooks.json to use machine-local commands.
 
@@ -88,7 +107,7 @@ def _materialize_codex_hooks(hooks_json_path: Path) -> bool:
                     handlers.append(handler)
                     continue
                 cmd = str(handler.get("command") or "")
-                if "evo-hook-drain" in cmd:
+                if _is_evo_hook_drain_command(cmd):
                     if cmd != drain_cmd:
                         handler = {**handler, "command": drain_cmd}
                         changed = True

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -424,6 +426,22 @@ class TestCodexHookMaterialization(_Base):
             self._read_command(hooks_path), codex._stable_hook_command()
         )
 
+    def test_legacy_absolute_drain_path_still_materializes(self):
+        from evo.host_install import codex
+
+        stable_path = str(codex.stable_binary_path().resolve())
+        command = (
+            subprocess.list2cmdline([stable_path])
+            if os.name == "nt"
+            else shlex.quote(stable_path)
+        )
+        hooks_path = self._write_hooks(command)
+
+        self.assertTrue(codex._materialize_codex_hooks(hooks_path))
+        self.assertEqual(
+            self._read_command(hooks_path), codex._stable_hook_command()
+        )
+
     def test_malformed_and_unrelated_wrappers_are_untouched(self):
         from evo.host_install import codex
 
@@ -431,6 +449,8 @@ class TestCodexHookMaterialization(_Base):
             "node -e \"eval(Buffer.from('not-base64!','base64').toString())\"",
             "node -e \"eval(Buffer.from('Y29uc29sZS5sb2coJ29rJyk=','base64').toString())\"",
             "node -e \"console.log('evo-hook-drain')\"",
+            "relative/bin/evo-hook-drain",
+            "/tmp/bin/evo-hook-drain --verbose",
         )
         for command in commands:
             with self.subTest(command=command):

--- a/tests/unit/test_codex_install_migration.py
+++ b/tests/unit/test_codex_install_migration.py
@@ -24,11 +24,13 @@ unrelated entries stay.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
@@ -361,6 +363,81 @@ class TestCodexConfigConvergence(_Base):
         text = self._read_config()
         self.assertNotIn("[hooks.state.", text)
         self.assertIn('[plugins."github@openai-curated"]', text)
+
+
+class TestCodexHookMaterialization(_Base):
+
+    def _write_hooks(self, command: str) -> Path:
+        hooks_path = self.codex_home / "hooks.json"
+        payload = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": command},
+                        ],
+                    },
+                ],
+            },
+        }
+        hooks_path.write_text(json.dumps(payload))
+        return hooks_path
+
+    def _read_command(self, hooks_path: Path) -> str:
+        data = json.loads(hooks_path.read_text())
+        return data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+    def test_rewrites_an_already_encoded_drain_command(self):
+        from evo.host_install import codex
+
+        old_command = codex._stable_hook_command()
+        hooks_path = self._write_hooks(old_command)
+        replacement = "replacement-evo-drain-command"
+
+        with mock.patch.object(
+            codex, "_stable_hook_command", return_value=replacement
+        ):
+            changed = codex._materialize_codex_hooks(hooks_path)
+
+        self.assertTrue(changed)
+        self.assertEqual(self._read_command(hooks_path), replacement)
+
+    def test_current_encoded_drain_command_is_idempotent(self):
+        from evo.host_install import codex
+
+        command = codex._stable_hook_command()
+        hooks_path = self._write_hooks(command)
+        before = hooks_path.read_bytes()
+
+        self.assertFalse(codex._materialize_codex_hooks(hooks_path))
+        self.assertEqual(hooks_path.read_bytes(), before)
+
+    def test_plaintext_drain_command_still_materializes(self):
+        from evo.host_install import codex
+
+        hooks_path = self._write_hooks(
+            "${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain"
+        )
+
+        self.assertTrue(codex._materialize_codex_hooks(hooks_path))
+        self.assertEqual(
+            self._read_command(hooks_path), codex._stable_hook_command()
+        )
+
+    def test_malformed_and_unrelated_wrappers_are_untouched(self):
+        from evo.host_install import codex
+
+        commands = (
+            "node -e \"eval(Buffer.from('not-base64!','base64').toString())\"",
+            "node -e \"eval(Buffer.from('Y29uc29sZS5sb2coJ29rJyk=','base64').toString())\"",
+            "node -e \"console.log('evo-hook-drain')\"",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                hooks_path = self._write_hooks(command)
+                before = hooks_path.read_bytes()
+                self.assertFalse(codex._materialize_codex_hooks(hooks_path))
+                self.assertEqual(hooks_path.read_bytes(), before)
 
 
 class TestDoctorHookBinary(_Base):


### PR DESCRIPTION
## Summary

Teach the Codex hook materializer to recognize Evo drain commands inside the existing base64-encoded Node wrapper, so repeat installs can refresh stale commands.

Fixes #84

## What changed

- Preserve support for the historical `${CLAUDE_PLUGIN_ROOT}/bin/evo-hook-drain` source command.
- Recognize only the exact `node -e "eval(Buffer.from(...,'base64').toString())"` wrapper emitted by Evo, validate and decode its payload, then look for the drain marker in the decoded script.
- Fail closed for malformed base64, non-UTF-8 payloads, different wrapper shapes, and unrelated Node commands.
- Add regressions for encoded-command refresh, current-command idempotency, plaintext compatibility, and malformed/unrelated wrappers.

## Why

After a hook has already been materialized, the literal `evo-hook-drain` marker exists only in the decoded payload. Matching the outer command therefore treated repeat installs as a no-op and prevented future wrapper updates (such as timeout changes) from propagating without `--force`.

## Test plan

- `pytest tests/unit/test_codex_install_migration.py -q` - 22 passed, 5 subtests passed
- `python tests/unit/test_codex_install_migration.py -v` on Python 3.10 and 3.14 - 22 passed on each
- `pytest tests/unit/ -q` in a Linux-native CI-equivalent copy - 803 passed, 48 skipped, 5 subtests passed
- `ruff check ... --select E4,E7,E9,F63,F7,F82`
- `python -m compileall -q` on both changed files