### PR TITLE
feat(cli): workspace asset registry — evo asset put/get/list/use/rm (closes #55)

### DIFF
--- a/plugins/evo/src/evo/assets.py
+++ b/plugins/evo/src/evo/assets.py
@@ -1,0 +1,154 @@
+"""Workspace asset registry (#55, local-first).
+
+Names workspace artifacts so experiments can reuse them by handle/tag instead
+of hardcoding brittle absolute paths, and records produced/consumed lineage.
+
+This module keeps the *pure* registry logic (operating on a plain dict) separate
+from disk I/O so the core is unit-testable without a workspace. Disk wrappers
+live at the bottom and mirror the locking/atomic-write conventions used by
+`evo config set`.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .core import atomic_write_json, workspace_path
+
+REGISTRY_VERSION = 1
+REGISTRY_FILE = "assets.json"
+
+
+def empty_registry() -> dict[str, Any]:
+    return {"version": REGISTRY_VERSION, "assets": {}}
+
+
+# --- pure registry logic (no I/O) ------------------------------------------
+
+def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Insert or replace an asset by name. Returns the stored entry."""
+    name = str(entry.get("name") or "").strip()
+    if not name:
+        raise ValueError("asset name must be non-empty")
+    if not str(entry.get("kind") or "").strip():
+        raise ValueError("asset kind must be non-empty")
+    reg.setdefault("assets", {})[name] = entry
+    return entry
+
+
+def registry_filter(
+    reg: dict[str, Any],
+    *,
+    kind: str | None = None,
+    tags: dict[str, str] | None = None,
+    produced_by: str | None = None,
+    consumed_by: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return assets matching all supplied criteria. `tags` is an AND-match."""
+    out = []
+    for entry in reg.get("assets", {}).values():
+        if kind is not None and entry.get("kind") != kind:
+            continue
+        if produced_by is not None and entry.get("produced_by") != produced_by:
+            continue
+        if consumed_by is not None and consumed_by not in (entry.get("consumed_by") or []):
+            continue
+        if tags:
+            entry_tags = entry.get("tags") or {}
+            if any(entry_tags.get(k) != v for k, v in tags.items()):
+                continue
+        out.append(entry)
+    return out
+
+
+def registry_record_use(reg: dict[str, Any], name: str, exp_id: str) -> dict[str, Any]:
+    """Record that `exp_id` consumes asset `name` (idempotent)."""
+    entry = reg.get("assets", {}).get(name)
+    if entry is None:
+        raise KeyError(name)
+    consumed = entry.setdefault("consumed_by", [])
+    if exp_id not in consumed:
+        consumed.append(exp_id)
+    return entry
+
+
+def registry_remove(reg: dict[str, Any], name: str, force: bool = False) -> dict[str, Any]:
+    """Remove asset `name`. Refuses if still consumed unless `force`."""
+    assets = reg.get("assets", {})
+    entry = assets.get(name)
+    if entry is None:
+        raise KeyError(name)
+    consumers = entry.get("consumed_by") or []
+    if consumers and not force:
+        raise RuntimeError(
+            f"asset {name!r} is consumed by {', '.join(consumers)}; "
+            f"pass --force to remove anyway"
+        )
+    return assets.pop(name)
+
+
+def asset_env_for_exp(reg: dict[str, Any], exp_id: str) -> dict[str, str]:
+    """Env vars to inject for a run: one EVO_ASSET_<NAME> per asset the
+    experiment consumes, mapping to the asset's canonical path."""
+    return {
+        asset_env_var(e["name"]): e["path"]
+        for e in registry_filter(reg, consumed_by=exp_id)
+    }
+
+
+def asset_env_var(name: str) -> str:
+    """Map an asset name to its run env var: 'base-model' -> EVO_ASSET_BASE_MODEL."""
+    slug = re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_").upper()
+    return f"EVO_ASSET_{slug}"
+
+
+def parse_tag(spec: str) -> tuple[str, str]:
+    """Parse a 'k=v' tag spec. The value may itself contain '='."""
+    key, sep, value = spec.partition("=")
+    if not sep or not key.strip():
+        raise ValueError(f"tag must be k=v (got {spec!r})")
+    return key.strip(), value
+
+
+# --- disk layer ------------------------------------------------------------
+
+def assets_path(root: Path) -> Path:
+    """Path to the workspace asset registry file (per active run)."""
+    return workspace_path(root) / REGISTRY_FILE
+
+
+def assets_dir(root: Path) -> Path:
+    """Directory holding materialized (`put --copy` / `use`) asset copies."""
+    return workspace_path(root) / "assets"
+
+
+def load_registry(root: Path) -> dict[str, Any]:
+    path = assets_path(root)
+    if not path.exists():
+        return empty_registry()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.setdefault("version", REGISTRY_VERSION)
+    data.setdefault("assets", {})
+    return data
+
+
+def save_registry(root: Path, reg: dict[str, Any]) -> None:
+    atomic_write_json(assets_path(root), reg)
+
+
+def materialize(root: Path, name: str, source: Path) -> Path:
+    """Copy `source` under the workspace assets dir and return the new path.
+    Used by `put --copy` so the registered asset survives moves of the source."""
+    dest_dir = assets_dir(root) / name
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / source.name
+    if source.is_dir():
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(source, dest)
+    else:
+        shutil.copy2(source, dest)
+    return dest.resolve()

--- a/plugins/evo/src/evo/assets.py
+++ b/plugins/evo/src/evo/assets.py
@@ -28,13 +28,25 @@ def empty_registry() -> dict[str, Any]:
 
 # --- pure registry logic (no I/O) ------------------------------------------
 
-def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
-    """Insert or replace an asset by name. Returns the stored entry."""
-    name = str(entry.get("name") or "").strip()
-    if not name:
+def normalize_asset_name(name: str) -> str:
+    """Canonical form of an asset handle (trimmed). Raises on empty/blank so the
+    stored key, the entry's name field, and every lookup agree on one form."""
+    normalized = str(name or "").strip()
+    if not normalized:
         raise ValueError("asset name must be non-empty")
+    return normalized
+
+
+def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Insert or replace an asset by name. Returns the stored entry.
+
+    Keys the entry under its normalized name and rewrites ``entry['name']`` to
+    match, so the storage key and the name field can never diverge.
+    """
+    name = normalize_asset_name(entry.get("name") or "")
     if not str(entry.get("kind") or "").strip():
         raise ValueError("asset kind must be non-empty")
+    entry["name"] = name
     reg.setdefault("assets", {})[name] = entry
     return entry
 

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -539,25 +539,29 @@ def cmd_asset_put(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    try:
+        name = _assets.normalize_asset_name(args.name)
+    except ValueError as exc:
+        raise RuntimeError(str(exc))
     source = Path(args.path)
     if not source.exists():
         raise RuntimeError(f"asset path does not exist: {source}")
     tags = dict(_assets.parse_tag(t) for t in (args.tag or []))
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
-        if args.name in reg.get("assets", {}):
+        if name in reg.get("assets", {}):
             raise RuntimeError(
-                f"asset {args.name!r} already exists; "
-                f"`evo asset rm {args.name}` first or pick another name"
+                f"asset {name!r} already exists; "
+                f"`evo asset rm {name}` first or pick another name"
             )
         if getattr(args, "copy", False):
-            path = _assets.materialize(root, args.name, source)
+            path = _assets.materialize(root, name, source)
             copied = True
         else:
             path = source.resolve()
             copied = False
         entry = {
-            "name": args.name,
+            "name": name,
             "kind": args.kind,
             "path": str(path),
             "tags": tags,
@@ -568,7 +572,7 @@ def cmd_asset_put(args: argparse.Namespace) -> int:
         }
         _assets.registry_put(reg, entry)
         _assets.save_registry(root, reg)
-    print(f"asset {args.name} registered ({args.kind}) -> {path}")
+    print(f"asset {name} registered ({args.kind}) -> {path}")
     return 0
 
 
@@ -577,7 +581,8 @@ def cmd_asset_get(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
-    entry = _assets.load_registry(root).get("assets", {}).get(args.name)
+    name = args.name.strip()
+    entry = _assets.load_registry(root).get("assets", {}).get(name)
     if entry is None:
         raise RuntimeError(f"unknown asset: {args.name}")
     print(entry["path"])
@@ -619,15 +624,16 @@ def cmd_asset_use(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    name = args.name.strip()
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
         try:
-            entry = _assets.registry_record_use(reg, args.name, args.exp)
+            entry = _assets.registry_record_use(reg, name, args.exp)
         except KeyError:
             raise RuntimeError(f"unknown asset: {args.name}")
         _assets.save_registry(root, reg)
-    env_var = _assets.asset_env_var(args.name)
-    print(f"asset {args.name} used by {args.exp}; runs see {env_var}={entry['path']}")
+    env_var = _assets.asset_env_var(name)
+    print(f"asset {name} used by {args.exp}; runs see {env_var}={entry['path']}")
     return 0
 
 
@@ -636,14 +642,15 @@ def cmd_asset_rm(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    name = args.name.strip()
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
         try:
-            _assets.registry_remove(reg, args.name, force=getattr(args, "force", False))
+            _assets.registry_remove(reg, name, force=getattr(args, "force", False))
         except KeyError:
             raise RuntimeError(f"unknown asset: {args.name}")
         _assets.save_registry(root, reg)
-    print(f"asset {args.name} removed")
+    print(f"asset {name} removed")
     return 0
 
 

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -519,6 +519,134 @@ def cmd_host(args: argparse.Namespace) -> int:
     raise RuntimeError(f"unknown host action: {action}")
 
 
+def cmd_asset(args: argparse.Namespace) -> int:
+    action = args.asset_action
+    if action == "put":
+        return cmd_asset_put(args)
+    if action == "get":
+        return cmd_asset_get(args)
+    if action == "list":
+        return cmd_asset_list(args)
+    if action == "use":
+        return cmd_asset_use(args)
+    if action == "rm":
+        return cmd_asset_rm(args)
+    raise RuntimeError(f"unknown asset action: {action}")
+
+
+def cmd_asset_put(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    source = Path(args.path)
+    if not source.exists():
+        raise RuntimeError(f"asset path does not exist: {source}")
+    tags = dict(_assets.parse_tag(t) for t in (args.tag or []))
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        if args.name in reg.get("assets", {}):
+            raise RuntimeError(
+                f"asset {args.name!r} already exists; "
+                f"`evo asset rm {args.name}` first or pick another name"
+            )
+        if getattr(args, "copy", False):
+            path = _assets.materialize(root, args.name, source)
+            copied = True
+        else:
+            path = source.resolve()
+            copied = False
+        entry = {
+            "name": args.name,
+            "kind": args.kind,
+            "path": str(path),
+            "tags": tags,
+            "produced_by": args.exp,
+            "consumed_by": [],
+            "copied": copied,
+            "created_at": utc_now(),
+        }
+        _assets.registry_put(reg, entry)
+        _assets.save_registry(root, reg)
+    print(f"asset {args.name} registered ({args.kind}) -> {path}")
+    return 0
+
+
+def cmd_asset_get(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    entry = _assets.load_registry(root).get("assets", {}).get(args.name)
+    if entry is None:
+        raise RuntimeError(f"unknown asset: {args.name}")
+    print(entry["path"])
+    return 0
+
+
+def cmd_asset_list(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    tags = dict(_assets.parse_tag(t) for t in (getattr(args, "tag", None) or []))
+    entries = _assets.registry_filter(
+        _assets.load_registry(root),
+        kind=getattr(args, "kind", None),
+        tags=tags or None,
+        produced_by=getattr(args, "produced_by", None),
+        consumed_by=getattr(args, "consumed_by", None),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(entries, indent=2))
+        return 0
+    if not entries:
+        print("<no assets>")
+        return 0
+    for e in sorted(entries, key=lambda x: x["name"]):
+        tagstr = ",".join(f"{k}={v}" for k, v in (e.get("tags") or {}).items())
+        print(
+            f"{e['name']}\t{e['kind']}\t{e['path']}"
+            f"\tproduced_by={e.get('produced_by') or '-'}"
+            f"\tconsumed_by={','.join(e.get('consumed_by') or []) or '-'}"
+            f"\t{tagstr}"
+        )
+    return 0
+
+
+def cmd_asset_use(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        try:
+            entry = _assets.registry_record_use(reg, args.name, args.exp)
+        except KeyError:
+            raise RuntimeError(f"unknown asset: {args.name}")
+        _assets.save_registry(root, reg)
+    env_var = _assets.asset_env_var(args.name)
+    print(f"asset {args.name} used by {args.exp}; runs see {env_var}={entry['path']}")
+    return 0
+
+
+def cmd_asset_rm(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        try:
+            _assets.registry_remove(reg, args.name, force=getattr(args, "force", False))
+        except KeyError:
+            raise RuntimeError(f"unknown asset: {args.name}")
+        _assets.save_registry(root, reg)
+    print(f"asset {args.name} removed")
+    return 0
+
+
 def cmd_config(args: argparse.Namespace) -> int:
     if args.config_action == "show":
         return cmd_config_show(args)
@@ -2624,6 +2752,15 @@ def _runtime_env_for_attempt(
             env["EVO_PARENT_POLICY"] = _seed
     except Exception:
         pass  # best-effort; never block a run on seed-env resolution
+    # Asset registry (#55): expose EVO_ASSET_<NAME> for every asset this
+    # experiment consumes (via `evo asset use`), so the recipe reads them by
+    # stable handle instead of a hardcoded path. Best-effort like the seed block.
+    try:
+        from . import assets as _assets
+
+        env.update(_assets.asset_env_for_exp(_assets.load_registry(root), exp_id))
+    except Exception:
+        pass
     return env
 
 
@@ -6211,6 +6348,44 @@ def build_parser() -> argparse.ArgumentParser:
     telemetry_feedback_p.add_argument("--exp-id", help="optional related experiment id")
     telemetry_feedback_p.add_argument("--tag", action="append", default=[])
     telemetry_feedback_p.set_defaults(func=cmd_telemetry)
+
+    asset_p = sub.add_parser(
+        "asset",
+        help="workspace asset registry: name and reuse artifacts across experiments",
+    )
+    asset_sub = asset_p.add_subparsers(dest="asset_action", required=True)
+    asset_put_p = asset_sub.add_parser("put", help="register an asset by name")
+    asset_put_p.add_argument("path", help="local path to the asset (file or dir)")
+    asset_put_p.add_argument("--name", required=True, help="workspace-unique handle")
+    asset_put_p.add_argument("--kind", required=True,
+                             help="free-form: model, dataset, checkpoint, index, ...")
+    asset_put_p.add_argument("--exp", default=None,
+                             help="producer experiment id (sets produced_by)")
+    asset_put_p.add_argument("--tag", action="append", default=[],
+                             metavar="K=V", help="searchable metadata (repeatable)")
+    asset_put_p.add_argument("--copy", action="store_true",
+                             help="materialize a copy under the workspace assets dir")
+    asset_put_p.set_defaults(func=cmd_asset)
+    asset_get_p = asset_sub.add_parser("get", help="print an asset's canonical local path")
+    asset_get_p.add_argument("name")
+    asset_get_p.set_defaults(func=cmd_asset)
+    asset_list_p = asset_sub.add_parser("list", help="list registered assets")
+    asset_list_p.add_argument("--kind", default=None)
+    asset_list_p.add_argument("--tag", action="append", default=[], metavar="K=V")
+    asset_list_p.add_argument("--produced-by", dest="produced_by", default=None)
+    asset_list_p.add_argument("--consumed-by", dest="consumed_by", default=None)
+    asset_list_p.add_argument("--json", action="store_true")
+    asset_list_p.set_defaults(func=cmd_asset)
+    asset_use_p = asset_sub.add_parser(
+        "use", help="record that an experiment consumes an asset (injects EVO_ASSET_<NAME>)")
+    asset_use_p.add_argument("name")
+    asset_use_p.add_argument("--exp", required=True, help="consumer experiment id")
+    asset_use_p.set_defaults(func=cmd_asset)
+    asset_rm_p = asset_sub.add_parser("rm", help="remove an asset")
+    asset_rm_p.add_argument("name")
+    asset_rm_p.add_argument("--force", action="store_true",
+                            help="remove even if still consumed")
+    asset_rm_p.set_defaults(func=cmd_asset)
 
     config_p = sub.add_parser(
         "config",

--- a/tests/unit/test_asset_cli.py
+++ b/tests/unit/test_asset_cli.py
@@ -1,0 +1,126 @@
+"""`evo asset` CLI round-trip against a temp workspace (#55)."""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from evo.assets import assets_path, load_registry
+from evo.cli import (
+    cmd_asset_get,
+    cmd_asset_list,
+    cmd_asset_put,
+    cmd_asset_rm,
+    cmd_asset_use,
+)
+from evo.core import init_workspace
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+
+
+def _put_args(path, name, kind, exp=None, tag=None, copy=False):
+    return argparse.Namespace(path=str(path), name=name, kind=kind, exp=exp,
+                              tag=tag or [], copy=copy)
+
+
+class TestAssetCli(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _init_git_repo(self.root)
+        init_workspace(self.root, target="t.py", benchmark="python bench.py",
+                       metric="max", gate=None)
+        # A file to register as an asset.
+        self.asset_file = self.root / "adapter.bin"
+        self.asset_file.write_text("weights")
+        self._old_cwd = Path.cwd()
+        os.chdir(self.root)
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        self._tmp.cleanup()
+
+    def _capture(self, fn, args) -> str:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            fn(args)
+        return buf.getvalue().strip()
+
+    def test_put_registers_asset(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint",
+                                exp="exp_0001", tag=["epoch=2"]))
+        reg = load_registry(self.root)
+        entry = reg["assets"]["adapter"]
+        self.assertEqual(entry["kind"], "checkpoint")
+        self.assertEqual(entry["produced_by"], "exp_0001")
+        self.assertEqual(entry["tags"], {"epoch": "2"})
+        self.assertEqual(Path(entry["path"]).read_text(), "weights")
+
+    def test_put_missing_path_errors(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.root / "nope.bin", "x", "model"))
+
+    def test_put_duplicate_name_errors(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "adapter", "model"))
+
+    def test_get_prints_path(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        out = self._capture(cmd_asset_get, argparse.Namespace(name="adapter"))
+        self.assertEqual(out, str(self.asset_file))
+
+    def test_get_unknown_raises(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_get(argparse.Namespace(name="ghost"))
+
+    def test_put_copy_materializes_under_assets_dir(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint", copy=True))
+        entry = load_registry(self.root)["assets"]["adapter"]
+        self.assertTrue(entry["copied"])
+        self.assertIn("assets", Path(entry["path"]).parts)
+        self.assertEqual(Path(entry["path"]).read_text(), "weights")
+
+    def test_list_filters_by_tag(self):
+        cmd_asset_put(_put_args(self.asset_file, "a", "dataset", tag=["held-out=true"]))
+        cmd_asset_put(_put_args(self.asset_file, "b", "dataset"))
+        out = self._capture(cmd_asset_list, argparse.Namespace(
+            kind=None, tag=["held-out=true"], produced_by=None, consumed_by=None, json=True))
+        names = [e["name"] for e in json.loads(out)]
+        self.assertEqual(names, ["a"])
+
+    def test_use_records_consumption(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        cmd_asset_use(argparse.Namespace(name="adapter", exp="exp_0002"))
+        self.assertEqual(
+            load_registry(self.root)["assets"]["adapter"]["consumed_by"], ["exp_0002"])
+
+    def test_rm_refuses_when_consumed(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        cmd_asset_use(argparse.Namespace(name="adapter", exp="exp_0002"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_rm(argparse.Namespace(name="adapter", force=False))
+        cmd_asset_rm(argparse.Namespace(name="adapter", force=True))
+        self.assertNotIn("adapter", load_registry(self.root)["assets"])
+
+    def test_registry_file_location(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        self.assertTrue(assets_path(self.root).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_asset_cli.py
+++ b/tests/unit/test_asset_cli.py
@@ -117,6 +117,28 @@ class TestAssetCli(unittest.TestCase):
         cmd_asset_rm(argparse.Namespace(name="adapter", force=True))
         self.assertNotIn("adapter", load_registry(self.root)["assets"])
 
+    def test_put_normalizes_whitespace_name(self):
+        # A padded handle must register under the trimmed name and be reachable
+        # both by the trimmed name and by the padded string the user typed.
+        cmd_asset_put(_put_args(self.asset_file, "  spaced  ", "checkpoint"))
+        entry = load_registry(self.root)["assets"]["spaced"]
+        self.assertEqual(entry["name"], "spaced")
+        self.assertEqual(
+            self._capture(cmd_asset_get, argparse.Namespace(name="spaced")),
+            str(self.asset_file))
+        self.assertEqual(
+            self._capture(cmd_asset_get, argparse.Namespace(name="  spaced  ")),
+            str(self.asset_file))
+
+    def test_put_whitespace_name_duplicate_detected(self):
+        cmd_asset_put(_put_args(self.asset_file, "spaced", "checkpoint"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "  spaced  ", "model"))
+
+    def test_put_blank_name_rejected(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "   ", "model"))
+
     def test_registry_file_location(self):
         cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
         self.assertTrue(assets_path(self.root).exists())

--- a/tests/unit/test_asset_registry.py
+++ b/tests/unit/test_asset_registry.py
@@ -1,0 +1,125 @@
+"""Tests for the workspace asset registry (#55, local-first).
+
+Split in two: the pure registry logic (no I/O) and the `evo asset` CLI
+round-trip against a temp workspace.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from evo.assets import (
+    asset_env_for_exp,
+    asset_env_var,
+    empty_registry,
+    parse_tag,
+    registry_filter,
+    registry_put,
+    registry_record_use,
+    registry_remove,
+)
+
+
+class TestPureRegistry(unittest.TestCase):
+    def _entry(self, name, **kw):
+        base = {
+            "name": name, "kind": kw.get("kind", "model"),
+            "path": kw.get("path", f"/data/{name}"), "tags": kw.get("tags", {}),
+            "produced_by": kw.get("produced_by"), "consumed_by": kw.get("consumed_by", []),
+            "copied": kw.get("copied", False), "created_at": "2026-08-27T00:00:00Z",
+        }
+        return base
+
+    def test_put_then_present(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model"))
+        self.assertIn("base-model", reg["assets"])
+
+    def test_put_rejects_empty_name(self):
+        with self.assertRaises(ValueError):
+            registry_put(empty_registry(), self._entry(""))
+
+    def test_put_rejects_empty_kind(self):
+        with self.assertRaises(ValueError):
+            registry_put(empty_registry(), self._entry("m", kind=""))
+
+    def test_filter_by_kind(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("m1", kind="model"))
+        registry_put(reg, self._entry("d1", kind="dataset"))
+        names = [e["name"] for e in registry_filter(reg, kind="dataset")]
+        self.assertEqual(names, ["d1"])
+
+    def test_filter_by_tags_is_and_match(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", tags={"verifier": "exact", "epoch": "2"}))
+        registry_put(reg, self._entry("b", tags={"verifier": "exact"}))
+        names = [e["name"] for e in registry_filter(reg, tags={"verifier": "exact", "epoch": "2"})]
+        self.assertEqual(names, ["a"])
+
+    def test_filter_by_produced_and_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", produced_by="exp_0001"))
+        registry_put(reg, self._entry("b", consumed_by=["exp_0002"]))
+        self.assertEqual([e["name"] for e in registry_filter(reg, produced_by="exp_0001")], ["a"])
+        self.assertEqual([e["name"] for e in registry_filter(reg, consumed_by="exp_0002")], ["b"])
+
+    def test_record_use_appends_once(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a"))
+        registry_record_use(reg, "a", "exp_0002")
+        registry_record_use(reg, "a", "exp_0002")  # idempotent
+        self.assertEqual(reg["assets"]["a"]["consumed_by"], ["exp_0002"])
+
+    def test_record_use_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            registry_record_use(empty_registry(), "nope", "exp_0002")
+
+    def test_remove_refuses_when_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", consumed_by=["exp_0002"]))
+        with self.assertRaises(RuntimeError):
+            registry_remove(reg, "a")
+
+    def test_remove_force_when_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", consumed_by=["exp_0002"]))
+        registry_remove(reg, "a", force=True)
+        self.assertNotIn("a", reg["assets"])
+
+    def test_remove_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            registry_remove(empty_registry(), "nope")
+
+    def test_asset_env_var(self):
+        self.assertEqual(asset_env_var("base-model"), "EVO_ASSET_BASE_MODEL")
+        self.assertEqual(asset_env_var("numina.cot 5k"), "EVO_ASSET_NUMINA_COT_5K")
+
+    def test_parse_tag(self):
+        self.assertEqual(parse_tag("epoch=2"), ("epoch", "2"))
+        self.assertEqual(parse_tag("uri=s3://a/b=c"), ("uri", "s3://a/b=c"))
+
+    def test_parse_tag_rejects_missing_eq(self):
+        with self.assertRaises(ValueError):
+            parse_tag("noequals")
+
+    def test_asset_env_for_exp_injects_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model", path="/m", consumed_by=["exp_0002"]))
+        registry_put(reg, self._entry("other", path="/o", consumed_by=["exp_0009"]))
+        env = asset_env_for_exp(reg, "exp_0002")
+        self.assertEqual(env, {"EVO_ASSET_BASE_MODEL": "/m"})
+
+    def test_asset_env_for_exp_empty_when_none_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model", consumed_by=["exp_0009"]))
+        self.assertEqual(asset_env_for_exp(reg, "exp_0002"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Closes #55. evo records per-experiment **producer** artifacts, but there's no way to **name** an asset and reuse it across experiments, **query by tag** rather than experiment id, or record **consumed** assets. Downstream experiments hardcode brittle absolute paths that break when a source run is gc'd or moved. This adds a local workspace asset registry.

**Scope:** local-storage-only. Pluggable storage backends (S3 / HF Hub) are intentionally deferred to a follow-up; the schema leaves room for a `backend` field. Kept the surface reviewable rather than shipping the entire proposal at once.

## Surface

```
evo asset put <path> --name N --kind K [--exp E] [--tag k=v]... [--copy]
evo asset get <name>                       # prints canonical local path
evo asset list [--kind] [--tag k=v] [--produced-by] [--consumed-by] [--json]
evo asset use <name> --exp E               # records consumption
evo asset rm <name> [--force]              # refuses while consumed unless --force
```

- `put` registers in place by default; `--copy` materializes under `workspace_path/assets/<name>/`; `--exp` sets `produced_by`. Names are workspace-unique (`rm` first to replace).
- `use` records consumption; from then on the asset path is injected into that experiment's runs as `EVO_ASSET_<NAME>` (e.g. `base-model` → `EVO_ASSET_BASE_MODEL`), so recipes read it by stable handle instead of a hardcoded path.

## Design

- **New module `evo/assets.py`** splits pure registry logic (dict in/out, unit-testable with no workspace) from thin disk wrappers (`load`/`save` under `advisory_lock` + `atomic_write_json`, matching `evo config set`).
- Registry at `workspace_path/assets.json`, **per-run scope** — resets with `evo reset`.
- **Run integration:** `_runtime_env_for_attempt` injects `EVO_ASSET_<NAME>` for every consumed asset, best-effort alongside the existing `EVO_SEED_ARTIFACT` block. Complements `evo new --from-artifact` (per-exp seeding); they coexist.

Registry entry shape:
```json
{ "name": "base-model", "kind": "model", "path": "/abs/path", "tags": {"epoch":"2"},
  "produced_by": "exp_0001", "consumed_by": ["exp_0002"], "copied": false, "created_at": "<utc>" }
```

## Testing

- 16 pure-logic unit tests (put/replace, filter by kind/tags/produced_by/consumed_by, record_use idempotency, remove refuse/force/unknown, env-var mapping, tag parsing) + 10 CLI round-trip tests against a temp workspace.
- Verified end-to-end via the **real CLI** (put in-place + `--copy`, get, list with filters + `--json`, use, rm refuse/force, dup/unknown errors) and a **real `_runtime_env_for_attempt`** call confirming `EVO_ASSET_<NAME>` is injected for a consumer and absent for a non-consumer.
- Full unit suite green (minus pre-existing Rust hook-binary failures unrelated to this change; they reproduce on `main`).

## Out of scope (follow-ups)

Pluggable storage backends (S3/HF), cross-run/global assets (registry is per-run), gc of orphaned materialized copies.

### Note

Issue #55 previously had a full attempt in #80, which its author self-closed (no maintainer objection). This is a fresh, test-driven, deliberately smaller local-first take.