### PR TITLE
fix(cli): actually use ripgrep in `evo grep` (fixes #94)

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -2429,7 +2429,7 @@ def cmd_ws_grep(args: argparse.Namespace) -> int:
     base = args.path or node["worktree"]
     with executor_ctxmgr as executor:
         which = executor.run(["which", "rg"], cwd=str(base))
-        if (which.exit_code or 1) == 0 and which.stdout.strip():
+        if which.exit_code == 0 and which.stdout.strip():
             cmd = ["rg", "--no-heading", "--line-number", args.pattern, str(base)]
         else:
             cmd = ["grep", "-rn", args.pattern, str(base)]

--- a/tests/unit/test_ws_grep_ripgrep.py
+++ b/tests/unit/test_ws_grep_ripgrep.py
@@ -1,0 +1,69 @@
+"""`evo grep` must actually use ripgrep when it is available (#94).
+
+The `rg`-availability test was `(which.exit_code or 1) == 0`, which is False
+even when `rg` is present (0 is falsy, so `0 or 1` -> 1, and `1 == 0` is
+False). The tool therefore always fell back to `grep`. These tests assert
+that a present `rg` is selected and an absent one falls back.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo import cli
+
+
+class _Result:
+    def __init__(self, exit_code, stdout="", stderr=""):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeExecutor:
+    """Records commands; answers `which rg` per `rg_present`."""
+
+    def __init__(self, rg_present: bool):
+        self._rg_present = rg_present
+        self.commands: list[list[str]] = []
+
+    def run(self, cmd, cwd=None, env=None, timeout=None):
+        self.commands.append(cmd)
+        if cmd[:2] == ["which", "rg"]:
+            return _Result(0, "/usr/bin/rg\n") if self._rg_present else _Result(1, "")
+        return _Result(0, "match\n")
+
+
+def _run_grep(rg_present: bool) -> _FakeExecutor:
+    executor = _FakeExecutor(rg_present)
+
+    @contextmanager
+    def _ctx():
+        yield executor
+
+    node = {"worktree": "/tmp/wt"}
+    with patch.object(cli, "_open_workspace_executor",
+                      return_value=(Path("/tmp"), node, _ctx())):
+        args = argparse.Namespace(path="/tmp/wt", pattern="foo")
+        with patch("sys.stdout", io.StringIO()):
+            cli.cmd_ws_grep(args)
+    return executor
+
+
+def test_uses_ripgrep_when_available():
+    executor = _run_grep(rg_present=True)
+    search_cmd = executor.commands[-1]
+    assert search_cmd[0] == "rg", f"expected rg, got {search_cmd!r}"
+
+
+def test_falls_back_to_grep_when_rg_absent():
+    executor = _run_grep(rg_present=False)
+    search_cmd = executor.commands[-1]
+    assert search_cmd[0] == "grep", f"expected grep, got {search_cmd!r}"


### PR DESCRIPTION
### Problem

`cmd_ws_grep` selects ripgrep via:

```python
if (which.exit_code or 1) == 0 and which.stdout.strip():
```

`which rg` exits `0` when rg is present, but `0 or 1` → `1`, so `1 == 0` is `False`; when rg is absent the exit code is `1` → `1 or 1` → `1`, again `False`. The condition is `False` in **every** case, so the `rg` branch is dead — `evo grep` always runs `grep -rn`.

Because `rg` and `grep` differ in regex dialect (`\d`, `\b`, lookarounds) and in `.gitignore` handling, patterns intended for rg match differently or error, and ignored dirs get searched. The documented "prefer rg, fall back to grep" contract never fires.

### Fix

```python
if which.exit_code == 0 and which.stdout.strip():
```

### Tests

`tests/unit/test_ws_grep_ripgrep.py` (TDD, failing first) drives `cmd_ws_grep` with a fake executor:
- rg present → the search command is `rg`
- rg absent → falls back to `grep`

Fixes #94.
