### PR TITLE
feat(cli): `evo budget` — cumulative spend rollup + warn-only cap (closes #104)

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -28,6 +28,7 @@ from .core import (
     attempt_log_path,
     attempt_outcome_path,
     attempt_traces_dir,
+    compute_spend,
     best_committed_node,
     best_committed_score,
     best_spine_ids,
@@ -707,6 +708,8 @@ def cmd_config_show(args: argparse.Namespace) -> int:
     print(f"project_name: {data.get('project_name') or root.name}")
     print(f"benchmark: {data.get('benchmark', '')}")
     print(f"metric: {data.get('metric', '')}")
+    budget = data.get("budget")
+    print(f"budget: {'<unset>' if budget is None else f'${float(budget):.2f}'}")
     print(f"host: {get_host(root) or '<not set>'}")
     print(f"commit_strategy: {data.get('commit_strategy', 'all')}")
     print(f"default_autonomous: {str(bool(data.get('default_autonomous'))).lower()}")
@@ -740,6 +743,7 @@ _CONFIG_FIELD_TO_KEY: dict[str, str] = {
     "per-exp-timeout": "per_exp_timeout",
     "default-orchestrator": "default_orchestrator",
     "task-skills": "task_skills",
+    "budget": "budget",
 }
 
 # Workspace run-behavior defaults captured at discover time. Off by default;
@@ -815,6 +819,19 @@ def cmd_config_set(args: argparse.Namespace) -> int:
             if seconds < 1:
                 raise RuntimeError("per-exp-timeout must be a positive integer (seconds)")
             config["per_exp_timeout"] = seconds
+        elif args.field == "budget":
+            # USD spend cap for warn-only budget enforcement. Empty clears it.
+            raw = args.value.strip()
+            if not raw:
+                config["budget"] = None
+            else:
+                try:
+                    amount = float(raw)
+                except ValueError:
+                    raise RuntimeError("budget must be a non-negative number (USD)")
+                if amount < 0:
+                    raise RuntimeError("budget must be a non-negative number (USD)")
+                config["budget"] = amount
         elif args.field == "gate":
             value = args.value.strip()
             config["gate"] = value or None
@@ -2477,6 +2494,11 @@ def _resolve_run_timeout(args: argparse.Namespace, config: dict) -> int:
 def cmd_run(args: argparse.Namespace) -> int:
     root = repo_root()
     config, graph = _require_workspace(root)
+    # Warn-only budget check (#104): surface cumulative overspend at the start
+    # of each experiment run without blocking it.
+    _budget_msg = _budget_warning(root, config)
+    if _budget_msg:
+        print(_budget_msg, file=sys.stderr)
     # Resolve the effective per-experiment timeout once, then write it back
     # so every downstream `args.timeout` reference picks up the resolved value.
     args.timeout = _resolve_run_timeout(args, config)
@@ -4151,6 +4173,73 @@ def cmd_status(args: argparse.Namespace) -> int:
         f"failed={sum(1 for n in nodes if n.get('status') == 'failed')} "
         f"active={sum(1 for n in nodes if n.get('status') == 'active')} best={best}"
     )
+    return 0
+
+
+def _budget_warning(root: Path, config: dict) -> str | None:
+    """Warn-only budget check (#104). Returns a message if a USD cap is set
+    and cumulative spend has reached it, else None. Never blocks."""
+    cap = config.get("budget")
+    if cap is None:
+        return None
+    try:
+        cap_f = float(cap)
+    except (TypeError, ValueError):
+        return None
+    spent = compute_spend(root)["total_usd"]
+    if spent < cap_f:
+        return None
+    return (
+        f"WARNING: budget cap ${cap_f:.2f} reached (spent ${spent:.2f}). evo is "
+        f"not stopping automatically; stop the optimization loop or raise the "
+        f"cap with `evo config set budget <usd>`."
+    )
+
+
+def cmd_budget(args: argparse.Namespace) -> int:
+    """Show cumulative benchmark spend, and how it compares to the cap."""
+    root = repo_root()
+    config, _graph = _require_workspace(root)
+    spend = compute_spend(root)
+    spent = spend["total_usd"]
+    cap = config.get("budget")
+    cap_f = float(cap) if cap is not None else None
+    remaining = (cap_f - spent) if cap_f is not None else None
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "spent_usd": spent,
+            "cap_usd": cap_f,
+            "remaining_usd": remaining,
+            "input_tokens": spend["input_tokens"],
+            "output_tokens": spend["output_tokens"],
+            "trace_count": spend["trace_count"],
+            "unpriced_traces": spend["unpriced_traces"],
+            "per_experiment": spend["per_experiment"],
+        }, indent=2, sort_keys=True))
+        return 0
+
+    print(
+        f"spent:     ${spent:.2f}  (inputs {spend['input_tokens']:,} tok, "
+        f"outputs {spend['output_tokens']:,} tok, across {spend['trace_count']} traces)"
+    )
+    if cap_f is not None:
+        pct = (spent / cap_f * 100) if cap_f > 0 else 100.0
+        print(f"cap:       ${cap_f:.2f}")
+        print(f"remaining: ${remaining:.2f}  ({pct:.0f}% used)")
+        if spent >= cap_f:
+            print("status:    OVER CAP (warn-only; evo does not stop automatically)")
+    else:
+        print("cap:       <unset>  (set one with `evo config set budget <usd>`)")
+    if spend["unpriced_traces"]:
+        print(
+            f"note:      {spend['unpriced_traces']} trace(s) had a cost but no usd "
+            f"-> spent is a lower bound"
+        )
+    if getattr(args, "by_experiment", False) and spend["per_experiment"]:
+        print("by experiment:")
+        for exp_id in sorted(spend["per_experiment"]):
+            print(f"  {exp_id}: ${spend['per_experiment'][exp_id]:.2f}")
     return 0
 
 
