### PR TITLE
feat(cli): variance-aware scoring for noisy benchmarks (closes #4)

### DIFF
--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -2499,6 +2499,24 @@ def _resolve_run_timeout(args: argparse.Namespace, config: dict) -> int:
     return 1800
 
 
+def persist_aggregate_result(
+    result_path: Path, parsed: dict[str, Any] | None, aggregate: float
+) -> None:
+    """Write the variance-aware aggregate score back to result.json.
+
+    Each extra trial overwrites result.json with its own (raw) score, so after
+    aggregation the file holds the last trial's score rather than the aggregate.
+    A crash-recovery resume re-reads result.json without re-aggregating (the
+    ``benchmark_completed`` gate), so it would otherwise be scored by that single
+    noisy trial. Persisting the aggregate keeps recovery and every downstream
+    result.json reader consistent with the committed node score. The primary
+    trial's other fields are preserved.
+    """
+    base = dict(parsed) if isinstance(parsed, dict) else {}
+    base["score"] = aggregate
+    atomic_write_json(result_path, base)
+
+
 def run_extra_benchmark_trials(
     executor: Any,
     *,
@@ -2549,6 +2567,19 @@ def run_extra_benchmark_trials(
         if bench is not None and bench.timed_out:
             raise RuntimeError("benchmark_timeout")
         if bench is not None and (bench.exit_code or 0) != 0:
+            # Mirror the primary run: a non-zero remote exit may be an infra
+            # failure, which must be classified as such (not benchmark_exit) so
+            # telemetry failure_type stays accurate.
+            if remote:
+                _fetch_remote_artifacts(
+                    executor, sandbox_result_path, sandbox_traces_dir,
+                    result_path, traces_dir,
+                )
+                if sandbox_checkpoint_dir and checkpoint_dir is not None:
+                    executor.fetch_dir(sandbox_checkpoint_dir, checkpoint_dir)
+                infra_error = _remote_infra_error_for_log(benchmark_log)
+                if infra_error is not None:
+                    raise RuntimeError(f"remote_infra_failure:{infra_error}")
             raise RuntimeError(f"benchmark_exit_{bench.exit_code}")
 
         if remote:
@@ -3470,6 +3501,10 @@ def _cmd_run_impl(
                 {"score": s, "returncode": 0} for s in trial_scores
             ]
             benchmark_record["aggregate"] = {**agg_stats, "value": score}
+            # Persist the aggregate so a crash-recovery resume (which re-reads
+            # result.json without re-aggregating) is scored by the aggregate,
+            # not the last raw trial.
+            persist_aggregate_result(result_path, parsed, score)
             print(
                 f"BENCH_AGGREGATE {args.exp_id} method={aggregation} "
                 f"n={len(trial_scores)} score={score} "

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -20,6 +20,7 @@ from .core import (
     _load_meta,
     add_gate,
     add_workspace_note,
+    aggregate_trial_scores,
     append_annotation,
     append_infra_event,
     ascii_tree,
@@ -707,6 +708,8 @@ def cmd_config_show(args: argparse.Namespace) -> int:
     print(f"project_name: {data.get('project_name') or root.name}")
     print(f"benchmark: {data.get('benchmark', '')}")
     print(f"metric: {data.get('metric', '')}")
+    print(f"bench_repeat: {data.get('bench_repeat', 1)}")
+    print(f"score_aggregation: {data.get('score_aggregation') or 'median'}")
     print(f"host: {get_host(root) or '<not set>'}")
     print(f"commit_strategy: {data.get('commit_strategy', 'all')}")
     print(f"default_autonomous: {str(bool(data.get('default_autonomous'))).lower()}")
@@ -740,6 +743,8 @@ _CONFIG_FIELD_TO_KEY: dict[str, str] = {
     "per-exp-timeout": "per_exp_timeout",
     "default-orchestrator": "default_orchestrator",
     "task-skills": "task_skills",
+    "bench-repeat": "bench_repeat",
+    "score-aggregation": "score_aggregation",
 }
 
 # Workspace run-behavior defaults captured at discover time. Off by default;
@@ -843,6 +848,26 @@ def cmd_config_set(args: argparse.Namespace) -> int:
             # read by every executing agent (prose subagent or workflow lane).
             names = [s.strip() for s in args.value.split(",") if s.strip()]
             config["task_skills"] = names or None
+        elif args.field == "bench-repeat":
+            # Number of times to run the scored benchmark per attempt (#4).
+            # 1 (default) keeps today's single-run behavior; >1 aggregates
+            # trial scores to blunt noisy-benchmark variance.
+            try:
+                repeat = int(args.value)
+            except ValueError:
+                raise RuntimeError("bench-repeat must be a positive integer")
+            if repeat < 1:
+                raise RuntimeError("bench-repeat must be a positive integer")
+            config["bench_repeat"] = repeat
+        elif args.field == "score-aggregation":
+            from .core import SCORE_AGGREGATIONS
+            value = args.value.strip().lower()
+            if value not in SCORE_AGGREGATIONS:
+                raise RuntimeError(
+                    "score-aggregation must be one of "
+                    f"{', '.join(SCORE_AGGREGATIONS)}"
+                )
+            config["score_aggregation"] = value
         elif args.field in _CONFIG_BOOL_FIELDS:
             config[_CONFIG_FIELD_TO_KEY[args.field]] = _parse_onoff(args.value)
         else:
@@ -2474,6 +2499,75 @@ def _resolve_run_timeout(args: argparse.Namespace, config: dict) -> int:
     return 1800
 
 
+def run_extra_benchmark_trials(
+    executor: Any,
+    *,
+    n_extra: int,
+    benchmark_cmd: str,
+    run_cwd: Any,
+    env: dict[str, str],
+    timeout: Any,
+    result_path: Path,
+    benchmark_log: Path,
+    benchmark_err: Path,
+    remote: bool = False,
+    sandbox_result_path: str = "",
+    sandbox_traces_dir: str = "",
+    traces_dir: Path | None = None,
+    sandbox_checkpoint_dir: str = "",
+    checkpoint_dir: Path | None = None,
+) -> list[float]:
+    """Run the scored benchmark ``n_extra`` ADDITIONAL times and return the
+    extra trial scores (#4, variance-aware scoring).
+
+    Only fresh runs repeat -- the caller invokes this after a primary run has
+    already produced one score, exclusively when ``bench_repeat > 1`` and the
+    primary run was not a crash-recovery/attach. Each trial clears the previous
+    ``result.json`` (local and, when remote, in the sandbox) so ``load_result``'s
+    O_EXCL writer claim starts clean, then re-streams the same command. Trials
+    are strict: a non-zero exit or timeout raises exactly as the primary run
+    would, so a flaky benchmark never masks a real crash. Each trial overwrites
+    the benchmark log (the last trial's log/traces are kept, matching the
+    design), while every trial score is preserved in the returned list.
+    """
+    extra: list[float] = []
+    for _ in range(n_extra):
+        # Clear the prior trial's result so this trial's writer starts clean.
+        if result_path.exists():
+            result_path.unlink()
+        if remote and sandbox_result_path:
+            executor.run(["rm", "-f", sandbox_result_path], cwd=run_cwd)
+
+        bench = executor.stream(
+            ["sh", "-c", benchmark_cmd],
+            cwd=run_cwd, env=env, timeout=timeout,
+            stdout_path=benchmark_log, stderr_path=benchmark_err,
+            mirror_remote_dir=sandbox_traces_dir if remote else None,
+            mirror_local_dir=traces_dir if remote else None,
+            mirror_dirs=[(sandbox_checkpoint_dir, checkpoint_dir)] if remote else None,
+        )
+        if bench is not None and bench.timed_out:
+            raise RuntimeError("benchmark_timeout")
+        if bench is not None and (bench.exit_code or 0) != 0:
+            raise RuntimeError(f"benchmark_exit_{bench.exit_code}")
+
+        if remote:
+            _fetch_remote_artifacts(
+                executor, sandbox_result_path, sandbox_traces_dir,
+                result_path, traces_dir,
+            )
+            if sandbox_checkpoint_dir and checkpoint_dir is not None:
+                executor.fetch_dir(sandbox_checkpoint_dir, checkpoint_dir)
+
+        bench_stdout = bench.stdout if bench is not None else (
+            benchmark_log.read_text(encoding="utf-8", errors="replace")
+            if benchmark_log.exists() else ""
+        )
+        trial_score, _ = load_result(result_path, bench_stdout)
+        extra.append(trial_score)
+    return extra
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     root = repo_root()
     config, graph = _require_workspace(root)
@@ -3337,6 +3431,50 @@ def _cmd_run_impl(
         score, parsed = load_result(result_path, bench_stdout)
         benchmark_record = {"command": benchmark_cmd, "returncode": 0, "result": parsed}
         _assert_tasks_aggregated(traces_dir, parsed)
+
+        # Variance-aware scoring (#4): for noisy benchmarks, re-run the scored
+        # benchmark and aggregate so a single lucky run can't set the new best.
+        # Only fresh runs repeat -- a crash-recovery/attach yields one score and
+        # must not be re-executed. bench_repeat<=1 keeps single-run behavior.
+        bench_repeat = int(config.get("bench_repeat", 1) or 1)
+        fresh_primary_run = not benchmark_completed and not resume_journal
+        if bench_repeat > 1 and fresh_primary_run:
+            aggregation = str(config.get("score_aggregation") or "median")
+            _write_attempt_state(
+                root, args.exp_id, attempt_n,
+                phase="benchmark", status="repeating", started_at=started_at,
+                extra={"bench_repeat": bench_repeat, "trial": 1},
+            )
+            extra_scores = run_extra_benchmark_trials(
+                executor,
+                n_extra=bench_repeat - 1,
+                benchmark_cmd=benchmark_cmd,
+                run_cwd=run_cwd,
+                env=env,
+                timeout=args.timeout,
+                result_path=result_path,
+                benchmark_log=benchmark_log,
+                benchmark_err=benchmark_err,
+                remote=remote,
+                sandbox_result_path=sandbox_result_path if remote else "",
+                sandbox_traces_dir=sandbox_traces_dir if remote else "",
+                traces_dir=traces_dir,
+                sandbox_checkpoint_dir=sandbox_checkpoint_dir if remote else "",
+                checkpoint_dir=checkpoint_dir,
+            )
+            trial_scores = [score] + extra_scores
+            score, agg_stats = aggregate_trial_scores(
+                trial_scores, aggregation, metric
+            )
+            benchmark_record["trials"] = [
+                {"score": s, "returncode": 0} for s in trial_scores
+            ]
+            benchmark_record["aggregate"] = {**agg_stats, "value": score}
+            print(
+                f"BENCH_AGGREGATE {args.exp_id} method={aggregation} "
+                f"n={len(trial_scores)} score={score} "
+                f"trials={','.join(str(s) for s in trial_scores)}"
+            )
 
         _write_attempt_state(
             root, args.exp_id, attempt_n,
@@ -6237,6 +6375,8 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "bench-repeat",
+            "score-aggregation",
         ],
     )
     config_set_p.add_argument(
@@ -6270,6 +6410,8 @@ def build_parser() -> argparse.ArgumentParser:
             "per-exp-timeout",
             "default-orchestrator",
             "task-skills",
+            "bench-repeat",
+            "score-aggregation",
         ],
     )
     config_get_p.add_argument("--json", action="store_true",

--- a/plugins/evo/src/evo/core.py
+++ b/plugins/evo/src/evo/core.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import secrets
+import statistics
 import subprocess
 import tempfile
 from datetime import datetime, timezone
@@ -1105,6 +1106,52 @@ def compare_scores(metric: str, candidate: float, parent: float | None) -> bool:
     if metric == "min":
         return candidate <= parent
     raise ValueError(f"Unknown metric: {metric}")
+
+
+SCORE_AGGREGATIONS = ("median", "mean", "worst")
+
+
+def aggregate_trial_scores(
+    scores: list[float], method: str, metric: str
+) -> tuple[float, dict[str, Any]]:
+    """Collapse N noisy benchmark-trial scores into one comparable score.
+
+    Returns ``(aggregate, stats)`` where stats carries
+    ``{n, mean, median, min, max, stdev, method}`` for transparency.
+
+    ``method`` is one of :data:`SCORE_AGGREGATIONS`. ``worst`` is
+    direction-aware: the lowest score when ``metric == "max"`` (higher is
+    better), the highest score when ``metric == "min"``. ``median`` resists a
+    single lucky/unlucky run, which is why it is the default.
+    """
+    if not scores:
+        raise ValueError("aggregate_trial_scores requires at least one score")
+    if method not in SCORE_AGGREGATIONS:
+        raise ValueError(
+            f"Unknown score aggregation: {method!r} "
+            f"(expected one of {', '.join(SCORE_AGGREGATIONS)})"
+        )
+    if metric not in ("max", "min"):
+        raise ValueError(f"Unknown metric: {metric}")
+
+    values = [float(s) for s in scores]
+    if method == "mean":
+        aggregate = statistics.fmean(values)
+    elif method == "median":
+        aggregate = statistics.median(values)
+    else:  # worst -- direction-aware
+        aggregate = min(values) if metric == "max" else max(values)
+
+    stats = {
+        "n": len(values),
+        "mean": statistics.fmean(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+        "stdev": statistics.pstdev(values) if len(values) > 1 else 0.0,
+        "method": method,
+    }
+    return aggregate, stats
 
 
 def _normalized_prune_kind(node: dict[str, Any]) -> str | None:

--- a/tests/unit/test_config_set.py
+++ b/tests/unit/test_config_set.py
@@ -138,6 +138,30 @@ class TestConfigSet(unittest.TestCase):
             cmd_config_set(_args("default-subagents-only", "maybe"))
         self.assertIn("on/off", str(ctx.exception))
 
+    # --- variance-aware scoring (#4) ------------------------------------
+
+    def test_set_bench_repeat(self):
+        cmd_config_set(_args("bench-repeat", "5"))
+        self.assertEqual(load_config(self.root)["bench_repeat"], 5)
+
+    def test_bench_repeat_rejects_zero(self):
+        with self.assertRaises(RuntimeError):
+            cmd_config_set(_args("bench-repeat", "0"))
+
+    def test_bench_repeat_rejects_non_integer(self):
+        with self.assertRaises(RuntimeError):
+            cmd_config_set(_args("bench-repeat", "lots"))
+
+    def test_set_score_aggregation(self):
+        for method in ("median", "mean", "worst"):
+            cmd_config_set(_args("score-aggregation", method))
+            self.assertEqual(load_config(self.root)["score_aggregation"], method)
+
+    def test_score_aggregation_rejects_unknown(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            cmd_config_set(_args("score-aggregation", "p95"))
+        self.assertIn("median", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_variance_scoring.py
+++ b/tests/unit/test_variance_scoring.py
@@ -11,8 +11,8 @@ import types
 import unittest
 from pathlib import Path
 
-from evo.cli import run_extra_benchmark_trials
-from evo.core import aggregate_trial_scores
+from evo.cli import persist_aggregate_result, run_extra_benchmark_trials
+from evo.core import aggregate_trial_scores, load_result
 
 
 class TestAggregateTrialScores(unittest.TestCase):
@@ -136,6 +136,100 @@ class TestRunExtraBenchmarkTrials(unittest.TestCase):
         ex = _FakeExecutor(self.result_path, [(None, 0, True)])
         with self.assertRaises(RuntimeError):
             self._call(ex, n_extra=1)
+
+
+class TestPersistAggregateResult(unittest.TestCase):
+    """The aggregate must be written back to result.json so a crash-recovery
+    resume (which re-reads result.json without re-aggregating) is scored by the
+    aggregate, not the last raw trial (Devin review, issue 1)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.rp = Path(self._tmp.name) / "result.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_overwrites_last_trial_score_with_aggregate(self):
+        # Simulate the last remote trial having overwritten result.json.
+        self.rp.write_text(json.dumps({"score": 0.99, "tasks": [{"id": "a"}]}))
+        persist_aggregate_result(self.rp, {"score": 0.99, "tasks": [{"id": "a"}]}, 0.5)
+        score, parsed = load_result(self.rp, "")
+        self.assertEqual(score, 0.5)  # aggregate, not the 0.99 raw trial
+        self.assertEqual(parsed["tasks"], [{"id": "a"}])  # other fields preserved
+
+    def test_handles_none_parsed(self):
+        persist_aggregate_result(self.rp, None, 0.42)
+        score, _ = load_result(self.rp, "")
+        self.assertEqual(score, 0.42)
+
+
+class _RemoteFakeExecutor:
+    """Remote-path fake: stream() returns the queued (exit_code, timed_out);
+    file_exists/read_bytes/fetch_dir/run are no-ops so _fetch_remote_artifacts
+    is exercised without a real sandbox."""
+
+    def __init__(self, trials):
+        self.trials = list(trials)
+        self.stream_calls = 0
+
+    def stream(self, cmd, **kwargs):
+        exit_code, timed_out = self.trials[self.stream_calls]
+        self.stream_calls += 1
+        return types.SimpleNamespace(stdout="", exit_code=exit_code, timed_out=timed_out)
+
+    def run(self, cmd, **kwargs):
+        return types.SimpleNamespace(stdout="", exit_code=0, timed_out=False)
+
+    def file_exists(self, path):
+        return False
+
+    def read_bytes(self, path):
+        return b""
+
+    def fetch_dir(self, remote, local):
+        return None
+
+
+class TestTrialLoopRemoteInfraClassification(unittest.TestCase):
+    """A remote infra failure in an extra trial must be classified as
+    remote_infra_failure (like the primary run), not benchmark_exit (issue 2)."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self.log = self.d / "bench.log"
+        self.log.write_text("")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _call(self, executor):
+        return run_extra_benchmark_trials(
+            executor, n_extra=1, benchmark_cmd="python bench.py",
+            run_cwd=self.d, env={}, timeout=None,
+            result_path=self.d / "result.json",
+            benchmark_log=self.log, benchmark_err=self.d / "bench_err.log",
+            remote=True, sandbox_result_path="/sb/result.json",
+            sandbox_traces_dir="/sb/traces", traces_dir=self.d / "traces",
+        )
+
+    def test_infra_journal_raises_remote_infra_failure(self):
+        # Journal companion marks the run as an infra failure.
+        self.log.with_name(self.log.name + ".remote.json").write_text(
+            json.dumps({"state": "failed_infra", "error": "sandbox died"})
+        )
+        ex = _RemoteFakeExecutor([(1, False)])
+        with self.assertRaises(RuntimeError) as ctx:
+            self._call(ex)
+        self.assertIn("remote_infra_failure", str(ctx.exception))
+
+    def test_plain_nonzero_exit_raises_benchmark_exit(self):
+        # No infra journal -> ordinary benchmark failure.
+        ex = _RemoteFakeExecutor([(3, False)])
+        with self.assertRaises(RuntimeError) as ctx:
+            self._call(ex)
+        self.assertIn("benchmark_exit_3", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_variance_scoring.py
+++ b/tests/unit/test_variance_scoring.py
@@ -1,0 +1,142 @@
+"""Tests for variance-aware scoring aggregation (#4).
+
+`aggregate_trial_scores` collapses N noisy benchmark-trial scores into one
+comparable score. Pure function, no I/O.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from evo.cli import run_extra_benchmark_trials
+from evo.core import aggregate_trial_scores
+
+
+class TestAggregateTrialScores(unittest.TestCase):
+    def test_median_odd_count(self):
+        agg, stats = aggregate_trial_scores([0.7, 0.9, 0.8], "median", "max")
+        self.assertEqual(agg, 0.8)
+        self.assertEqual(stats["method"], "median")
+        self.assertEqual(stats["n"], 3)
+
+    def test_median_resists_lucky_outlier(self):
+        # The issue's core case: one lucky-high run shouldn't move the score.
+        without = aggregate_trial_scores([0.50, 0.51, 0.49], "median", "max")[0]
+        with_lucky = aggregate_trial_scores([0.50, 0.51, 0.49, 0.99], "median", "max")[0]
+        # Median barely moves; a mean would jump toward the outlier.
+        self.assertLess(abs(with_lucky - without), 0.02)
+
+    def test_mean(self):
+        agg, _ = aggregate_trial_scores([0.6, 0.8], "mean", "max")
+        self.assertAlmostEqual(agg, 0.7)
+
+    def test_worst_is_min_when_metric_max(self):
+        agg, _ = aggregate_trial_scores([0.6, 0.9, 0.8], "worst", "max")
+        self.assertEqual(agg, 0.6)
+
+    def test_worst_is_max_when_metric_min(self):
+        # For metric=min, lower is better, so worst-case is the highest score.
+        agg, _ = aggregate_trial_scores([0.6, 0.9, 0.8], "worst", "min")
+        self.assertEqual(agg, 0.9)
+
+    def test_stats_payload(self):
+        _, stats = aggregate_trial_scores([1.0, 2.0, 3.0], "mean", "max")
+        self.assertEqual(stats["min"], 1.0)
+        self.assertEqual(stats["max"], 3.0)
+        self.assertEqual(stats["median"], 2.0)
+        self.assertAlmostEqual(stats["mean"], 2.0)
+        self.assertGreater(stats["stdev"], 0.0)
+
+    def test_single_trial_zero_stdev(self):
+        agg, stats = aggregate_trial_scores([0.42], "median", "max")
+        self.assertEqual(agg, 0.42)
+        self.assertEqual(stats["n"], 1)
+        self.assertEqual(stats["stdev"], 0.0)
+
+    def test_rejects_empty_scores(self):
+        with self.assertRaises(ValueError):
+            aggregate_trial_scores([], "median", "max")
+
+    def test_rejects_unknown_method(self):
+        with self.assertRaises(ValueError):
+            aggregate_trial_scores([0.5], "p95", "max")
+
+    def test_rejects_unknown_metric(self):
+        with self.assertRaises(ValueError):
+            aggregate_trial_scores([0.5], "worst", "sideways")
+
+
+class _FakeExecutor:
+    """Local-path fake: each stream() writes the next queued score to
+    result_path (mimicking a benchmark that publishes result.json) and returns
+    a stream-result object with the given exit_code/timed_out."""
+
+    def __init__(self, result_path: Path, trials):
+        self.result_path = result_path
+        self.trials = list(trials)  # list of (score_or_None, exit_code, timed_out)
+        self.stream_calls = 0
+        self.result_existed_at_call = []
+
+    def stream(self, cmd, **kwargs):
+        self.result_existed_at_call.append(self.result_path.exists())
+        score, exit_code, timed_out = self.trials[self.stream_calls]
+        self.stream_calls += 1
+        if score is not None:
+            self.result_path.write_text(json.dumps({"score": score}))
+        return types.SimpleNamespace(
+            stdout="", exit_code=exit_code, timed_out=timed_out
+        )
+
+
+class TestRunExtraBenchmarkTrials(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self.result_path = self.d / "result.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _call(self, executor, n_extra):
+        return run_extra_benchmark_trials(
+            executor,
+            n_extra=n_extra,
+            benchmark_cmd="python bench.py",
+            run_cwd=self.d,
+            env={},
+            timeout=None,
+            result_path=self.result_path,
+            benchmark_log=self.d / "bench.log",
+            benchmark_err=self.d / "bench_err.log",
+        )
+
+    def test_runs_n_extra_times_and_returns_scores(self):
+        ex = _FakeExecutor(self.result_path, [(0.7, 0, False), (0.9, 0, False)])
+        scores = self._call(ex, n_extra=2)
+        self.assertEqual(scores, [0.7, 0.9])
+        self.assertEqual(ex.stream_calls, 2)
+
+    def test_clears_stale_result_before_each_trial(self):
+        # Seed a stale result so trial 1 must clear it before streaming.
+        self.result_path.write_text(json.dumps({"score": 0.1}))
+        ex = _FakeExecutor(self.result_path, [(0.7, 0, False), (0.9, 0, False)])
+        self._call(ex, n_extra=2)
+        # result.json must not exist at the moment each trial streams.
+        self.assertEqual(ex.result_existed_at_call, [False, False])
+
+    def test_raises_on_nonzero_exit(self):
+        ex = _FakeExecutor(self.result_path, [(None, 1, False)])
+        with self.assertRaises(RuntimeError):
+            self._call(ex, n_extra=1)
+
+    def test_raises_on_timeout(self):
+        ex = _FakeExecutor(self.result_path, [(None, 0, True)])
+        with self.assertRaises(RuntimeError):
+            self._call(ex, n_extra=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Closes #4. Noisy benchmarks (LLM-judged, sampled, network-dependent) are scored from a **single** run today, so one lucky run can land as the new best score and bias every comparison after it. This adds **opt-in** repeat-and-aggregate scoring; deterministic benchmarks are untouched and pay nothing.

The direction (opt-in config vs. auto-detection) follows the thread: @alokwhitewolf noted auto noise-detection is coming later at *discover* time, so this ships the config primitive that such detection would simply set. The `score-aggregation` name matches @anirudh5harma's suggestion.

## Design

Only the **benchmark evaluation** repeats — the agent attempt runs once (the code under test is fixed; the *measurement* is what's noisy), and the benchmark is the last phase, so repeating just it is cheap.

- **`core.aggregate_trial_scores(scores, method, metric)`** — pure aggregator returning `(aggregate, stats)`. Methods: `median` (default, resists a single lucky/unlucky run), `mean`, `worst` (direction-aware: min for `metric=max`, max for `metric=min`).
- **`cli.run_extra_benchmark_trials(...)`** — re-runs the scored benchmark `bench_repeat - 1` extra times for **fresh runs only** (a crash-recovery/attach yields one score and is not re-executed), clearing `result.json` between trials so each writer's `O_EXCL` claim starts clean. Strict: a non-zero exit or timeout still fails the attempt, so a flaky benchmark never masks a real crash.
- The **aggregate becomes the top-level `score`**, so `compare_scores` / `best_committed_score` / dashboard / frontier strategies are unchanged — they just consume a sturdier number. Per-trial scores + aggregate stats are stored in the benchmark record (only when `bench_repeat > 1`).

## Config surface

```
evo config set bench-repeat 5            # default 1 = today's single-run behavior, zero overhead
evo config set score-aggregation median  # median | mean | worst
evo config show                          # now lists bench_repeat + score_aggregation
```

## Behavior compatibility

`bench_repeat = 1` (the default) takes the existing single-run path byte-for-byte — no record-shape change, no extra work for deterministic benchmarks.

## Testing

- Unit tests for `aggregate_trial_scores` (median/mean/worst, direction-awareness, n==1, stdev, validation) and for the trials loop (fake executor: N runs, result cleared between trials, strict on exit/timeout).
- Config set/get validation tests for both new fields.
- Verified locally end-to-end against a real `LocalExecutor` with a noisy benchmark: trials `[0.5, 0.99, 0.48]` → median **0.5** (lucky 0.99 spike neutralized) vs mean **0.657**. Full unit suite passes except pre-existing Rust hook-binary failures unrelated to this change (reproduce on `main`).

### Note for reviewers

The remote-sandbox multi-trial path mirrors the existing `_fetch_remote_artifacts` pattern but I could only exercise the **local** executor locally; a check on a remote backend would be appreciated.

## Out of scope

Automatic noise detection (planned at discover time) and single-concurrent-benchmark locking (#4 thread, separate concern).