### PR TITLE
fix(sdk-python): detach Run finalizer on finish/exit (fixes #97)

### DIFF
--- a/sdk/python/src/evo_agent/_run.py
+++ b/sdk/python/src/evo_agent/_run.py
@@ -212,6 +212,11 @@ class Run:
         finally:
             with _ACTIVE_RUNS_LOCK:
                 _ACTIVE_RUNS.discard(self._experiment_id)
+            # Cancel the safety-net finalizer now that the slot is released.
+            # Otherwise it stays armed and, when this finished Run is later
+            # gc'd, fires _release_active_run(experiment_id) — clobbering the
+            # slot of a *different* live Run that reused the same id (#97).
+            self._finalizer.detach()
 
     # -- context manager --------------------------------------------------
 
@@ -223,6 +228,8 @@ class Run:
             self.finish()
         elif not self._finished:
             # Exception path -- finish() never called and won't be. Release
-            # the registry slot so a retry in the same process isn't blocked.
+            # the registry slot so a retry in the same process isn't blocked,
+            # and detach the finalizer so it can't later clobber a reused id.
             with _ACTIVE_RUNS_LOCK:
                 _ACTIVE_RUNS.discard(self._experiment_id)
+            self._finalizer.detach()

--- a/tests/unit/test_sdk_run_finalizer.py
+++ b/tests/unit/test_sdk_run_finalizer.py
@@ -1,0 +1,72 @@
+"""The active-run registry must not be clobbered by a stale finalizer (#97).
+
+Each Run arms `weakref.finalize(self, _release_active_run, experiment_id)`
+as a safety net for leaked (never-finished) runs. But finish()/__exit__ did
+not detach that finalizer, so when a *finished* Run was later gc'd its
+finalizer fired and discarded the experiment_id from the registry — even if
+that id now belonged to a different, still-active Run, silently defeating
+the double-Run guard.
+"""
+from __future__ import annotations
+
+import gc
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "sdk" / "python" / "src"))
+
+from evo_agent._run import Run, _ACTIVE_RUNS
+from evo_agent._backend import Backend
+
+
+class _NullBackend(Backend):
+    def setup(self, **k): pass
+    def write_trace(self, *a, **k): pass
+    def emit_result(self, *a, **k): pass
+    def emit_gate_summary(self, *a, **k): pass
+
+
+def _mk(exp="x") -> Run:
+    return Run(experiment_id=exp, backend=_NullBackend())
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    _ACTIVE_RUNS.clear()
+    yield
+    _ACTIVE_RUNS.clear()
+
+
+def test_gc_of_finished_run_does_not_free_a_live_runs_slot():
+    r1 = _mk("x")
+    r1.finish()               # slot freed
+    r2 = _mk("x")             # allowed; r2 is live and never finished
+    del r1
+    gc.collect()              # r1's finalizer must NOT clobber r2's slot
+    with pytest.raises(RuntimeError):
+        _mk("x")              # r2 still active -> must be refused
+    r2.finish()
+
+
+def test_gc_of_context_exited_run_does_not_free_a_live_runs_slot():
+    with _mk("y"):
+        pass                  # finishes via __exit__
+    r2 = _mk("y")
+    import gc as _gc
+    _gc.collect()
+    with pytest.raises(RuntimeError):
+        _mk("y")
+    r2.finish()
+
+
+def test_leaked_run_still_released_by_finalizer_on_gc():
+    """The safety net must still work: a Run that is never finished releases
+    its slot when garbage-collected."""
+    r = _mk("z")
+    del r
+    gc.collect()
+    r2 = _mk("z")             # slot must have been released by the finalizer
+    r2.finish()


### PR DESCRIPTION
### Problem

The Python SDK keeps a process-wide registry (`_ACTIVE_RUNS`) so two `Run`s with the same `experiment_id` can't be live at once. Each `Run` also arms `weakref.finalize(self, _release_active_run, self._experiment_id)` as a safety net for a leaked run.

`finish()` / `__exit__` release the slot but never `detach()` the finalizer. Since the registry is keyed only by `experiment_id`, GC of an already-finished `Run` fires its stale finalizer and frees the slot of a **different, still-active** `Run` that reused the id:

```
r1 = Run(experiment_id="x"); r1.finish()   # slot freed
r2 = Run(experiment_id="x")                 # allowed; r2 live, never finished
del r1; gc.collect()                        # r1's stale finalizer clears "x"
r3 = Run(experiment_id="x")                 # SUCCEEDS — guard defeated
```

`r2` and `r3` then both run and collide writing `EVO_RESULT_PATH` — the exact late-failure the registry was added to prevent.

### Fix

`detach()` the finalizer immediately after the slot is released, in both `finish()`'s `finally` and `__exit__`'s exception path. The leaked-run safety net (finalizer fires for a never-finished `Run`) is unchanged.

### Tests

`tests/unit/test_sdk_run_finalizer.py` (TDD, failing first):
- GC of a finished `Run` does NOT free a live Run's slot (via `finish()` and via `with`)
- a leaked (never-finished) `Run` still releases its slot on GC

Existing `sdk/python/test` passes.

Fixes #97.
