### PR TITLE
fix(core): clear error from repo_root() outside a git repository (#58)

### DIFF
--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -50,13 +50,27 @@ def utc_now() -> str:
 
 def repo_root(cwd: Path | None = None) -> Path:
     base = cwd or Path.cwd()
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        cwd=base,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=base,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        # git isn't installed / not on PATH.
+        raise RuntimeError(
+            "git was not found on PATH. evo needs git to locate your "
+            "workspace; install git and run evo from inside your project."
+        ) from None
+    except subprocess.CalledProcessError:
+        # Not inside a git repository. Surface an actionable message instead
+        # of leaking the raw `git rev-parse` exit status (see #58).
+        raise RuntimeError(
+            f"not inside a git repository (looked from {base}). Run evo from "
+            "within your project directory, or `git init` to create one."
+        ) from None
     return Path(result.stdout.strip())
 
 

--- a/tests/unit/test_repo_root_error.py
+++ b/tests/unit/test_repo_root_error.py
@@ -1,0 +1,59 @@
+"""`repo_root()` must fail with a clear message outside a git repository.
+
+Regression test for the bug noted in #58: every command that resolves the
+workspace through `repo_root()` (e.g. `evo direct-status`, `evo direct`,
+`evo status`) leaked the raw git failure
+
+    ERROR: Command '['git', 'rev-parse', '--show-toplevel']' returned
+    non-zero exit status 128.
+
+when run from a directory that is not inside a git repository. That's an
+internal implementation detail, not an actionable message. `repo_root()`
+should instead raise a friendly, git-agnostic error.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+
+class TestRepoRootOutsideGitRepo(unittest.TestCase):
+    def test_raises_runtime_error_not_called_process_error(self):
+        """A plain, non-git temp dir must produce a RuntimeError, never the
+        raw subprocess.CalledProcessError."""
+        from evo.core import repo_root
+        with tempfile.TemporaryDirectory() as d:
+            outside = Path(d).resolve()
+            # Sanity: the temp dir really is outside any git repo.
+            probe = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=outside, capture_output=True, text=True,
+            )
+            self.assertNotEqual(probe.returncode, 0, "temp dir unexpectedly in a git repo")
+
+            with self.assertRaises(RuntimeError) as ctx:
+                repo_root(cwd=outside)
+            self.assertNotIsInstance(ctx.exception, subprocess.CalledProcessError)
+
+    def test_message_is_actionable_and_hides_git_internals(self):
+        """The message must mention the workspace/git-repo requirement and
+        must not leak the raw `rev-parse` / `exit status 128` internals."""
+        from evo.core import repo_root
+        with tempfile.TemporaryDirectory() as d:
+            outside = Path(d).resolve()
+            with self.assertRaises(RuntimeError) as ctx:
+                repo_root(cwd=outside)
+            msg = str(ctx.exception).lower()
+            self.assertIn("git repository", msg)
+            self.assertNotIn("rev-parse", msg)
+            self.assertNotIn("exit status", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

Every `evo` command resolves the workspace through `core.repo_root()`, which runs `git rev-parse --show-toplevel` with `check=True`. When invoked from a directory that is **not inside a git repository**, that raises a bare `CalledProcessError`, and the top-level handler in `main()` prints its `str()`:

```
ERROR: Command '['git', 'rev-parse', '--show-toplevel']' returned non-zero exit status 128.
```

That's an internal implementation detail, not something a user can act on. It affects `evo direct-status`, `evo direct`, `evo status`, and every other subcommand.

This is the secondary bug noted at the bottom of #6... — filed under **#58** ("`evo direct-status` ... fails with `git rev-parse --show-toplevel returned non-zero exit status 128` ... should ... error with a clear 'must be in a workspace' message instead of leaking the git internal failure"). It turned out to be general (all commands), not specific to `direct-status`, so the fix lives in `repo_root()`.

### Fix

Catch the git failure in `repo_root()` and raise an actionable, git-agnostic `RuntimeError`:

```
ERROR: not inside a git repository (looked from <cwd>). Run evo from within your project directory, or `git init` to create one.
```

Also handles `git` missing from `PATH`. `main()`'s existing handler already prints the message and exits non-zero, so no other change is needed. Success path is unchanged.

### Before / after

```
$ cd /tmp && evo direct-status ABC123
# before: ERROR: Command '['git', 'rev-parse', '--show-toplevel']' returned non-zero exit status 128.
# after:  ERROR: not inside a git repository (looked from /tmp). Run evo from within your project directory, or `git init` to create one.
```

### Tests

Added `tests/unit/test_repo_root_error.py` (TDD — written failing first):
- `repo_root()` outside a git repo raises `RuntimeError`, never the raw `CalledProcessError`
- the message is actionable and does not leak `rev-parse` / `exit status` internals

Full `tests/unit` suite: 811 passed. The only failures locally are in `test_hook_drain.py` / `test_subagent_identity.py` / `test_directive_delivery_e2e.py`, which exec the Rust `evo-hook-drain` binary — unrelated to this change and environmental (no Rust toolchain on my machine; CI builds the binary).

### Scope

Fixes only the "leaked git error" sub-bug. The main #58 issue (directives never delivered to engaged sessions) is **not** addressed here, so this intentionally does not `Closes #58`.
