### PR TITLE
fix(core): preserve non-ASCII UTF-8 in double-quoted dotenv values (fixes #96)

### DIFF
--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -379,6 +379,29 @@ def save_config(root: Path, config: dict[str, Any]) -> None:
 
 _DOTENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Backslash escapes honored inside double-quoted dotenv values. Kept explicit
+# (rather than str.decode("unicode_escape")) so non-ASCII UTF-8 characters pass
+# through untouched instead of being reinterpreted byte-by-byte as Latin-1.
+_DOTENV_ESCAPES = {
+    "n": "\n", "t": "\t", "r": "\r", "\\": "\\", '"': '"', "'": "'", "`": "`",
+}
+
+
+def _unescape_double_quoted(value: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        ch = value[i]
+        if ch == "\\" and i + 1 < n:
+            nxt = value[i + 1]
+            out.append(_DOTENV_ESCAPES.get(nxt, "\\" + nxt))
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
 
 def parse_dotenv(text: str) -> dict[str, str]:
     """Parse the simple dotenv subset evo supports for runtime env forwarding."""
@@ -399,7 +422,7 @@ def parse_dotenv(text: str) -> dict[str, str]:
         if len(value) >= 2 and value[0] == value[-1] == "'":
             value = value[1:-1]
         elif len(value) >= 2 and value[0] == value[-1] == '"':
-            value = bytes(value[1:-1], "utf-8").decode("unicode_escape")
+            value = _unescape_double_quoted(value[1:-1])
         else:
             match = re.search(r"\s+#", value)
             if match:

--- a/tests/unit/test_parse_dotenv.py
+++ b/tests/unit/test_parse_dotenv.py
@@ -1,0 +1,44 @@
+"""`parse_dotenv` must not corrupt non-ASCII UTF-8 in quoted values (#96).
+
+The double-quoted branch used to do
+    bytes(value[1:-1], "utf-8").decode("unicode_escape")
+which reinterprets each UTF-8 byte as a Latin-1 code point, mangling any
+multi-byte character (café -> caf\xc3\xa9). The fix must keep non-ASCII
+intact while still honoring the common backslash escapes.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.core import parse_dotenv
+
+
+def test_double_quoted_non_ascii_is_preserved():
+    assert parse_dotenv('X="café"')["X"] == "café"
+    assert parse_dotenv('T="токен"')["T"] == "токен"
+    assert parse_dotenv('E="a—b 🙂"')["E"] == "a—b 🙂"
+
+
+def test_unquoted_non_ascii_is_preserved():
+    assert parse_dotenv("Y=café")["Y"] == "café"
+
+
+def test_double_quoted_common_escapes_still_work():
+    # Source contains literal backslash-n / -t / -" / -\ inside the quotes.
+    assert parse_dotenv(r'X="a\nb"')["X"] == "a\nb"
+    assert parse_dotenv(r'X="a\tb"')["X"] == "a\tb"
+    assert parse_dotenv(r'X="a\"b"')["X"] == 'a"b'
+    assert parse_dotenv(r'X="a\\b"')["X"] == "a\\b"
+
+
+def test_escaped_and_unicode_combined():
+    assert parse_dotenv(r'X="café\nnext"')["X"] == "café\nnext"
+
+
+def test_single_quoted_is_literal():
+    # Single quotes do not process escapes.
+    assert parse_dotenv(r"Z='a\nb'")["Z"] == r"a\nb"


### PR DESCRIPTION
### Problem

`parse_dotenv` decoded double-quoted values with `bytes(value, "utf-8").decode("unicode_escape")`, which reinterprets each UTF-8 byte as a Latin-1 code point. Any multi-byte character is mangled:

```
parse_dotenv('X="café"')['X']  ->  'cafÃ©'   # wrong
parse_dotenv('Y=café')['Y']    ->  'café'    # unquoted branch is fine
```

The corrupted value is then forwarded into the benchmark/gate environment via `resolve_runtime_env`, so a double-quoted non-ASCII secret (accented text, a non-Latin API token, em-dash, emoji) reaches the benchmark broken.

### Fix

Replace the Latin-1 round-trip with an explicit unescape (`_unescape_double_quoted`) that honors the common backslash escapes (`\n \t \r \\ \" \' \``) and leaves everything else — including non-ASCII — untouched.

### Tests

`tests/unit/test_parse_dotenv.py` (TDD, written failing first):
- double-quoted non-ASCII preserved (`café`, Cyrillic, em-dash + emoji)
- unquoted non-ASCII preserved
- common escapes still work (`\n \t \" \\`)
- escapes + unicode combined
- single-quoted stays literal

Full `test_runtime_env.py` + `test_core.py`: 23 passed.

Fixes #96.