@@ -6237,6 +6326,7 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "budget",
         ],
     )
     config_set_p.add_argument(
@@ -6270,6 +6360,7 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "budget",
         ],
     )
     config_get_p.add_argument("--json", action="store_true",
@@ -6612,6 +6703,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     status_p = sub.add_parser("status")
     status_p.set_defaults(func=cmd_status)
+
+    budget_p = sub.add_parser(
+        "budget",
+        help="show cumulative benchmark spend vs the configured budget cap",
+    )
+    budget_p.add_argument("--json", action="store_true", help="emit JSON")
+    budget_p.add_argument("--by-experiment", action="store_true",
+                          help="break spend down per experiment")
+    budget_p.set_defaults(func=cmd_budget)
 
     tree_p = sub.add_parser("tree")
     tree_p.set_defaults(func=cmd_tree)

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -668,6 +668,60 @@ def attempt_traces_dir(root: Path, exp_id: str, attempt: int) -> Path:
     return attempt_dir(root, exp_id, attempt) / "traces"
 
 
+def compute_spend(root: Path) -> dict[str, Any]:
+    """Roll up cumulative benchmark spend across every experiment attempt.
+
+    Walks each experiment's `attempts/*/traces/*.json` and sums the free-form
+    per-task `cost` dict (convention `{input_tokens, output_tokens, usd,
+    model}`). USD is the enforceable unit; traces that carry a `cost` but no
+    numeric `usd` are counted as `unpriced` so callers can flag the total as a
+    lower bound. Traces with no `cost` at all are ignored entirely.
+    """
+    total_usd = 0.0
+    input_tokens = 0
+    output_tokens = 0
+    priced = 0
+    unpriced = 0
+    per_experiment: dict[str, float] = {}
+
+    exp_root = experiments_path(root)
+    if exp_root.exists():
+        for trace_path in sorted(exp_root.glob("*/attempts/*/traces/*.json")):
+            try:
+                trace = json.loads(trace_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(trace, dict):
+                continue
+            cost = trace.get("cost")
+            if not isinstance(cost, dict):
+                continue
+            exp_id = trace_path.relative_to(exp_root).parts[0]
+            usd = cost.get("usd")
+            if isinstance(usd, (int, float)) and not isinstance(usd, bool):
+                total_usd += float(usd)
+                per_experiment[exp_id] = per_experiment.get(exp_id, 0.0) + float(usd)
+                priced += 1
+            else:
+                unpriced += 1
+            it = cost.get("input_tokens")
+            ot = cost.get("output_tokens")
+            if isinstance(it, int) and not isinstance(it, bool):
+                input_tokens += it
+            if isinstance(ot, int) and not isinstance(ot, bool):
+                output_tokens += ot
+
+    return {
+        "total_usd": round(total_usd, 6),
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "trace_count": priced + unpriced,
+        "priced_traces": priced,
+        "unpriced_traces": unpriced,
+        "per_experiment": {k: round(v, 6) for k, v in per_experiment.items()},
+    }
+
+
 def attempt_outcome_path(root: Path, exp_id: str, attempt: int) -> Path:
     return attempt_dir(root, exp_id, attempt) / "outcome.json"
 

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -1,0 +1,156 @@
+"""`evo budget` — cumulative spend rollup + warn-only cap (#104)."""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo import cli
+from evo.core import (
+    compute_spend,
+    experiments_path,
+    init_workspace,
+    load_config,
+)
+
+
+def _init_ws(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    init_workspace(root, target="t.py", benchmark="echo hi", metric="max", gate=None)
+
+
+def _write_trace(root: Path, exp_id: str, attempt: int, task: str, cost) -> None:
+    d = experiments_path(root) / exp_id / "attempts" / f"{attempt:03d}" / "traces"
+    d.mkdir(parents=True, exist_ok=True)
+    trace = {"experiment_id": exp_id, "task_id": task, "score": 1.0}
+    if cost is not None:
+        trace["cost"] = cost
+    (d / f"task_{task}.json").write_text(json.dumps(trace), encoding="utf-8")
+
+
+# --- compute_spend --------------------------------------------------------
+
+def test_compute_spend_sums_usd_across_experiments_and_attempts(tmp_path):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 0.10, "input_tokens": 100, "output_tokens": 20})
+    _write_trace(root, "exp_0000", 1, "1", {"usd": 0.05, "input_tokens": 50, "output_tokens": 10})
+    _write_trace(root, "exp_0000", 2, "0", {"usd": 0.20, "input_tokens": 200, "output_tokens": 40})
+    _write_trace(root, "exp_0001", 1, "0", {"usd": 0.65, "input_tokens": 600, "output_tokens": 60})
+
+    spend = compute_spend(root)
+    assert round(spend["total_usd"], 2) == 1.00
+    assert spend["input_tokens"] == 950
+    assert spend["output_tokens"] == 130
+    assert spend["per_experiment"]["exp_0000"] == 0.35
+    assert spend["per_experiment"]["exp_0001"] == 0.65
+
+
+def test_compute_spend_counts_unpriced_traces(tmp_path):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 0.10})
+    _write_trace(root, "exp_0000", 1, "1", {"input_tokens": 100})   # cost, no usd
+    _write_trace(root, "exp_0000", 1, "2", None)                     # no cost at all
+
+    spend = compute_spend(root)
+    assert round(spend["total_usd"], 2) == 0.10
+    assert spend["unpriced_traces"] == 1
+    assert spend["priced_traces"] == 1
+
+
+def test_compute_spend_empty_workspace_is_zero(tmp_path):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    spend = compute_spend(root)
+    assert spend["total_usd"] == 0.0
+    assert spend["trace_count"] == 0
+
+
+# --- budget config field --------------------------------------------------
+
+def test_config_set_budget(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="budget", value="20"))
+    assert load_config(root)["budget"] == 20.0
+
+
+def test_config_set_budget_rejects_negative(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    import pytest
+    with pytest.raises(RuntimeError):
+        cli.cmd_config_set(argparse.Namespace(field="budget", value="-5"))
+
+
+def test_config_set_budget_clears_on_empty(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="budget", value="20"))
+    cli.cmd_config_set(argparse.Namespace(field="budget", value=""))
+    assert load_config(root).get("budget") is None
+
+
+# --- evo budget command ---------------------------------------------------
+
+def test_cmd_budget_json(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="budget", value="1.00"))
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 0.60})
+
+    out = io.StringIO()
+    with patch("sys.stdout", out):
+        rc = cli.cmd_budget(argparse.Namespace(json=True))
+    assert rc == 0
+    payload = json.loads(out.getvalue())
+    assert round(payload["spent_usd"], 2) == 0.60
+    assert payload["cap_usd"] == 1.00
+    assert round(payload["remaining_usd"], 2) == 0.40
+
+
+# --- warn-only enforcement helper ----------------------------------------
+
+def test_budget_warning_none_when_no_cap(tmp_path):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 999.0})
+    assert cli._budget_warning(root, load_config(root)) is None
+
+
+def test_budget_warning_none_when_under_cap(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="budget", value="10"))
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 3.0})
+    assert cli._budget_warning(root, load_config(root)) is None
+
+
+def test_budget_warning_fires_when_over_cap(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    _init_ws(root)
+    monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="budget", value="10"))
+    _write_trace(root, "exp_0000", 1, "0", {"usd": 11.0})
+    msg = cli._budget_warning(root, load_config(root))
+    assert msg is not None
+    assert "budget cap" in msg.lower()


