### PR TITLE
feat(cli): add `evo recover` for crash recovery; surface stale experiments in `evo status`

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -2171,6 +2171,30 @@ def _read_attempt_state(root: Path, exp_id: str, attempt: int) -> dict | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _stale_active_entries(root: Path, graph: dict) -> list[tuple[str, int, int]]:
+    """Local `active` nodes whose stamped driver PID is gone (or was never
+    stamped) — i.e. an `evo run` that crashed, was killed, or died on reboot
+    and left the node wedged at status=active forever.
+
+    Returns (exp_id, attempt, pid) per stale node. Remote nodes are excluded:
+    they carry their own resume metadata (stream journal) and are reclaimed by
+    re-running, not by PID liveness.
+    """
+    entries: list[tuple[str, int, int]] = []
+    for exp_id, node in graph.get("nodes", {}).items():
+        if exp_id == "root" or node.get("status") != "active":
+            continue
+        if node.get("backend") == "remote":
+            continue
+        attempt = int(node.get("current_attempt") or 0)
+        state = _read_attempt_state(root, exp_id, attempt) or {}
+        pid = int(state.get("pid") or 0)
+        if pid and _is_pid_alive(pid):
+            continue
+        entries.append((exp_id, attempt, pid))
+    return entries
+
+
 def _write_attempt_state(
     root: Path,
     exp_id: str,
@@ -4143,14 +4167,92 @@ def cmd_status(args: argparse.Namespace) -> int:
     metric = config["metric"]
     nodes = [node for node in graph["nodes"].values() if node["id"] != "root"]
     best = best_committed_score(graph, metric)
+    stale = _stale_active_entries(root, graph)
     print(
         f"metric={metric} epoch={config.get('current_eval_epoch', 1)} "
         f"experiments={len(nodes)} committed={sum(1 for n in nodes if effective_status(graph, n) == 'committed')} "
         f"evaluated={sum(1 for n in nodes if n.get('status') == 'evaluated')} "
         f"discarded={sum(1 for n in nodes if n.get('status') == 'discarded')} "
         f"failed={sum(1 for n in nodes if n.get('status') == 'failed')} "
-        f"active={sum(1 for n in nodes if n.get('status') == 'active')} best={best}"
+        f"active={sum(1 for n in nodes if n.get('status') == 'active')} "
+        f"stale={len(stale)} best={best}"
     )
+    if stale:
+        ids = ", ".join(exp_id for exp_id, _a, _p in stale)
+        print(
+            f"\n! {len(stale)} stale active experiment(s) — driver process "
+            f"gone: {ids}"
+        )
+        print("  Run `evo recover` to mark them failed (traces preserved).")
+    return 0
+
+
+def cmd_recover(args: argparse.Namespace) -> int:
+    """Sweep crashed-mid-run experiments and settle them.
+
+    An `evo run` that dies (crash, shell exit, reboot) leaves its node wedged
+    at status=active with a dead driver PID stamped in attempt_state.json. This
+    walks every such node and, unless --dry-run, marks it `failed` with a
+    "process disappeared" reason -- leaving the worktree and traces intact so
+    partial data survives (unlike `evo discard`, which deletes them).
+    Idempotent. Remote experiments are skipped (they resume via their own
+    metadata)."""
+    root = repo_root()
+    _config, graph = _require_workspace(root)
+    dry_run = bool(getattr(args, "dry_run", False))
+    as_json = bool(getattr(args, "json", False))
+    stale = _stale_active_entries(root, graph)
+
+    recovered: list[str] = []
+    reason = "process disappeared (recovered by `evo recover`)"
+    if not dry_run:
+        for exp_id, attempt, _pid in stale:
+            node = graph["nodes"][exp_id]
+
+            def _mark_failed(current_node: dict, _graph: dict) -> None:
+                current_node["status"] = "failed"
+                current_node["error"] = reason
+
+            update_node(root, exp_id, _mark_failed)
+            _finalize_result(
+                root, exp_id, node, node.get("score"), "failed",
+                {"error": reason, "recovered": True},
+            )
+            prior = _read_attempt_state(root, exp_id, attempt) or {}
+            _write_attempt_state(
+                root, exp_id, attempt,
+                phase="failed", status="failed",
+                started_at=str(prior.get("started_at") or utc_now()),
+                extra={"error": reason, "recovered": True},
+            )
+            recovered.append(exp_id)
+
+    if as_json:
+        print(json.dumps({
+            "dry_run": dry_run,
+            "stale": [exp_id for exp_id, _a, _p in stale],
+            "recovered": recovered,
+        }))
+        return 0
+
+    if not stale:
+        print("No stale experiments found.")
+        return 0
+    if dry_run:
+        print(f"Would recover {len(stale)} stale experiment(s) (process gone):")
+        for exp_id, attempt, pid in stale:
+            print(f"  {exp_id} (attempt {attempt:03d}, pid {pid or 'unstamped'})")
+        print(
+            "\nRe-run without --dry-run to mark them failed "
+            "(worktrees + traces are preserved)."
+        )
+        return 0
+    print(
+        f"Recovered {len(recovered)} stale experiment(s) "
+        f"(marked failed, traces preserved):"
+    )
+    for exp_id in recovered:
+        print(f"  {exp_id}")
     return 0
 
 
@@ -6612,6 +6714,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     status_p = sub.add_parser("status")
     status_p.set_defaults(func=cmd_status)
+
+    recover_p = sub.add_parser(
+        "recover",
+        help="detect and settle crashed-mid-run (stale active) experiments",
+        description="Walk active experiments whose driver process has "
+        "disappeared (crash, shell exit, reboot) and mark them failed, "
+        "preserving worktrees and traces. Remote experiments are skipped.",
+    )
+    recover_p.add_argument(
+        "--dry-run", action="store_true",
+        help="list stale experiments without modifying anything",
+    )
+    recover_p.add_argument("--json", action="store_true", help="emit JSON")
+    recover_p.set_defaults(func=cmd_recover)
 
     tree_p = sub.add_parser("tree")
     tree_p.set_defaults(func=cmd_tree)

--- a/tests/unit/test_recover.py
+++ b/tests/unit/test_recover.py
@@ -1,0 +1,200 @@
+"""Unit tests for `evo recover` and stale-active surfacing in `evo status`.
+
+Crash recovery (issue #6): when `evo run` crashes / the shell dies / the box
+reboots mid-run, the node is left at `status: "active"` in graph.json with a
+dead driver PID stamped in attempt_state.json. `evo recover` sweeps those,
+marks the dead ones `failed` (reason "process disappeared") while leaving the
+worktree + traces intact, and `evo status` surfaces them prominently.
+
+Real filesystem, real subprocesses. A live PID is this test process
+(guaranteed alive for the check); a dead PID comes from a child spawned to
+exit immediately, then reaped.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+
+
+def _make_workspace(root: Path) -> None:
+    _init_git_repo(root)
+    from evo.core import init_workspace
+    init_workspace(root, target="agent.py", benchmark="echo hi", metric="max", gate=None)
+
+
+def _dead_pid() -> int:
+    """A guaranteed-dead PID: spawn a process that exits immediately, reap it."""
+    child = subprocess.Popen([sys.executable, "-c", ""])
+    child.wait()
+    return child.pid
+
+
+def _inject_node(
+    root: Path,
+    exp_id: str,
+    *,
+    status: str = "active",
+    attempt: int = 1,
+    pid: int | None = None,
+    backend: str | None = None,
+    write_state: bool = True,
+) -> None:
+    """Inject a node into graph.json (optionally with attempt_state carrying a
+    PID). `pid=None` + `write_state=False` means no attempt_state at all."""
+    from evo.core import load_graph, save_graph, attempt_dir
+    from evo.cli import _write_attempt_state
+    worktree = root / f"wt-{exp_id}"
+    worktree.mkdir(exist_ok=True)
+    graph = load_graph(root)
+    node = {
+        "id": exp_id, "parent": "root", "children": [],
+        "status": status, "score": None, "hypothesis": "recover-test",
+        "branch": f"evo/run_0000/{exp_id}", "commit": None,
+        "current_attempt": attempt, "worktree": str(worktree),
+    }
+    if backend is not None:
+        node["backend"] = backend
+    graph["nodes"][exp_id] = node
+    graph["nodes"]["root"].setdefault("children", []).append(exp_id)
+    save_graph(root, graph)
+    attempt_dir(root, exp_id, attempt).mkdir(parents=True, exist_ok=True)
+    if write_state:
+        _write_attempt_state(
+            root, exp_id, attempt,
+            phase="benchmark", status="running",
+            started_at="2026-01-01T00:00:00+00:00",
+            extra={"pid": pid if pid is not None else 0},
+        )
+
+
+def _node_status(root: Path, exp_id: str) -> str:
+    from evo.core import load_graph
+    return load_graph(root)["nodes"][exp_id]["status"]
+
+
+class _WorkspaceCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _make_workspace(self.root)
+        self._prev_cwd = Path.cwd()
+        os.chdir(self.root)
+
+    def tearDown(self):
+        os.chdir(self._prev_cwd)
+        self._tmp.cleanup()
+
+    def _recover(self, dry_run: bool = False) -> tuple[int, str]:
+        from evo.cli import cmd_recover
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            rc = cmd_recover(argparse.Namespace(dry_run=dry_run, json=False))
+        return rc, out.getvalue()
+
+    def _status(self) -> str:
+        from evo.cli import cmd_status
+        out = io.StringIO()
+        with patch("sys.stdout", out):
+            cmd_status(argparse.Namespace())
+        return out.getvalue()
+
+
+class TestRecover(_WorkspaceCase):
+    def test_marks_dead_active_node_failed(self):
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        rc, _ = self._recover()
+        self.assertEqual(rc, 0)
+        self.assertEqual(_node_status(self.root, "exp_0001"), "failed")
+
+    def test_failed_node_reason_says_process_disappeared(self):
+        from evo.core import load_graph
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        self._recover()
+        node = load_graph(self.root)["nodes"]["exp_0001"]
+        self.assertIn("process disappeared", (node.get("error") or "").lower())
+
+    def test_preserves_worktree_and_traces(self):
+        from evo.core import attempt_traces_dir
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        traces = attempt_traces_dir(self.root, "exp_0001", 1)
+        traces.mkdir(parents=True, exist_ok=True)
+        (traces / "partial.log").write_text("half a run\n")
+        self._recover()
+        # Unlike discard, recover must not delete partial data.
+        self.assertTrue((self.root / "wt-exp_0001").exists())
+        self.assertTrue((traces / "partial.log").exists())
+
+    def test_leaves_live_active_node_active(self):
+        _inject_node(self.root, "exp_0001", pid=os.getpid())
+        self._recover()
+        self.assertEqual(_node_status(self.root, "exp_0001"), "active")
+
+    def test_dry_run_reports_but_does_not_mutate(self):
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        rc, out = self._recover(dry_run=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("exp_0001", out)
+        self.assertEqual(_node_status(self.root, "exp_0001"), "active")
+
+    def test_missing_attempt_state_treated_as_stale(self):
+        # active node whose attempt never wrote state (crash before stamp)
+        _inject_node(self.root, "exp_0001", write_state=False)
+        self._recover()
+        self.assertEqual(_node_status(self.root, "exp_0001"), "failed")
+
+    def test_ignores_non_active_nodes(self):
+        # a committed node with a (coincidentally dead) pid must not be touched
+        _inject_node(self.root, "exp_0001", status="committed", pid=_dead_pid())
+        self._recover()
+        self.assertEqual(_node_status(self.root, "exp_0001"), "committed")
+
+    def test_skips_remote_nodes(self):
+        # remote backend has its own resume metadata; recover leaves it alone
+        _inject_node(self.root, "exp_0001", pid=_dead_pid(), backend="remote")
+        self._recover()
+        self.assertEqual(_node_status(self.root, "exp_0001"), "active")
+
+    def test_finalizes_result_json(self):
+        from evo.core import experiment_result_path
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        self._recover()
+        result = json.loads(experiment_result_path(self.root, "exp_0001").read_text())
+        self.assertEqual(result["status"], "failed")
+
+
+class TestStatusSurfacesStale(_WorkspaceCase):
+    def test_status_reports_stale_active_count(self):
+        _inject_node(self.root, "exp_0001", pid=_dead_pid())
+        out = self._status()
+        self.assertIn("stale", out.lower())
+        self.assertIn("exp_0001", out)
+
+    def test_status_does_not_flag_live_active(self):
+        _inject_node(self.root, "exp_0001", pid=os.getpid())
+        out = self._status()
+        self.assertNotIn("exp_0001", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #6 (crash-recovery portion).

### Problem
When `evo run` crashes, the shell dies, or the machine reboots mid-run, the experiment is left wedged at `status: "active"` in `graph.json` forever, with a dead driver PID in `attempt_state.json`. Today recovery is manual — notice it via `evo status`, check the PID by hand, then `evo discard`, which also throws away the partial traces. For autonomous setups this leaves the loop spinning on phantom in-flight experiments.

### Change
- **`evo recover`** walks `active` nodes, reuses the existing `_is_pid_alive` check against the stamped driver PID, and marks dead ones `failed` (`"process disappeared"`) **while preserving the worktree and traces** — unlike `discard`, so partial data survives. Supports `--dry-run` and `--json`, and is idempotent. Remote experiments are skipped (they resume via their own stream-journal metadata).
- **`evo status`** now reports a `stale=N` count and lists stale active experiments prominently, instead of counting them as healthy `active`.

### Notes / scope
- The stuck state is actually `status: "active"` (the issue says "running"; that string only exists in the dispatch-job/phase layer).
- Out of scope, as flagged in the issue thread: the `next_id` allocation race.

### Testing
New `tests/unit/test_recover.py` (11 cases: dead-PID → failed, trace/worktree preservation, live-PID left alone, `--dry-run`, missing attempt_state, non-active ignored, remote skipped, result.json finalized, status surfacing). Also verified end-to-end against the real CLI. Full `tests/unit` suite passes except tests that require the prebuilt Rust `evo-hook-drain` binary (no local `cargo`); those fail identically on `main` and are built in CI.