### PR TITLE
fix(claude-code): numeric-aware plugin-cache version selection (fixes #95)

### DIFF
--- a/plugins/evo/src/evo/host_install/claude_code.py
+++ b/plugins/evo/src/evo/host_install/claude_code.py
@@ -50,6 +50,14 @@ def _claude_config_dir() -> Path:
     return Path(cfg) if cfg else Path.home() / ".claude"
 
 
+def _ver_key(name: str):
+    """Numeric-aware sort key so 0.10.0 sorts after 0.9.0 (plain sorted() is
+    lexicographic and would invert that). Non-numeric segments (pre-release
+    tags) fall into a separate rank so int/str never compare."""
+    return [(0, int(s)) if s.isdigit() else (1, s)
+            for s in re.split(r"[.-]", name)]
+
+
 def _latest_cache_dir() -> Path | None:
     """Return the latest-version plugin cache dir, or None if not installed.
     Cache layout: <claude-config-dir>/plugins/cache/<mkt>/evo/<version>/
@@ -57,7 +65,8 @@ def _latest_cache_dir() -> Path | None:
     root = _claude_config_dir() / "plugins" / "cache" / _MARKETPLACE_NAME / "evo"
     if not root.exists():
         return None
-    versions = sorted(p for p in root.iterdir() if p.is_dir())
+    versions = sorted((p for p in root.iterdir() if p.is_dir()),
+                      key=lambda p: _ver_key(p.name))
     return versions[-1] if versions else None
 
 
@@ -323,7 +332,8 @@ def doctor(args: argparse.Namespace) -> int:
     )
     if plugin_cache_root.exists() and mkt_manifest.exists():
         installed_versions = sorted(
-            p.name for p in plugin_cache_root.iterdir() if p.is_dir()
+            (p.name for p in plugin_cache_root.iterdir() if p.is_dir()),
+            key=_ver_key,
         )
         if installed_versions:
             installed = installed_versions[-1]

--- a/tests/unit/test_claude_cache_version.py
+++ b/tests/unit/test_claude_cache_version.py
@@ -1,0 +1,44 @@
+"""Claude Code cache "latest version" selection must be numeric-aware (#95).
+
+`_latest_cache_dir` used a plain lexicographic `sorted()`, so `0.9.0` sorts
+after `0.10.0` and the wrong cache dir was picked once a two-digit minor or
+patch existed. That stages the hook binary into the wrong version and makes
+`doctor` report a false "cache stale".
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo.host_install import claude_code
+
+
+def _make_cache(config_dir: Path, versions: list[str]) -> None:
+    root = config_dir / "plugins" / "cache" / claude_code._MARKETPLACE_NAME / "evo"
+    for v in versions:
+        (root / v).mkdir(parents=True, exist_ok=True)
+
+
+def test_latest_cache_dir_is_numeric_aware(tmp_path: Path):
+    _make_cache(tmp_path, ["0.9.0", "0.10.0", "0.11.0"])
+    with patch.object(claude_code, "_claude_config_dir", return_value=tmp_path):
+        latest = claude_code._latest_cache_dir()
+    assert latest is not None
+    assert latest.name == "0.11.0", f"picked {latest.name}, expected 0.11.0"
+
+
+def test_latest_cache_dir_two_digit_patch(tmp_path: Path):
+    _make_cache(tmp_path, ["0.8.9", "0.8.10"])
+    with patch.object(claude_code, "_claude_config_dir", return_value=tmp_path):
+        latest = claude_code._latest_cache_dir()
+    assert latest is not None
+    assert latest.name == "0.8.10", f"picked {latest.name}, expected 0.8.10"
+
+
+def test_latest_cache_dir_none_when_empty(tmp_path: Path):
+    with patch.object(claude_code, "_claude_config_dir", return_value=tmp_path):
+        assert claude_code._latest_cache_dir() is None


### PR DESCRIPTION
### Problem

The Claude Code adapter selects the "latest" plugin-cache version with a plain lexicographic `sorted()`:

- `_latest_cache_dir()` — `plugins/evo/src/evo/host_install/claude_code.py`
- `doctor()` cache-staleness check — same file

`'0.9.0' > '0.10.0'` lexically (because `'9' > '1'`), so `versions[-1]` returns `0.9.0` when `0.10.0`/`0.11.0` also exist.

Impact:
- `_stage_hook_drain` stages the native `evo-hook-drain` binary into the `0.9.0/bin/` dir, but Claude Code resolves `${CLAUDE_PLUGIN_ROOT}` to `0.10.0`, whose `bin/` lacks it → hooks that need the binary break (`evo direct` delivery).
- `doctor()` prints `✗ cache stale: installed=0.9.0, marketplace=0.10.0` (rc=1) even though `0.10.0` is installed — a false failure that also makes `evo update` skip the host.

The sibling `codex.py` adapter already solves this with a numeric-aware `_ver_key`; this ports the same fix.

### Fix

Add a numeric-aware `_ver_key` and use it at both sort sites.

### Tests

`tests/unit/test_claude_cache_version.py` (TDD, failing first): `_latest_cache_dir` picks `0.11.0` over `0.9.0`, and `0.8.10` over `0.8.9`; returns `None` on an empty cache. Existing `test_claude_code_install_paths.py` still passes.

Fixes #95.
