### PR TITLE
feat(cli): webhook notifications for autoresearch events (closes #106)

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -707,6 +707,7 @@ def cmd_config_show(args: argparse.Namespace) -> int:
     print(f"project_name: {data.get('project_name') or root.name}")
     print(f"benchmark: {data.get('benchmark', '')}")
     print(f"metric: {data.get('metric', '')}")
+    print(f"notify_webhook: {data.get('notify_webhook') or '<unset>'}")
     print(f"host: {get_host(root) or '<not set>'}")
     print(f"commit_strategy: {data.get('commit_strategy', 'all')}")
     print(f"default_autonomous: {str(bool(data.get('default_autonomous'))).lower()}")
@@ -740,6 +741,7 @@ _CONFIG_FIELD_TO_KEY: dict[str, str] = {
     "per-exp-timeout": "per_exp_timeout",
     "default-orchestrator": "default_orchestrator",
     "task-skills": "task_skills",
+    "notify-webhook": "notify_webhook",
 }
 
 # Workspace run-behavior defaults captured at discover time. Off by default;
@@ -815,6 +817,15 @@ def cmd_config_set(args: argparse.Namespace) -> int:
             if seconds < 1:
                 raise RuntimeError("per-exp-timeout must be a positive integer (seconds)")
             config["per_exp_timeout"] = seconds
+        elif args.field == "notify-webhook":
+            # Webhook URL for event notifications (#106). Empty clears it.
+            raw = args.value.strip()
+            if not raw:
+                config["notify_webhook"] = None
+            elif raw.startswith("http://") or raw.startswith("https://"):
+                config["notify_webhook"] = raw
+            else:
+                raise RuntimeError("notify-webhook must be an http(s) URL")
         elif args.field == "gate":
             value = args.value.strip()
             config["gate"] = value or None
@@ -3484,6 +3495,16 @@ def _cmd_run_impl(
             )
             delta = "" if parent_score is None else f" ({'+' if metric == 'max' else ''}{score - parent_score:.4f} vs parent)"
             print(f"COMMITTED {args.exp_id} {score}{delta}")
+            # Notify (best-effort) when this commit is a new workspace best (#106).
+            if compare_scores(metric, score, best_before_score):
+                best_txt = "first commit" if best_before_score is None else f"previous best {best_before_score}"
+                _maybe_notify(
+                    root, config, "new_best",
+                    f"🎉 evo: new best score {score} on {args.exp_id} ({best_txt})",
+                    {"exp_id": args.exp_id, "score": score,
+                     "previous_best": best_before_score, "commit": commit,
+                     "metric": metric},
+                )
             return 0
 
         def _mark_evaluated(current_node: dict, _graph: dict) -> None:
@@ -4152,6 +4173,47 @@ def cmd_status(args: argparse.Namespace) -> int:
         f"active={sum(1 for n in nodes if n.get('status') == 'active')} best={best}"
     )
     return 0
+
+
+def _maybe_notify(root: Path, config: dict, event: str, message: str,
+                  extra: dict | None = None) -> bool:
+    """Fire a webhook notification if one is configured. Best-effort and
+    non-fatal: a missing or failing webhook never breaks the caller (#106)."""
+    url = config.get("notify_webhook")
+    if not url:
+        return False
+    from . import notify
+    ok = notify.send_notification(url, event, message, extra)
+    if not ok:
+        print(f"WARNING: notification webhook POST failed (event={event})", file=sys.stderr)
+    return ok
+
+
+def cmd_notify(args: argparse.Namespace) -> int:
+    """`evo notify test` — send a test notification to the configured webhook."""
+    if getattr(args, "notify_action", None) != "test":
+        print("usage: evo notify test", file=sys.stderr)
+        return 2
+    root = repo_root()
+    config, _graph = _require_workspace(root)
+    url = config.get("notify_webhook")
+    if not url:
+        print(
+            "ERROR: no notify-webhook configured. Set one with "
+            "`evo config set notify-webhook <url>`.",
+            file=sys.stderr,
+        )
+        return 2
+    from . import notify
+    ok = notify.send_notification(
+        url, "test", "✅ evo test notification — your webhook is wired up.",
+        {"workspace": str(root)},
+    )
+    if ok:
+        print("notification sent")
+        return 0
+    print("ERROR: notification POST failed (check the webhook URL)", file=sys.stderr)
+    return 1
 
 
 def cmd_tree(args: argparse.Namespace) -> int:
