### PR TITLE
fix(core): don't hold graph lock across backend.allocate() (fixes #98)

### DIFF
--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -755,6 +755,15 @@ def allocate_experiment(
     from .backends import AllocateCtx, backend_spec_from_config, load_backend
 
     gpath = graph_path(root)
+
+    # --- Phase 1: reserve the id under the lock -------------------------
+    # Only ID generation, parent validation, and the frozen parent-commit
+    # reference need the graph lock. The slow backend.allocate() (git
+    # `worktree add`, or remote sandbox provisioning) must NOT run under it,
+    # or parallel `evo new` calls serialize and later ones exceed the lock
+    # timeout with a spurious LockTimeoutError (#98). We bump+persist next_id
+    # here so the reserved exp_id is unique even though the node is attached
+    # later, then release the lock before allocating.
     with advisory_lock(lock_file_for(gpath)):
         graph = load_json(gpath, default_graph())
         nodes = graph["nodes"]
@@ -777,7 +786,6 @@ def allocate_experiment(
             )
         next_id = graph.get("next_id", 0)
         exp_id = f"exp_{next_id:04d}"
-        graph["next_id"] = next_id + 1
 
         meta = _load_meta(root)
         run_id = meta.get("active", "run")
@@ -808,57 +816,74 @@ def allocate_experiment(
                     f"Parent {parent_id} has no recorded commit; cannot allocate child"
                 )
 
-        workspace_config = load_config(root)
-        if backend_override is None:
-            backend_name, backend_config = backend_spec_from_config(workspace_config)
-        else:
-            backend_name = backend_override["name"]
-            backend_config = dict(backend_override.get("config") or {})
-
-        backend = load_backend(
-            root,
-            explicit_name=backend_name,
-            explicit_config=backend_config,
-        )
-        result = backend.allocate(
-            AllocateCtx(
-                root=root,
-                exp_id=exp_id,
-                parent_node=parent if parent_id != "root" else None,
-                parent_commit=parent_commit,
-                parent_ref=start_point,
-                branch=branch,
-                hypothesis=hypothesis,
-            )
-        )
-
-        node = {
-            "id": exp_id,
-            "parent": parent_id,
-            "children": [],
-            "status": "pending",
-            "hypothesis": hypothesis,
-            "created_at": utc_now(),
-            "updated_at": utc_now(),
-            "eval_epoch": load_config(root).get("current_eval_epoch", 1),
-            "score": None,
-            "backend": backend_name,
-            "backend_config": backend_config,
-            "branch": result.branch,
-            "worktree": str(result.worktree),
-            "commit": result.commit,
-            "pruned_reason": None,
-            "prune_kind": None,
-            "benchmark_result": None,
-            "gate_result": None,
-            "gates": [],
-            "current_attempt": 0,
-        }
-        nodes[exp_id] = node
-        nodes[parent_id].setdefault("children", []).append(exp_id)
+        parent_node_snapshot = parent if parent_id != "root" else None
+        # Persist the id reservation so a concurrent allocator can't hand out
+        # the same exp_id while we allocate outside the lock. (If the backend
+        # allocation below fails, this id is simply skipped -- exp_ids may have
+        # gaps; nothing depends on them being contiguous.)
+        graph["next_id"] = next_id + 1
         atomic_write_json(gpath, graph)
-        experiments_dir_for(root, exp_id).mkdir(parents=True, exist_ok=True)
-        return node
+
+    # --- Phase 2: slow backend allocation, NOT under the lock -----------
+    workspace_config = load_config(root)
+    if backend_override is None:
+        backend_name, backend_config = backend_spec_from_config(workspace_config)
+    else:
+        backend_name = backend_override["name"]
+        backend_config = dict(backend_override.get("config") or {})
+
+    backend = load_backend(
+        root,
+        explicit_name=backend_name,
+        explicit_config=backend_config,
+    )
+    result = backend.allocate(
+        AllocateCtx(
+            root=root,
+            exp_id=exp_id,
+            parent_node=parent_node_snapshot,
+            parent_commit=parent_commit,
+            parent_ref=start_point,
+            branch=branch,
+            hypothesis=hypothesis,
+        )
+    )
+
+    node = {
+        "id": exp_id,
+        "parent": parent_id,
+        "children": [],
+        "status": "pending",
+        "hypothesis": hypothesis,
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
+        "eval_epoch": workspace_config.get("current_eval_epoch", 1),
+        "score": None,
+        "backend": backend_name,
+        "backend_config": backend_config,
+        "branch": result.branch,
+        "worktree": str(result.worktree),
+        "commit": result.commit,
+        "pruned_reason": None,
+        "prune_kind": None,
+        "benchmark_result": None,
+        "gate_result": None,
+        "gates": [],
+        "current_attempt": 0,
+    }
+
+    # --- Phase 3: attach the finished node under the lock ---------------
+    # Re-read the graph so we don't clobber nodes other allocators committed
+    # while we were in backend.allocate().
+    with advisory_lock(lock_file_for(gpath)):
+        graph = load_json(gpath, default_graph())
+        nodes = graph["nodes"]
+        nodes[exp_id] = node
+        if parent_id in nodes:
+            nodes[parent_id].setdefault("children", []).append(exp_id)
+        atomic_write_json(gpath, graph)
+    experiments_dir_for(root, exp_id).mkdir(parents=True, exist_ok=True)
+    return node
 
 
 def remove_worktree_only(root: Path, node: dict[str, Any]) -> bool:

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -752,7 +752,12 @@ def allocate_experiment(
     Graph mutation (ID generation, parent linking, status init) stays here;
     workspace creation is delegated to the configured backend.
     """
-    from .backends import AllocateCtx, backend_spec_from_config, load_backend
+    from .backends import (
+        AllocateCtx,
+        DiscardCtx,
+        backend_spec_from_config,
+        load_backend,
+    )
 
     gpath = graph_path(root)
 
@@ -874,14 +879,47 @@ def allocate_experiment(
 
     # --- Phase 3: attach the finished node under the lock ---------------
     # Re-read the graph so we don't clobber nodes other allocators committed
-    # while we were in backend.allocate().
+    # while we were in backend.allocate(). Re-validate the parent too: the
+    # lock was released across backend.allocate(), so a concurrent
+    # prune/invalidate/delete could have made the parent ineligible since
+    # phase 1. Attaching regardless would either violate the phase-1 guards
+    # or (if the parent was deleted) orphan the child under a dangling
+    # parent reference.
+    attach_error: str | None = None
     with advisory_lock(lock_file_for(gpath)):
         graph = load_json(gpath, default_graph())
         nodes = graph["nodes"]
-        nodes[exp_id] = node
-        if parent_id in nodes:
+        if parent_id not in nodes:
+            attach_error = f"parent {parent_id} was removed during allocation"
+        elif lineage_invalidated_by(graph, parent_id) is not None:
+            blocker = lineage_invalidated_by(graph, parent_id)
+            attach_error = (
+                f"parent {parent_id} lineage was invalidated at "
+                f"{blocker.get('id')} during allocation"
+            )
+        elif nodes[parent_id].get("status") == "pruned":
+            attach_error = f"parent {parent_id} was pruned during allocation"
+        else:
+            nodes[exp_id] = node
             nodes[parent_id].setdefault("children", []).append(exp_id)
-        atomic_write_json(gpath, graph)
+            atomic_write_json(gpath, graph)
+
+    if attach_error is not None:
+        # Release the workspace we allocated in phase 2 so it doesn't leak,
+        # then surface the race. Teardown runs outside the graph lock and is
+        # best-effort -- a residual workspace is reclaimable via `evo gc`.
+        ctx = DiscardCtx(root=root, node=node)
+        for teardown in (backend.release_lease, backend.gc):
+            try:
+                teardown(ctx)
+            except Exception:  # noqa: BLE001
+                pass
+        raise RuntimeError(
+            f"Cannot attach experiment {exp_id}: {attach_error}. The reserved "
+            f"id is skipped and its workspace has been released; branch from a "
+            f"currently-valid node instead."
+        )
+
     experiments_dir_for(root, exp_id).mkdir(parents=True, exist_ok=True)
     return node
 

--- a/tests/unit/test_allocate_lock_scope.py
+++ b/tests/unit/test_allocate_lock_scope.py
@@ -1,0 +1,93 @@
+"""allocate_experiment must not hold the graph lock across backend.allocate() (#98).
+
+The slow work (git `worktree add`, remote sandbox provisioning) lives in
+`backend.allocate()`. Holding the graph.json advisory lock across it
+serializes concurrent `evo new` calls and makes later ones exceed the 10s
+lock timeout (`LockTimeoutError`) even though nothing is wrong.
+
+This test drives two concurrent allocations through a backend whose
+`allocate()` overlaps in time, and asserts they actually run concurrently
+(max observed concurrency == 2) and both succeed with distinct ids. On the
+old code the graph lock serializes them (max concurrency == 1).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+import evo.backends as backends
+from evo.core import init_workspace, allocate_experiment, load_graph
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+
+
+class _ConcurrencyProbingBackend:
+    """allocate() overlaps in time and records the max concurrency seen."""
+
+    def __init__(self):
+        self.name = "probe"
+        self._lock = threading.Lock()
+        self._live = 0
+        self.max_concurrent = 0
+
+    def allocate(self, ctx):
+        with self._lock:
+            self._live += 1
+            self.max_concurrent = max(self.max_concurrent, self._live)
+        time.sleep(0.5)  # overlap window
+        with self._lock:
+            self._live -= 1
+        return type("R", (), {
+            "worktree": str(ctx.root), "branch": ctx.branch,
+            "commit": "deadbeef", "extra": {},
+        })()
+
+
+def test_allocate_runs_concurrently_and_yields_distinct_ids(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_git_repo(root)
+    init_workspace(root, target="t.py", benchmark="echo hi", metric="max", gate=None)
+
+    probe = _ConcurrencyProbingBackend()
+    monkeypatch.setattr(backends, "load_backend", lambda *a, **k: probe)
+
+    results: dict[str, dict] = {}
+    errors: dict[str, Exception] = {}
+
+    def worker(name):
+        try:
+            results[name] = allocate_experiment(root, parent_id="root", hypothesis="h")
+        except Exception as e:  # noqa: BLE001
+            errors[name] = e
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in ("A", "B")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"allocation errored: {errors}"
+    ids = {r["id"] for r in results.values()}
+    assert len(ids) == 2, f"expected 2 distinct ids, got {ids}"
+    assert probe.max_concurrent == 2, (
+        f"allocations serialized (max_concurrent={probe.max_concurrent}); "
+        "the graph lock is still held across backend.allocate()"
+    )
+    graph = load_graph(root)
+    for exp_id in ids:
+        assert exp_id in graph["nodes"]
+        assert exp_id in graph["nodes"]["root"]["children"]

--- a/tests/unit/test_allocate_lock_scope.py
+++ b/tests/unit/test_allocate_lock_scope.py
@@ -91,3 +91,78 @@ def test_allocate_runs_concurrently_and_yields_distinct_ids(tmp_path, monkeypatc
     for exp_id in ids:
         assert exp_id in graph["nodes"]
         assert exp_id in graph["nodes"]["root"]["children"]
+
+
+class _ParentMutatingBackend:
+    """Simulates a concurrent mutation of the parent during the unlocked
+    backend.allocate() window: it edits graph.json on disk before returning,
+    exactly as a racing `evo discard`/`evo prune` process would."""
+
+    def __init__(self, root, parent_id, action):
+        self.name = "probe"
+        self._root = root
+        self._parent_id = parent_id
+        self._action = action  # "delete" or "prune"
+        self.torn_down = False
+
+    def allocate(self, ctx):
+        from evo.core import load_graph, save_graph
+        g = load_graph(self._root)
+        if self._action == "delete":
+            g["nodes"].pop(self._parent_id, None)
+            for n in g["nodes"].values():
+                if self._parent_id in n.get("children", []):
+                    n["children"].remove(self._parent_id)
+        elif self._action == "prune":
+            g["nodes"][self._parent_id]["status"] = "pruned"
+        save_graph(self._root, g)
+        return type("R", (), {
+            "worktree": str(ctx.root / "wt"), "branch": ctx.branch,
+            "commit": "deadbeef", "extra": {},
+        })()
+
+    def release_lease(self, ctx):
+        self.torn_down = True
+
+    def gc(self, ctx):
+        self.torn_down = True
+        return True
+
+
+def _setup_with_parent(tmp_path):
+    root = tmp_path.resolve()
+    _init_git_repo(root)
+    init_workspace(root, target="t.py", benchmark="echo hi", metric="max", gate=None)
+    # Real allocation of a committable parent (child of root).
+    parent = allocate_experiment(root, parent_id="root", hypothesis="p")
+    return root, parent["id"]
+
+
+def test_parent_deleted_during_allocation_raises_and_leaves_no_orphan(tmp_path, monkeypatch):
+    root, parent_id = _setup_with_parent(tmp_path)
+    probe = _ParentMutatingBackend(root, parent_id, "delete")
+    monkeypatch.setattr(backends, "load_backend", lambda *a, **k: probe)
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        allocate_experiment(root, parent_id=parent_id, hypothesis="child")
+
+    graph = load_graph(root)
+    # No node may reference the now-deleted parent (no dangling-parent orphan).
+    orphans = [n["id"] for n in graph["nodes"].values() if n.get("parent") == parent_id]
+    assert orphans == [], f"orphan node(s) attached to a deleted parent: {orphans}"
+    assert probe.torn_down, "allocated workspace was not released on the failure path"
+
+
+def test_parent_pruned_during_allocation_is_rejected(tmp_path, monkeypatch):
+    root, parent_id = _setup_with_parent(tmp_path)
+    probe = _ParentMutatingBackend(root, parent_id, "prune")
+    monkeypatch.setattr(backends, "load_backend", lambda *a, **k: probe)
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        allocate_experiment(root, parent_id=parent_id, hypothesis="child")
+
+    graph = load_graph(root)
+    children = graph["nodes"][parent_id].get("children", [])
+    assert children == [], f"child attached under a pruned parent: {children}"


### PR DESCRIPTION
### Problem

`allocate_experiment` (`plugins/evo/src/evo/core.py`) opened the `graph.json` advisory lock and held it for the whole body — **including `backend.allocate()`**, which does the slow work: `git worktree add` (a full checkout) for the worktree backend, or network **sandbox provisioning** (tens of seconds) for the remote backend.

evo's core workflow dispatches a round of N subagents, each invoking `evo new` as a **separate process**. They all contend on `graph.json.lock` and serialize. With the remote backend, a single provisioning easily exceeds the 10s lock timeout, so even 2 concurrent `evo new` calls make the second die with `LockTimeoutError` — despite nothing being wrong.

Reproduced (backend `allocate()` sleeping 11s):
```
A -> ('ok', 11.2)
B -> ('LockTimeoutError', 10.1)
```

### Fix

Only ID generation, parent validation, and the frozen `parent_commit` reference need the graph lock. Split the critical section:

1. **under the lock** — validate parent (existence / lineage-invalidated / pruned), reserve `exp_id` by bumping **and persisting** `next_id`, compute `parent_commit`; release.
2. **outside the lock** — `backend.allocate()` (the slow part).
3. **under the lock** — re-read the graph (so we don't clobber nodes other allocators committed meanwhile) and attach the finished node, appending to the parent's `children`.

Persisting the `next_id` bump in phase 1 keeps reserved ids unique across concurrent allocators. If `backend.allocate()` fails, the reserved id is simply skipped — exp_ids may have gaps and nothing depends on them being contiguous.

### Tests

`tests/unit/test_allocate_lock_scope.py` (TDD, failing first) drives two concurrent allocations through a backend whose `allocate()` overlaps in time, and asserts they actually run concurrently (`max_concurrent == 2`) with distinct ids, both correctly attached to the graph. On the old code the lock serializes them (`max_concurrent == 1`).

Regression: `test_lifecycle.py`, `test_concurrent_run_guard.py`, `test_core.py`, `test_gitdir_backend.py`, `test_dispatch.py` all pass (83), plus the broader `tests/unit` sweep.

Fixes #98.