### PR DESCRIPTION
Closes #104.

### Feature

evo runs many (often paid) LLM benchmark experiments, and the SDK already records a per-task `cost` dict in every trace (convention `{input_tokens, output_tokens, usd, model}`) — but nothing surfaced or aggregated it. This adds spend visibility plus an optional, **non-blocking** budget cap.

**`core.compute_spend(root)`** — walks every experiment's `experiments/<id>/attempts/*/traces/*.json`, sums `cost.usd` (+ input/output tokens), and counts `unpriced` traces (a `cost` present but no numeric `usd`) so the total can be flagged as a lower bound. Traces with no `cost` are ignored.

**`evo budget`** `[--json] [--by-experiment]`:
```
$ evo budget
spent:     $6.25  (inputs 1,000 tok, outputs 200 tok, across 1 traces)
cap:       $5.00
remaining: $-1.25  (125% used)
status:    OVER CAP (warn-only; evo does not stop automatically)
```

**`evo config set budget <usd>`** — a USD cap stored in the workspace config (shown in `config show`, readable via `config get budget`); empty clears it; negatives / non-numbers are rejected.

**Warn-only enforcement in `evo run`** — at the start of each run, if a cap is set and cumulative spend >= cap, evo prints a prominent stderr `WARNING` and continues (never blocks). Because each `evo run` is a separate process, this warns once per experiment start — the right cadence for a loop.

### Design notes / scope

- **Warn-only by design** — no hard-blocking of `evo run` (chosen deliberately; a residual over-cap run is never silently killed).
- USD only; benchmarks that report a `cost` without `usd` are counted as `unpriced` and surfaced as a note, not silently dropped.
- No dashboard UI in this PR.

### Tests

`tests/unit/test_budget.py` (TDD, written failing first) — 10 tests:
- `compute_spend` sums USD across experiments + attempts, tracks tokens and per-experiment totals, counts unpriced traces, and is zero on an empty workspace
- `config set budget` stores / validates / rejects negatives / clears on empty
- `evo budget --json` reports spent / cap / remaining
- `_budget_warning` returns None with no cap or under cap, and fires over cap

Also verified end-to-end (`evo init` → `config set budget` → seed a trace → `evo budget` / `--json` / `config show`). Full `tests/unit` sweep green.