@@ -6237,6 +6299,7 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "notify-webhook",
         ],
     )
     config_set_p.add_argument(
@@ -6270,6 +6333,7 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "notify-webhook",
         ],
     )
     config_get_p.add_argument("--json", action="store_true",
@@ -6612,6 +6676,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     status_p = sub.add_parser("status")
     status_p.set_defaults(func=cmd_status)
+
+    notify_p = sub.add_parser("notify", help="webhook notifications")
+    notify_sub = notify_p.add_subparsers(dest="notify_action", required=True)
+    notify_test_p = notify_sub.add_parser("test", help="send a test notification")
+    notify_test_p.set_defaults(func=cmd_notify)
 
     tree_p = sub.add_parser("tree")
     tree_p.set_defaults(func=cmd_tree)

--- a/plugins/evo/src/evo/notify.py
+++ b/plugins/evo/src/evo/notify.py
@@ -1,0 +1,46 @@
+"""Best-effort webhook notifications for autoresearch events (#106).
+
+A single configured webhook URL receives a JSON payload on key events (e.g.
+a new best score committing). The payload sets both `text` (Slack incoming
+webhooks) and `content` (Discord webhooks) to the message, plus structured
+fields, so one URL works for Slack, Discord, or any generic receiver.
+
+Sending is always best-effort: a down or misconfigured webhook must never
+break an experiment run, so `send_notification` swallows every error and
+returns a bool instead of raising.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+DEFAULT_TIMEOUT = 5
+
+
+def build_payload(event: str, message: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "source": "evo",
+        "event": event,
+        "text": message,      # Slack incoming-webhook message key
+        "content": message,   # Discord webhook message key
+    }
+    if extra:
+        payload["data"] = extra
+    return payload
+
+
+def send_notification(
+    url: str,
+    event: str,
+    message: str,
+    extra: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> bool:
+    """POST a notification payload. Best-effort: returns True on a 2xx
+    response, False on any non-2xx or transport error. Never raises."""
+    try:
+        resp = requests.post(url, json=build_payload(event, message, extra), timeout=timeout)
+        return 200 <= resp.status_code < 300
+    except Exception:  # noqa: BLE001 -- a bad webhook must never break a run
+        return False

--- a/tests/unit/test_notify.py
+++ b/tests/unit/test_notify.py
@@ -1,0 +1,124 @@
+"""Webhook notifications for autoresearch events (#106)."""
+from __future__ import annotations
+
+import argparse
+import io
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "evo" / "src"))
+
+from evo import cli, notify
+from evo.core import init_workspace, load_config
+
+
+def _init_ws(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    init_workspace(root, target="t.py", benchmark="echo hi", metric="max", gate=None)
+
+
+# --- payload ---------------------------------------------------------------
+
+def test_payload_carries_slack_and_discord_keys():
+    p = notify.build_payload("new_best", "hello", {"exp_id": "exp_0001"})
+    assert p["text"] == "hello"       # Slack incoming-webhook key
+    assert p["content"] == "hello"    # Discord webhook key
+    assert p["event"] == "new_best"
+    assert p["source"] == "evo"
+    assert p["data"]["exp_id"] == "exp_0001"
+
+
+# --- send_notification (never raises) -------------------------------------
+
+def test_send_posts_json_and_returns_true_on_2xx():
+    resp = MagicMock(status_code=200)
+    with patch.object(notify, "requests") as rq:
+        rq.post.return_value = resp
+        ok = notify.send_notification("https://hooks.example/x", "test", "hi")
+    assert ok is True
+    args, kwargs = rq.post.call_args
+    assert args[0] == "https://hooks.example/x"
+    assert kwargs["json"]["text"] == "hi"
+
+
+def test_send_returns_false_on_non_2xx():
+    with patch.object(notify, "requests") as rq:
+        rq.post.return_value = MagicMock(status_code=500)
+        assert notify.send_notification("https://hooks.example/x", "t", "hi") is False
+
+
+def test_send_swallows_exceptions_and_returns_false():
+    with patch.object(notify, "requests") as rq:
+        rq.post.side_effect = Exception("network down")
+        assert notify.send_notification("https://hooks.example/x", "t", "hi") is False
+
+
+# --- config field ----------------------------------------------------------
+
+def test_config_set_notify_webhook(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value="https://hooks.slack.com/services/x"))
+    assert load_config(root)["notify_webhook"] == "https://hooks.slack.com/services/x"
+
+
+def test_config_set_notify_webhook_rejects_non_url(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    import pytest
+    with pytest.raises(RuntimeError):
+        cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value="not-a-url"))
+
+
+def test_config_set_notify_webhook_clears_on_empty(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value="https://hooks.example/x"))
+    cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value=""))
+    assert load_config(root).get("notify_webhook") is None
+
+
+# --- _maybe_notify gate ----------------------------------------------------
+
+def test_maybe_notify_noop_without_webhook(tmp_path):
+    root = tmp_path.resolve(); _init_ws(root)
+    with patch.object(notify, "send_notification") as send:
+        result = cli._maybe_notify(root, load_config(root), "new_best", "msg")
+    assert result is False
+    send.assert_not_called()
+
+
+def test_maybe_notify_sends_when_webhook_set(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value="https://hooks.example/x"))
+    with patch.object(notify, "send_notification", return_value=True) as send:
+        result = cli._maybe_notify(root, load_config(root), "new_best", "msg", {"k": "v"})
+    assert result is True
+    send.assert_called_once()
+    assert send.call_args[0][0] == "https://hooks.example/x"
+
+
+# --- evo notify test -------------------------------------------------------
+
+def test_cmd_notify_test_posts(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    cli.cmd_config_set(argparse.Namespace(field="notify-webhook", value="https://hooks.example/x"))
+    with patch.object(notify, "send_notification", return_value=True) as send:
+        rc = cli.cmd_notify(argparse.Namespace(notify_action="test"))
+    assert rc == 0
+    send.assert_called_once()
+
+
+def test_cmd_notify_test_errors_without_webhook(tmp_path, monkeypatch):
+    root = tmp_path.resolve(); _init_ws(root); monkeypatch.chdir(root)
+    err = io.StringIO()
+    with patch("sys.stderr", err):
+        rc = cli.cmd_notify(argparse.Namespace(notify_action="test"))
+    assert rc != 0
+    assert "notify-webhook" in err.getvalue()


### PR DESCRIPTION
Closes #106.

### Motivation

evo optimization loops run autonomously for a long time (SFT/RL cycles are 1–2h+ each, chained across many experiments), but there was **no way to be notified** when the loop found a new best score. Crawling the evo docs (JS-rendered) and grepping the codebase both confirm no notification/webhook/Slack integration exists anywhere — the public integrations are hosts + remote sandboxes + gates + dashboard. This fills that gap.

### What's added

- **`notify.py`** — `send_notification(url, event, message, extra)` POSTs a JSON payload and **never raises** (a down or misconfigured webhook must not break a run; it returns a bool). The payload sets both `text` (Slack incoming-webhook key) and `content` (Discord webhook key) to the message, plus `source`/`event`/`data`, so one URL works for Slack, Discord, or any generic receiver.
- **`evo config set notify-webhook <url>`** — stores the webhook (http/https only; empty clears; shown in `config show`, readable via `config get`).
- **`new_best` event** — at the end of `evo run`, when a commit beats the previous best (`compare_scores(metric, score, best_before_score)`), evo fires a best-effort notification:
  > 🎉 evo: new best score 0.8123 on exp_0007 (previous best 0.7913)
- **`evo notify test`** — sends a test notification so users can verify setup without waiting for a run.

### Design notes / scope

- **Best-effort by design.** `_maybe_notify` and `send_notification` swallow all errors and only warn on stderr; a failed webhook never affects run outcome.
- **In:** the `notify` module, the config field, the `new_best` event, and `evo notify test`.
- **Out (easy follow-ups):** run-finished / budget-cap-hit / experiment-failed events, per-event routing, message templating, retries/backoff.

### Tests

`tests/unit/test_notify.py` (TDD, written failing first) — 11 tests:
- payload carries both `text` and `content` + structured data
- `send_notification` returns True on 2xx, False on non-2xx, and False (no raise) on transport error
- `config set notify-webhook` stores / rejects non-URLs / clears on empty
- `_maybe_notify` is a no-op without a webhook and posts when one is set
- `evo notify test` posts when configured and errors clearly when not

Also verified end-to-end (`init` → `config set notify-webhook` → `config show` → `evo notify test` fails gracefully against a bogus host, rc=1, no crash). Full `tests/unit` sweep green.
