### PR TITLE
feat(dispatch): Compact Instructions block for lineage forks (closes #27)

### DIFF
--- a/plugins/evo/src/evo/dispatch.py
+++ b/plugins/evo/src/evo/dispatch.py
@@ -277,10 +277,29 @@ Budget: {budget} iterations. Follow the protocol you loaded earlier. Begin.
 # must NOT continue. It may also have been auto-compacted, summarizing the
 # protocol away. The lineage prompt explicitly closes the parent's task and
 # tells the child to re-read the protocol if it can't recall it.
+# Injected only into lineage forks. Such a child inherits the parent's
+# session, so the worker protocol reaches it through the cached transcript;
+# on long ancestor chains Claude Code auto-compacts the older portion and can
+# summarize the protocol away. This block marks the load-bearing context as
+# preserve-on-summary so compaction keeps it rather than trimming it (#27).
+LINEAGE_COMPACT_INSTRUCTIONS = """# Compact Instructions
+
+Preserve when summarizing:
+- current exp_id, hypothesis, parent_commit
+- worker protocol; `evo run` is terminal
+- pointer-trace references and gate semantics
+
+May be discarded:
+- older file reads (recoverable via `evo get` / Read)
+- older benchmark output detail
+- failed tool calls from prior attempts
+"""
+
 LINEAGE_EXECUTE_USER_PROMPT_TEMPLATE = """A new experiment is starting. Your prior work on {parent_id} is COMMITTED and CLOSED -- do not continue it.
 
 If your earlier transcript has been summarized during context compaction and you can no longer see the full worker protocol, re-read it from {protocol_path} before acting.
 
+{compact_instructions}
 EXECUTE phase begins now.
 Your experiment: {exp_id}
 Worktree: {worktree_path}
@@ -321,6 +340,7 @@ def render_execute_prompt(
             brief=brief.strip(),
             budget=budget,
             protocol_path=Path(subagent_skill_path()).as_posix(),
+            compact_instructions=LINEAGE_COMPACT_INSTRUCTIONS,
         )
     return EXECUTE_USER_PROMPT_TEMPLATE.format(
         exp_id=exp_id,

--- a/tests/unit/test_compact_instructions.py
+++ b/tests/unit/test_compact_instructions.py
@@ -1,0 +1,57 @@
+"""Lineage-forked children must carry a Compact Instructions block (#27).
+
+A lineage fork inherits the parent experiment's session, so the worker
+protocol reaches the child only through the cached transcript. On long
+ancestor chains Claude Code auto-compacts the older portion and can
+summarize the protocol away. The existing lineage prompt only *hints*
+("re-read it if you can't see it"); this pins the load-bearing context as
+preserve-on-summary so compaction keeps it.
+
+Fresh (non-lineage) children get their protocol in the current turn and do
+not inherit a long transcript, so they must NOT carry the block -- keeping
+the contrast is what these tests guard.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.dispatch import render_execute_prompt
+
+
+def _render(lineage: bool) -> str:
+    return render_execute_prompt(
+        exp_id="exp_0009",
+        worktree_path=Path("/tmp/wt"),
+        parent_id="exp_0004",
+        brief="widen search beam",
+        budget=3,
+        lineage=lineage,
+    )
+
+
+def test_lineage_prompt_includes_compact_instructions_header():
+    out = _render(lineage=True)
+    assert "Compact Instructions" in out
+    assert "Preserve when summarizing" in out
+
+
+def test_lineage_prompt_pins_load_bearing_context():
+    """The block must name the specific things that must survive a summary:
+    the experiment identity, that the worker protocol / `evo run` is
+    terminal, and gate semantics."""
+    out = _render(lineage=True).lower()
+    assert "exp_id" in out
+    assert "hypothesis" in out
+    assert "parent_commit" in out
+    assert "worker protocol" in out
+    assert "evo run" in out and "terminal" in out
+    assert "gate" in out
+
+
+def test_non_lineage_prompt_omits_compact_instructions():
+    out = _render(lineage=False)
+    assert "Compact Instructions" not in out


### PR DESCRIPTION
### Problem

A lineage fork (`evo dispatch` forking from a committed parent experiment's own session) inherits the parent's transcript. The worker protocol therefore reaches the child only through that cached context. On long ancestor chains, Claude Code auto-compacts the older portion of the transcript and can summarize the protocol away.

The existing `LINEAGE_EXECUTE_USER_PROMPT_TEMPLATE` only *hints* at this — "re-read the protocol from `<path>` if you can no longer see it." As #27 notes, that's a hint, not a guarantee.

### Fix

Add a `# Compact Instructions` block to the lineage execute prompt that marks the load-bearing context as preserve-on-summary, exactly as proposed in #27:

```
# Compact Instructions

Preserve when summarizing:
- current exp_id, hypothesis, parent_commit
- worker protocol; `evo run` is terminal
- pointer-trace references and gate semantics

May be discarded:
- older file reads (recoverable via `evo get` / Read)
- older benchmark output detail
- failed tool calls from prior attempts
```

The block is injected **only** into lineage forks (`render_execute_prompt(..., lineage=True)`). Fresh explorer children receive the protocol in the current turn and don't inherit a long transcript, so they intentionally do not carry the block.

### Tests

Added `tests/unit/test_compact_instructions.py` (TDD — written failing first):
- lineage prompt includes the `Compact Instructions` header + `Preserve when summarizing`
- lineage prompt pins the specific load-bearing items (exp_id, hypothesis, parent_commit, worker protocol, `evo run` is terminal, gate)
- non-lineage prompt omits the block

`tests/unit` (excluding the three Rust-`evo-hook-drain`-binary tests, which are environmental on a machine without a Rust toolchain): **801 passed, 4 skipped**. All existing `test_dispatch.py` tests pass unchanged.
