### PR TITLE
feat(cli): pluggable S3/HF storage backends for asset registry (#55 follow-up)

### DIFF
--- a/plugins/evo/src/evo/asset_backends.py
+++ b/plugins/evo/src/evo/asset_backends.py
@@ -1,0 +1,172 @@
+"""Pluggable storage backends for the asset registry (#55 follow-up).
+
+An asset URI's scheme selects a backend that can upload a local file to remote
+storage, download it back to a local path, and check existence. Remote backends
+(S3, HF Hub) wrap their SDKs behind lazy, optional imports and accept an
+**injected client**, so their logic is unit-testable with a fake client -- no
+network, no credentials. Real S3/HF round-trips are a manual/CI concern.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Callable
+
+
+# --- pure URI parsing ------------------------------------------------------
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """`s3://bucket/key/path` -> ('bucket', 'key/path')."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"not an s3:// uri: {uri!r}")
+    rest = uri[len("s3://"):]
+    bucket, sep, key = rest.partition("/")
+    if not bucket or not sep or not key:
+        raise ValueError(f"s3 uri must be s3://bucket/key (got {uri!r})")
+    return bucket, key
+
+
+def parse_hf_uri(uri: str) -> tuple[str, str]:
+    """`hf://org/model/path/to/file` -> ('org/model', 'path/to/file').
+
+    The repo id is the first two segments (owner/name); the remainder is the
+    file path within the repo.
+    """
+    if not uri.startswith("hf://"):
+        raise ValueError(f"not an hf:// uri: {uri!r}")
+    parts = [p for p in uri[len("hf://"):].split("/") if p != ""]
+    if len(parts) < 3:
+        raise ValueError(f"hf uri must be hf://owner/name/path (got {uri!r})")
+    return f"{parts[0]}/{parts[1]}", "/".join(parts[2:])
+
+
+def _strip_file_scheme(uri: str) -> str:
+    return uri[len("file://"):] if uri.startswith("file://") else uri
+
+
+# --- backends --------------------------------------------------------------
+
+class LocalBackend:
+    scheme = "local"
+
+    def upload(self, local: Path, uri: str) -> None:
+        target = Path(_strip_file_scheme(uri))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(local, target)
+
+    def download(self, uri: str, dest_dir: Path) -> Path:
+        source = Path(_strip_file_scheme(uri))
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / source.name
+        shutil.copy2(source, dest)
+        return dest
+
+    def exists(self, uri: str) -> bool:
+        return Path(_strip_file_scheme(uri)).exists()
+
+
+class S3Backend:
+    scheme = "s3"
+
+    def __init__(self, client: Any | None = None,
+                 _import_client: Callable[[], Any] | None = None):
+        self.client = client
+        self._import_client = _import_client or (
+            lambda: __import__("boto3").client("s3")
+        )
+
+    def _resolved_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        try:
+            self.client = self._import_client()
+        except ImportError as exc:
+            raise RuntimeError(
+                "boto3 is required for s3:// assets; pip install boto3"
+            ) from exc
+        return self.client
+
+    def upload(self, local: Path, uri: str) -> None:
+        bucket, key = parse_s3_uri(uri)
+        self._resolved_client().upload_file(
+            Filename=str(local), Bucket=bucket, Key=key)
+
+    def download(self, uri: str, dest_dir: Path) -> Path:
+        bucket, key = parse_s3_uri(uri)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / Path(key).name
+        self._resolved_client().download_file(
+            Bucket=bucket, Key=key, Filename=str(dest))
+        return dest
+
+    def exists(self, uri: str) -> bool:
+        bucket, key = parse_s3_uri(uri)
+        client = self._resolved_client()
+        try:
+            client.head_object(Bucket=bucket, Key=key)
+            return True
+        except Exception:
+            return False
+
+
+class HFBackend:
+    scheme = "hf"
+
+    def __init__(self, client: Any | None = None,
+                 _import_client: Callable[[], Any] | None = None):
+        self.client = client
+        self._import_client = _import_client or _default_hf_client
+
+    def _resolved_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        try:
+            self.client = self._import_client()
+        except ImportError as exc:
+            raise RuntimeError(
+                "huggingface_hub is required for hf:// assets; "
+                "pip install huggingface_hub"
+            ) from exc
+        return self.client
+
+    def upload(self, local: Path, uri: str) -> None:
+        repo_id, path = parse_hf_uri(uri)
+        self._resolved_client().upload_file(
+            path_or_fileobj=str(local), path_in_repo=path, repo_id=repo_id)
+
+    def download(self, uri: str, dest_dir: Path) -> Path:
+        repo_id, path = parse_hf_uri(uri)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        out = self._resolved_client().hf_hub_download(
+            repo_id=repo_id, filename=path, local_dir=str(dest_dir))
+        return Path(out)
+
+    def exists(self, uri: str) -> bool:
+        repo_id, path = parse_hf_uri(uri)
+        return bool(self._resolved_client().file_exists(
+            repo_id=repo_id, filename=path))
+
+
+def _default_hf_client() -> Any:
+    """Adapter exposing hf_hub_download / upload_file / file_exists backed by
+    the real huggingface_hub library (only used outside tests)."""
+    import huggingface_hub as hf  # noqa: F401 -- raises ImportError if absent
+    from huggingface_hub import HfApi
+    from types import SimpleNamespace
+
+    api = HfApi()
+    return SimpleNamespace(
+        hf_hub_download=hf.hf_hub_download,
+        upload_file=api.upload_file,
+        file_exists=api.file_exists,
+    )
+
+
+def backend_for_uri(uri: str, *, client: Any | None = None):
+    """Select a backend by URI scheme. `client` is injected for remote backends
+    (tests pass a fake; production leaves it None to lazily construct the SDK)."""
+    if uri.startswith("s3://"):
+        return S3Backend(client=client)
+    if uri.startswith("hf://"):
+        return HFBackend(client=client)
+    return LocalBackend()

--- a/plugins/evo/src/evo/assets.py
+++ b/plugins/evo/src/evo/assets.py
@@ -1,0 +1,154 @@
+"""Workspace asset registry (#55, local-first).
+
+Names workspace artifacts so experiments can reuse them by handle/tag instead
+of hardcoding brittle absolute paths, and records produced/consumed lineage.
+
+This module keeps the *pure* registry logic (operating on a plain dict) separate
+from disk I/O so the core is unit-testable without a workspace. Disk wrappers
+live at the bottom and mirror the locking/atomic-write conventions used by
+`evo config set`.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .core import atomic_write_json, workspace_path
+
+REGISTRY_VERSION = 1
+REGISTRY_FILE = "assets.json"
+
+
+def empty_registry() -> dict[str, Any]:
+    return {"version": REGISTRY_VERSION, "assets": {}}
+
+
+# --- pure registry logic (no I/O) ------------------------------------------
+
+def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Insert or replace an asset by name. Returns the stored entry."""
+    name = str(entry.get("name") or "").strip()
+    if not name:
+        raise ValueError("asset name must be non-empty")
+    if not str(entry.get("kind") or "").strip():
+        raise ValueError("asset kind must be non-empty")
+    reg.setdefault("assets", {})[name] = entry
+    return entry
+
+
+def registry_filter(
+    reg: dict[str, Any],
+    *,
+    kind: str | None = None,
+    tags: dict[str, str] | None = None,
+    produced_by: str | None = None,
+    consumed_by: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return assets matching all supplied criteria. `tags` is an AND-match."""
+    out = []
+    for entry in reg.get("assets", {}).values():
+        if kind is not None and entry.get("kind") != kind:
+            continue
+        if produced_by is not None and entry.get("produced_by") != produced_by:
+            continue
+        if consumed_by is not None and consumed_by not in (entry.get("consumed_by") or []):
+            continue
+        if tags:
+            entry_tags = entry.get("tags") or {}
+            if any(entry_tags.get(k) != v for k, v in tags.items()):
+                continue
+        out.append(entry)
+    return out
+
+
+def registry_record_use(reg: dict[str, Any], name: str, exp_id: str) -> dict[str, Any]:
+    """Record that `exp_id` consumes asset `name` (idempotent)."""
+    entry = reg.get("assets", {}).get(name)
+    if entry is None:
+        raise KeyError(name)
+    consumed = entry.setdefault("consumed_by", [])
+    if exp_id not in consumed:
+        consumed.append(exp_id)
+    return entry
+
+
+def registry_remove(reg: dict[str, Any], name: str, force: bool = False) -> dict[str, Any]:
+    """Remove asset `name`. Refuses if still consumed unless `force`."""
+    assets = reg.get("assets", {})
+    entry = assets.get(name)
+    if entry is None:
+        raise KeyError(name)
+    consumers = entry.get("consumed_by") or []
+    if consumers and not force:
+        raise RuntimeError(
+            f"asset {name!r} is consumed by {', '.join(consumers)}; "
+            f"pass --force to remove anyway"
+        )
+    return assets.pop(name)
+
+
+def asset_env_for_exp(reg: dict[str, Any], exp_id: str) -> dict[str, str]:
+    """Env vars to inject for a run: one EVO_ASSET_<NAME> per asset the
+    experiment consumes, mapping to the asset's canonical path."""
+    return {
+        asset_env_var(e["name"]): e["path"]
+        for e in registry_filter(reg, consumed_by=exp_id)
+    }
+
+
+def asset_env_var(name: str) -> str:
+    """Map an asset name to its run env var: 'base-model' -> EVO_ASSET_BASE_MODEL."""
+    slug = re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_").upper()
+    return f"EVO_ASSET_{slug}"
+
+
+def parse_tag(spec: str) -> tuple[str, str]:
+    """Parse a 'k=v' tag spec. The value may itself contain '='."""
+    key, sep, value = spec.partition("=")
+    if not sep or not key.strip():
+        raise ValueError(f"tag must be k=v (got {spec!r})")
+    return key.strip(), value
+
+
+# --- disk layer ------------------------------------------------------------
+
+def assets_path(root: Path) -> Path:
+    """Path to the workspace asset registry file (per active run)."""
+    return workspace_path(root) / REGISTRY_FILE
+
+
+def assets_dir(root: Path) -> Path:
+    """Directory holding materialized (`put --copy` / `use`) asset copies."""
+    return workspace_path(root) / "assets"
+
+
+def load_registry(root: Path) -> dict[str, Any]:
+    path = assets_path(root)
+    if not path.exists():
+        return empty_registry()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.setdefault("version", REGISTRY_VERSION)
+    data.setdefault("assets", {})
+    return data
+
+
+def save_registry(root: Path, reg: dict[str, Any]) -> None:
+    atomic_write_json(assets_path(root), reg)
+
+
+def materialize(root: Path, name: str, source: Path) -> Path:
+    """Copy `source` under the workspace assets dir and return the new path.
+    Used by `put --copy` so the registered asset survives moves of the source."""
+    dest_dir = assets_dir(root) / name
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / source.name
+    if source.is_dir():
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(source, dest)
+    else:
+        shutil.copy2(source, dest)
+    return dest.resolve()

--- a/plugins/evo/src/evo/assets.py
+++ b/plugins/evo/src/evo/assets.py
@@ -28,13 +28,25 @@ def empty_registry() -> dict[str, Any]:
 
 # --- pure registry logic (no I/O) ------------------------------------------
 
-def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
-    """Insert or replace an asset by name. Returns the stored entry."""
-    name = str(entry.get("name") or "").strip()
-    if not name:
+def normalize_asset_name(name: str) -> str:
+    """Canonical form of an asset handle (trimmed). Raises on empty/blank so the
+    stored key, the entry's name field, and every lookup agree on one form."""
+    normalized = str(name or "").strip()
+    if not normalized:
         raise ValueError("asset name must be non-empty")
+    return normalized
+
+
+def registry_put(reg: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Insert or replace an asset by name. Returns the stored entry.
+
+    Keys the entry under its normalized name and rewrites ``entry['name']`` to
+    match, so the storage key and the name field can never diverge.
+    """
+    name = normalize_asset_name(entry.get("name") or "")
     if not str(entry.get("kind") or "").strip():
         raise ValueError("asset kind must be non-empty")
+    entry["name"] = name
     reg.setdefault("assets", {})[name] = entry
     return entry
 

--- a/plugins/evo/src/evo/assets.py
+++ b/plugins/evo/src/evo/assets.py
@@ -104,11 +104,15 @@ def registry_remove(reg: dict[str, Any], name: str, force: bool = False) -> dict
 
 def asset_env_for_exp(reg: dict[str, Any], exp_id: str) -> dict[str, str]:
     """Env vars to inject for a run: one EVO_ASSET_<NAME> per asset the
-    experiment consumes, mapping to the asset's canonical path."""
-    return {
-        asset_env_var(e["name"]): e["path"]
-        for e in registry_filter(reg, consumed_by=exp_id)
-    }
+    experiment consumes. Local assets map to their path; remote assets have no
+    local copy yet, so they expose the uri (the recipe resolves it via
+    `evo asset get`)."""
+    out: dict[str, str] = {}
+    for e in registry_filter(reg, consumed_by=exp_id):
+        value = e.get("path") or e.get("uri")
+        if value:
+            out[asset_env_var(e["name"])] = value
+    return out
 
 
 def asset_env_var(name: str) -> str:
@@ -135,6 +139,11 @@ def assets_path(root: Path) -> Path:
 def assets_dir(root: Path) -> Path:
     """Directory holding materialized (`put --copy` / `use`) asset copies."""
     return workspace_path(root) / "assets"
+
+
+def assets_cache_dir(root: Path, name: str) -> Path:
+    """Local cache dir where a remote asset is downloaded on `get`/`use`."""
+    return assets_dir(root) / "_cache" / name
 
 
 def load_registry(root: Path) -> dict[str, Any]:

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -539,25 +539,29 @@ def cmd_asset_put(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    try:
+        name = _assets.normalize_asset_name(args.name)
+    except ValueError as exc:
+        raise RuntimeError(str(exc))
     source = Path(args.path)
     if not source.exists():
         raise RuntimeError(f"asset path does not exist: {source}")
     tags = dict(_assets.parse_tag(t) for t in (args.tag or []))
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
-        if args.name in reg.get("assets", {}):
+        if name in reg.get("assets", {}):
             raise RuntimeError(
-                f"asset {args.name!r} already exists; "
-                f"`evo asset rm {args.name}` first or pick another name"
+                f"asset {name!r} already exists; "
+                f"`evo asset rm {name}` first or pick another name"
             )
         if getattr(args, "copy", False):
-            path = _assets.materialize(root, args.name, source)
+            path = _assets.materialize(root, name, source)
             copied = True
         else:
             path = source.resolve()
             copied = False
         entry = {
-            "name": args.name,
+            "name": name,
             "kind": args.kind,
             "path": str(path),
             "tags": tags,
@@ -568,7 +572,7 @@ def cmd_asset_put(args: argparse.Namespace) -> int:
         }
         _assets.registry_put(reg, entry)
         _assets.save_registry(root, reg)
-    print(f"asset {args.name} registered ({args.kind}) -> {path}")
+    print(f"asset {name} registered ({args.kind}) -> {path}")
     return 0
 
 
@@ -577,7 +581,8 @@ def cmd_asset_get(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
-    entry = _assets.load_registry(root).get("assets", {}).get(args.name)
+    name = args.name.strip()
+    entry = _assets.load_registry(root).get("assets", {}).get(name)
     if entry is None:
         raise RuntimeError(f"unknown asset: {args.name}")
     print(entry["path"])
@@ -619,15 +624,16 @@ def cmd_asset_use(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    name = args.name.strip()
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
         try:
-            entry = _assets.registry_record_use(reg, args.name, args.exp)
+            entry = _assets.registry_record_use(reg, name, args.exp)
         except KeyError:
             raise RuntimeError(f"unknown asset: {args.name}")
         _assets.save_registry(root, reg)
-    env_var = _assets.asset_env_var(args.name)
-    print(f"asset {args.name} used by {args.exp}; runs see {env_var}={entry['path']}")
+    env_var = _assets.asset_env_var(name)
+    print(f"asset {name} used by {args.exp}; runs see {env_var}={entry['path']}")
     return 0
 
 
@@ -636,14 +642,15 @@ def cmd_asset_rm(args: argparse.Namespace) -> int:
 
     root = repo_root()
     _require_workspace(root)
+    name = args.name.strip()
     with advisory_lock(lock_file_for(_assets.assets_path(root))):
         reg = _assets.load_registry(root)
         try:
-            _assets.registry_remove(reg, args.name, force=getattr(args, "force", False))
+            _assets.registry_remove(reg, name, force=getattr(args, "force", False))
         except KeyError:
             raise RuntimeError(f"unknown asset: {args.name}")
         _assets.save_registry(root, reg)
-    print(f"asset {args.name} removed")
+    print(f"asset {name} removed")
     return 0
 
 

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -519,6 +519,134 @@ def cmd_host(args: argparse.Namespace) -> int:
     raise RuntimeError(f"unknown host action: {action}")
 
 
+def cmd_asset(args: argparse.Namespace) -> int:
+    action = args.asset_action
+    if action == "put":
+        return cmd_asset_put(args)
+    if action == "get":
+        return cmd_asset_get(args)
+    if action == "list":
+        return cmd_asset_list(args)
+    if action == "use":
+        return cmd_asset_use(args)
+    if action == "rm":
+        return cmd_asset_rm(args)
+    raise RuntimeError(f"unknown asset action: {action}")
+
+
+def cmd_asset_put(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    source = Path(args.path)
+    if not source.exists():
+        raise RuntimeError(f"asset path does not exist: {source}")
+    tags = dict(_assets.parse_tag(t) for t in (args.tag or []))
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        if args.name in reg.get("assets", {}):
+            raise RuntimeError(
+                f"asset {args.name!r} already exists; "
+                f"`evo asset rm {args.name}` first or pick another name"
+            )
+        if getattr(args, "copy", False):
+            path = _assets.materialize(root, args.name, source)
+            copied = True
+        else:
+            path = source.resolve()
+            copied = False
+        entry = {
+            "name": args.name,
+            "kind": args.kind,
+            "path": str(path),
+            "tags": tags,
+            "produced_by": args.exp,
+            "consumed_by": [],
+            "copied": copied,
+            "created_at": utc_now(),
+        }
+        _assets.registry_put(reg, entry)
+        _assets.save_registry(root, reg)
+    print(f"asset {args.name} registered ({args.kind}) -> {path}")
+    return 0
+
+
+def cmd_asset_get(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    entry = _assets.load_registry(root).get("assets", {}).get(args.name)
+    if entry is None:
+        raise RuntimeError(f"unknown asset: {args.name}")
+    print(entry["path"])
+    return 0
+
+
+def cmd_asset_list(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    tags = dict(_assets.parse_tag(t) for t in (getattr(args, "tag", None) or []))
+    entries = _assets.registry_filter(
+        _assets.load_registry(root),
+        kind=getattr(args, "kind", None),
+        tags=tags or None,
+        produced_by=getattr(args, "produced_by", None),
+        consumed_by=getattr(args, "consumed_by", None),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(entries, indent=2))
+        return 0
+    if not entries:
+        print("<no assets>")
+        return 0
+    for e in sorted(entries, key=lambda x: x["name"]):
+        tagstr = ",".join(f"{k}={v}" for k, v in (e.get("tags") or {}).items())
+        print(
+            f"{e['name']}\t{e['kind']}\t{e['path']}"
+            f"\tproduced_by={e.get('produced_by') or '-'}"
+            f"\tconsumed_by={','.join(e.get('consumed_by') or []) or '-'}"
+            f"\t{tagstr}"
+        )
+    return 0
+
+
+def cmd_asset_use(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        try:
+            entry = _assets.registry_record_use(reg, args.name, args.exp)
+        except KeyError:
+            raise RuntimeError(f"unknown asset: {args.name}")
+        _assets.save_registry(root, reg)
+    env_var = _assets.asset_env_var(args.name)
+    print(f"asset {args.name} used by {args.exp}; runs see {env_var}={entry['path']}")
+    return 0
+
+
+def cmd_asset_rm(args: argparse.Namespace) -> int:
+    from . import assets as _assets
+
+    root = repo_root()
+    _require_workspace(root)
+    with advisory_lock(lock_file_for(_assets.assets_path(root))):
+        reg = _assets.load_registry(root)
+        try:
+            _assets.registry_remove(reg, args.name, force=getattr(args, "force", False))
+        except KeyError:
+            raise RuntimeError(f"unknown asset: {args.name}")
+        _assets.save_registry(root, reg)
+    print(f"asset {args.name} removed")
+    return 0
+
+
 def cmd_config(args: argparse.Namespace) -> int:
     if args.config_action == "show":
         return cmd_config_show(args)
@@ -2624,6 +2752,15 @@ def _runtime_env_for_attempt(
             env["EVO_PARENT_POLICY"] = _seed
     except Exception:
         pass  # best-effort; never block a run on seed-env resolution
+    # Asset registry (#55): expose EVO_ASSET_<NAME> for every asset this
+    # experiment consumes (via `evo asset use`), so the recipe reads them by
+    # stable handle instead of a hardcoded path. Best-effort like the seed block.
+    try:
+        from . import assets as _assets
+
+        env.update(_assets.asset_env_for_exp(_assets.load_registry(root), exp_id))
+    except Exception:
+        pass
     return env
 
 
@@ -6211,6 +6348,44 @@ def build_parser() -> argparse.ArgumentParser:
     telemetry_feedback_p.add_argument("--exp-id", help="optional related experiment id")
     telemetry_feedback_p.add_argument("--tag", action="append", default=[])
     telemetry_feedback_p.set_defaults(func=cmd_telemetry)
+
+    asset_p = sub.add_parser(
+        "asset",
+        help="workspace asset registry: name and reuse artifacts across experiments",
+    )
+    asset_sub = asset_p.add_subparsers(dest="asset_action", required=True)
+    asset_put_p = asset_sub.add_parser("put", help="register an asset by name")
+    asset_put_p.add_argument("path", help="local path to the asset (file or dir)")
+    asset_put_p.add_argument("--name", required=True, help="workspace-unique handle")
+    asset_put_p.add_argument("--kind", required=True,
+                             help="free-form: model, dataset, checkpoint, index, ...")
+    asset_put_p.add_argument("--exp", default=None,
+                             help="producer experiment id (sets produced_by)")
+    asset_put_p.add_argument("--tag", action="append", default=[],
+                             metavar="K=V", help="searchable metadata (repeatable)")
+    asset_put_p.add_argument("--copy", action="store_true",
+                             help="materialize a copy under the workspace assets dir")
+    asset_put_p.set_defaults(func=cmd_asset)
+    asset_get_p = asset_sub.add_parser("get", help="print an asset's canonical local path")
+    asset_get_p.add_argument("name")
+    asset_get_p.set_defaults(func=cmd_asset)
+    asset_list_p = asset_sub.add_parser("list", help="list registered assets")
+    asset_list_p.add_argument("--kind", default=None)
+    asset_list_p.add_argument("--tag", action="append", default=[], metavar="K=V")
+    asset_list_p.add_argument("--produced-by", dest="produced_by", default=None)
+    asset_list_p.add_argument("--consumed-by", dest="consumed_by", default=None)
+    asset_list_p.add_argument("--json", action="store_true")
+    asset_list_p.set_defaults(func=cmd_asset)
+    asset_use_p = asset_sub.add_parser(
+        "use", help="record that an experiment consumes an asset (injects EVO_ASSET_<NAME>)")
+    asset_use_p.add_argument("name")
+    asset_use_p.add_argument("--exp", required=True, help="consumer experiment id")
+    asset_use_p.set_defaults(func=cmd_asset)
+    asset_rm_p = asset_sub.add_parser("rm", help="remove an asset")
+    asset_rm_p.add_argument("name")
+    asset_rm_p.add_argument("--force", action="store_true",
+                            help="remove even if still consumed")
+    asset_rm_p.set_defaults(func=cmd_asset)
 
     config_p = sub.add_parser(
         "config",

--- a/plugins/evo/src/evo/cli.py
+++ b/plugins/evo/src/evo/cli.py
@@ -554,25 +554,50 @@ def cmd_asset_put(args: argparse.Namespace) -> int:
                 f"asset {name!r} already exists; "
                 f"`evo asset rm {name}` first or pick another name"
             )
-        if getattr(args, "copy", False):
-            path = _assets.materialize(root, name, source)
-            copied = True
+        backend_uri = getattr(args, "backend", None)
+        if backend_uri:
+            # Remote-backed asset: upload the local file to S3/HF and record the
+            # canonical uri; `get`/`use` download it back to a local cache.
+            from . import asset_backends
+            be = asset_backends.backend_for_uri(backend_uri)
+            be.upload(source, backend_uri)
+            scheme = backend_uri.split("://", 1)[0] if "://" in backend_uri else "local"
+            entry = {
+                "name": name,
+                "kind": args.kind,
+                "path": None,
+                "uri": backend_uri,
+                "backend": scheme,
+                "tags": tags,
+                "produced_by": args.exp,
+                "consumed_by": [],
+                "copied": False,
+                "created_at": utc_now(),
+            }
+            location = backend_uri
         else:
-            path = source.resolve()
-            copied = False
-        entry = {
-            "name": name,
-            "kind": args.kind,
-            "path": str(path),
-            "tags": tags,
-            "produced_by": args.exp,
-            "consumed_by": [],
-            "copied": copied,
-            "created_at": utc_now(),
-        }
+            if getattr(args, "copy", False):
+                path = _assets.materialize(root, name, source)
+                copied = True
+            else:
+                path = source.resolve()
+                copied = False
+            entry = {
+                "name": name,
+                "kind": args.kind,
+                "path": str(path),
+                "uri": None,
+                "backend": "local",
+                "tags": tags,
+                "produced_by": args.exp,
+                "consumed_by": [],
+                "copied": copied,
+                "created_at": utc_now(),
+            }
+            location = path
         _assets.registry_put(reg, entry)
         _assets.save_registry(root, reg)
-    print(f"asset {name} registered ({args.kind}) -> {path}")
+    print(f"asset {name} registered ({args.kind}) -> {location}")
     return 0
 
 
@@ -585,8 +610,25 @@ def cmd_asset_get(args: argparse.Namespace) -> int:
     entry = _assets.load_registry(root).get("assets", {}).get(name)
     if entry is None:
         raise RuntimeError(f"unknown asset: {args.name}")
-    print(entry["path"])
+    print(_resolve_asset_local_path(root, name, entry))
     return 0
+
+
+def _resolve_asset_local_path(root: Path, name: str, entry: dict) -> str:
+    """Return a local path for an asset. Local assets return their stored path;
+    remote assets download to a per-asset cache (reusing an existing copy)."""
+    from . import assets as _assets
+
+    if (entry.get("backend") or "local") == "local":
+        return entry["path"]
+    from . import asset_backends
+
+    uri = entry["uri"]
+    cache = _assets.assets_cache_dir(root, name)
+    cached = cache / uri.rstrip("/").split("/")[-1]
+    if not cached.exists():
+        cached = asset_backends.backend_for_uri(uri).download(uri, cache)
+    return str(cached)
 
 
 def cmd_asset_list(args: argparse.Namespace) -> int:
@@ -6372,6 +6414,10 @@ def build_parser() -> argparse.ArgumentParser:
                              metavar="K=V", help="searchable metadata (repeatable)")
     asset_put_p.add_argument("--copy", action="store_true",
                              help="materialize a copy under the workspace assets dir")
+    asset_put_p.add_argument("--backend", default=None, metavar="URI",
+                             help="upload to a storage backend and record its uri "
+                                  "(s3://bucket/key or hf://owner/name/path); "
+                                  "get/use download it back to a local cache")
     asset_put_p.set_defaults(func=cmd_asset)
     asset_get_p = asset_sub.add_parser("get", help="print an asset's canonical local path")
     asset_get_p.add_argument("name")

--- a/tests/unit/test_asset_backends.py
+++ b/tests/unit/test_asset_backends.py
@@ -1,0 +1,190 @@
+"""Tests for pluggable asset storage backends (#55 follow-up).
+
+Pure URI parsing + scheme dispatch + LocalBackend run for real. The S3/HF
+backends are exercised with injected fake clients so no network/credentials are
+touched.
+"""
+from __future__ import annotations
+
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from evo.asset_backends import (
+    HFBackend,
+    LocalBackend,
+    S3Backend,
+    backend_for_uri,
+    parse_hf_uri,
+    parse_s3_uri,
+)
+
+
+class TestUriParsing(unittest.TestCase):
+    def test_parse_s3_uri(self):
+        self.assertEqual(parse_s3_uri("s3://my-bucket/a/b/c.bin"), ("my-bucket", "a/b/c.bin"))
+
+    def test_parse_s3_uri_rejects_missing_key(self):
+        with self.assertRaises(ValueError):
+            parse_s3_uri("s3://only-bucket")
+
+    def test_parse_s3_uri_rejects_wrong_scheme(self):
+        with self.assertRaises(ValueError):
+            parse_s3_uri("gs://b/k")
+
+    def test_parse_hf_uri(self):
+        self.assertEqual(parse_hf_uri("hf://org/model/adapter.safetensors"),
+                         ("org/model", "adapter.safetensors"))
+
+    def test_parse_hf_uri_rejects_missing_path(self):
+        with self.assertRaises(ValueError):
+            parse_hf_uri("hf://org-model-only")
+
+
+class TestDispatch(unittest.TestCase):
+    def test_local_for_plain_path(self):
+        self.assertIsInstance(backend_for_uri("/data/x.bin"), LocalBackend)
+
+    def test_local_for_file_scheme(self):
+        self.assertIsInstance(backend_for_uri("file:///data/x.bin"), LocalBackend)
+
+    def test_s3_for_s3_scheme(self):
+        self.assertIsInstance(backend_for_uri("s3://b/k", client=object()), S3Backend)
+
+    def test_hf_for_hf_scheme(self):
+        self.assertIsInstance(backend_for_uri("hf://org/m/f", client=object()), HFBackend)
+
+
+class TestLocalBackend(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self.src = self.d / "src.bin"
+        self.src.write_text("payload")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_download_copies_into_dest(self):
+        dest = self.d / "cache"
+        dest.mkdir()
+        out = LocalBackend().download(str(self.src), dest)
+        self.assertEqual(Path(out).read_text(), "payload")
+        self.assertEqual(Path(out).parent, dest)
+
+    def test_exists(self):
+        self.assertTrue(LocalBackend().exists(str(self.src)))
+        self.assertFalse(LocalBackend().exists(str(self.d / "nope")))
+
+    def test_upload_copies_to_target(self):
+        target = self.d / "out" / "dest.bin"
+        LocalBackend().upload(self.src, str(target))
+        self.assertEqual(target.read_text(), "payload")
+
+
+class _FakeS3Client:
+    """Records boto3-style calls; simulates a bucket dict."""
+    def __init__(self, objects=None):
+        self.objects = dict(objects or {})
+        self.uploaded = []
+
+    def upload_file(self, Filename, Bucket, Key):
+        self.objects[(Bucket, Key)] = Path(Filename).read_bytes()
+        self.uploaded.append((Bucket, Key))
+
+    def download_file(self, Bucket, Key, Filename):
+        Path(Filename).write_bytes(self.objects[(Bucket, Key)])
+
+    def head_object(self, Bucket, Key):
+        if (Bucket, Key) not in self.objects:
+            raise KeyError((Bucket, Key))
+        return {"ContentLength": len(self.objects[(Bucket, Key)])}
+
+
+class TestS3Backend(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_upload_then_download_roundtrip(self):
+        src = self.d / "a.bin"; src.write_text("weights")
+        client = _FakeS3Client()
+        be = S3Backend(client=client)
+        be.upload(src, "s3://bucket/models/a.bin")
+        self.assertIn(("bucket", "models/a.bin"), client.objects)
+        dest = self.d / "cache"; dest.mkdir()
+        out = be.download("s3://bucket/models/a.bin", dest)
+        self.assertEqual(Path(out).read_text(), "weights")
+        self.assertEqual(Path(out).parent, dest)
+
+    def test_exists(self):
+        client = _FakeS3Client({("bucket", "k.bin"): b"x"})
+        be = S3Backend(client=client)
+        self.assertTrue(be.exists("s3://bucket/k.bin"))
+        self.assertFalse(be.exists("s3://bucket/missing"))
+
+    def test_missing_boto3_raises_clear_error(self):
+        # No client injected and boto3 unavailable -> actionable error.
+        be = S3Backend(client=None, _import_client=lambda: (_ for _ in ()).throw(ImportError()))
+        with self.assertRaises(RuntimeError) as ctx:
+            be.exists("s3://bucket/k")
+        self.assertIn("boto3", str(ctx.exception))
+
+
+class _FakeHF:
+    """Records huggingface_hub-style calls."""
+    def __init__(self, files=None):
+        self.files = dict(files or {})  # (repo_id, path) -> bytes
+        self.uploaded = []
+
+    def hf_hub_download(self, repo_id, filename, local_dir=None):
+        data = self.files[(repo_id, filename)]
+        out = Path(local_dir) / Path(filename).name
+        out.write_bytes(data)
+        return str(out)
+
+    def upload_file(self, path_or_fileobj, path_in_repo, repo_id):
+        self.files[(repo_id, path_in_repo)] = Path(path_or_fileobj).read_bytes()
+        self.uploaded.append((repo_id, path_in_repo))
+
+    def file_exists(self, repo_id, filename):
+        return (repo_id, filename) in self.files
+
+
+class TestHFBackend(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_upload_then_download_roundtrip(self):
+        src = self.d / "a.bin"; src.write_text("adapter")
+        client = _FakeHF()
+        be = HFBackend(client=client)
+        be.upload(src, "hf://org/model/a.bin")
+        self.assertIn(("org/model", "a.bin"), client.files)
+        dest = self.d / "cache"; dest.mkdir()
+        out = be.download("hf://org/model/a.bin", dest)
+        self.assertEqual(Path(out).read_text(), "adapter")
+
+    def test_exists(self):
+        client = _FakeHF({("org/model", "a.bin"): b"x"})
+        be = HFBackend(client=client)
+        self.assertTrue(be.exists("hf://org/model/a.bin"))
+        self.assertFalse(be.exists("hf://org/model/missing"))
+
+    def test_missing_dep_raises_clear_error(self):
+        be = HFBackend(client=None, _import_client=lambda: (_ for _ in ()).throw(ImportError()))
+        with self.assertRaises(RuntimeError) as ctx:
+            be.exists("hf://org/model/a.bin")
+        self.assertIn("huggingface_hub", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_asset_cli.py
+++ b/tests/unit/test_asset_cli.py
@@ -11,6 +11,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from unittest import mock
+
 from evo.assets import assets_path, load_registry
 from evo.cli import (
     cmd_asset_get,
@@ -32,9 +34,27 @@ def _init_git_repo(root: Path) -> None:
     subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
 
 
-def _put_args(path, name, kind, exp=None, tag=None, copy=False):
+def _put_args(path, name, kind, exp=None, tag=None, copy=False, backend=None):
     return argparse.Namespace(path=str(path), name=name, kind=kind, exp=exp,
-                              tag=tag or [], copy=copy)
+                              tag=tag or [], copy=copy, backend=backend)
+
+
+class _FakeRemoteBackend:
+    """In-memory stand-in for S3/HF: upload stores bytes by uri, download
+    writes them into dest_dir under the uri's basename."""
+    _store: dict = {}
+
+    def upload(self, local, uri):
+        type(self)._store[uri] = Path(local).read_bytes()
+
+    def download(self, uri, dest_dir):
+        Path(dest_dir).mkdir(parents=True, exist_ok=True)
+        dest = Path(dest_dir) / uri.rstrip("/").split("/")[-1]
+        dest.write_bytes(type(self)._store[uri])
+        return dest
+
+    def exists(self, uri):
+        return uri in type(self)._store
 
 
 class TestAssetCli(unittest.TestCase):
@@ -142,6 +162,36 @@ class TestAssetCli(unittest.TestCase):
     def test_registry_file_location(self):
         cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
         self.assertTrue(assets_path(self.root).exists())
+
+    # --- storage backends (#55 follow-up) -------------------------------
+
+    def test_put_backend_uploads_and_records_uri(self):
+        _FakeRemoteBackend._store = {}
+        with mock.patch("evo.asset_backends.backend_for_uri",
+                        return_value=_FakeRemoteBackend()):
+            cmd_asset_put(_put_args(self.asset_file, "remote-adapter", "checkpoint",
+                                    backend="s3://bucket/models/remote-adapter.bin"))
+        entry = load_registry(self.root)["assets"]["remote-adapter"]
+        self.assertEqual(entry["backend"], "s3")
+        self.assertEqual(entry["uri"], "s3://bucket/models/remote-adapter.bin")
+        self.assertIn("s3://bucket/models/remote-adapter.bin", _FakeRemoteBackend._store)
+
+    def test_get_remote_downloads_to_cache(self):
+        _FakeRemoteBackend._store = {}
+        with mock.patch("evo.asset_backends.backend_for_uri",
+                        return_value=_FakeRemoteBackend()):
+            cmd_asset_put(_put_args(self.asset_file, "remote-adapter", "checkpoint",
+                                    backend="s3://bucket/models/remote-adapter.bin"))
+            out = self._capture(cmd_asset_get, argparse.Namespace(name="remote-adapter"))
+        # get returns a LOCAL cache path whose contents match the uploaded file.
+        self.assertTrue(Path(out).exists())
+        self.assertEqual(Path(out).read_text(), "weights")
+        self.assertIn("_cache", Path(out).parts)
+
+    def test_local_put_records_local_backend(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        entry = load_registry(self.root)["assets"]["adapter"]
+        self.assertEqual(entry.get("backend", "local"), "local")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_asset_cli.py
+++ b/tests/unit/test_asset_cli.py
@@ -1,0 +1,126 @@
+"""`evo asset` CLI round-trip against a temp workspace (#55)."""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from evo.assets import assets_path, load_registry
+from evo.cli import (
+    cmd_asset_get,
+    cmd_asset_list,
+    cmd_asset_put,
+    cmd_asset_rm,
+    cmd_asset_use,
+)
+from evo.core import init_workspace
+
+
+def _init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@evo"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=root, check=True)
+    (root / "README.md").write_text("x\n")
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+
+
+def _put_args(path, name, kind, exp=None, tag=None, copy=False):
+    return argparse.Namespace(path=str(path), name=name, kind=kind, exp=exp,
+                              tag=tag or [], copy=copy)
+
+
+class TestAssetCli(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        _init_git_repo(self.root)
+        init_workspace(self.root, target="t.py", benchmark="python bench.py",
+                       metric="max", gate=None)
+        # A file to register as an asset.
+        self.asset_file = self.root / "adapter.bin"
+        self.asset_file.write_text("weights")
+        self._old_cwd = Path.cwd()
+        os.chdir(self.root)
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        self._tmp.cleanup()
+
+    def _capture(self, fn, args) -> str:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            fn(args)
+        return buf.getvalue().strip()
+
+    def test_put_registers_asset(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint",
+                                exp="exp_0001", tag=["epoch=2"]))
+        reg = load_registry(self.root)
+        entry = reg["assets"]["adapter"]
+        self.assertEqual(entry["kind"], "checkpoint")
+        self.assertEqual(entry["produced_by"], "exp_0001")
+        self.assertEqual(entry["tags"], {"epoch": "2"})
+        self.assertEqual(Path(entry["path"]).read_text(), "weights")
+
+    def test_put_missing_path_errors(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.root / "nope.bin", "x", "model"))
+
+    def test_put_duplicate_name_errors(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "adapter", "model"))
+
+    def test_get_prints_path(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        out = self._capture(cmd_asset_get, argparse.Namespace(name="adapter"))
+        self.assertEqual(out, str(self.asset_file))
+
+    def test_get_unknown_raises(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_get(argparse.Namespace(name="ghost"))
+
+    def test_put_copy_materializes_under_assets_dir(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint", copy=True))
+        entry = load_registry(self.root)["assets"]["adapter"]
+        self.assertTrue(entry["copied"])
+        self.assertIn("assets", Path(entry["path"]).parts)
+        self.assertEqual(Path(entry["path"]).read_text(), "weights")
+
+    def test_list_filters_by_tag(self):
+        cmd_asset_put(_put_args(self.asset_file, "a", "dataset", tag=["held-out=true"]))
+        cmd_asset_put(_put_args(self.asset_file, "b", "dataset"))
+        out = self._capture(cmd_asset_list, argparse.Namespace(
+            kind=None, tag=["held-out=true"], produced_by=None, consumed_by=None, json=True))
+        names = [e["name"] for e in json.loads(out)]
+        self.assertEqual(names, ["a"])
+
+    def test_use_records_consumption(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        cmd_asset_use(argparse.Namespace(name="adapter", exp="exp_0002"))
+        self.assertEqual(
+            load_registry(self.root)["assets"]["adapter"]["consumed_by"], ["exp_0002"])
+
+    def test_rm_refuses_when_consumed(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        cmd_asset_use(argparse.Namespace(name="adapter", exp="exp_0002"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_rm(argparse.Namespace(name="adapter", force=False))
+        cmd_asset_rm(argparse.Namespace(name="adapter", force=True))
+        self.assertNotIn("adapter", load_registry(self.root)["assets"])
+
+    def test_registry_file_location(self):
+        cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
+        self.assertTrue(assets_path(self.root).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_asset_cli.py
+++ b/tests/unit/test_asset_cli.py
@@ -117,6 +117,28 @@ class TestAssetCli(unittest.TestCase):
         cmd_asset_rm(argparse.Namespace(name="adapter", force=True))
         self.assertNotIn("adapter", load_registry(self.root)["assets"])
 
+    def test_put_normalizes_whitespace_name(self):
+        # A padded handle must register under the trimmed name and be reachable
+        # both by the trimmed name and by the padded string the user typed.
+        cmd_asset_put(_put_args(self.asset_file, "  spaced  ", "checkpoint"))
+        entry = load_registry(self.root)["assets"]["spaced"]
+        self.assertEqual(entry["name"], "spaced")
+        self.assertEqual(
+            self._capture(cmd_asset_get, argparse.Namespace(name="spaced")),
+            str(self.asset_file))
+        self.assertEqual(
+            self._capture(cmd_asset_get, argparse.Namespace(name="  spaced  ")),
+            str(self.asset_file))
+
+    def test_put_whitespace_name_duplicate_detected(self):
+        cmd_asset_put(_put_args(self.asset_file, "spaced", "checkpoint"))
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "  spaced  ", "model"))
+
+    def test_put_blank_name_rejected(self):
+        with self.assertRaises(RuntimeError):
+            cmd_asset_put(_put_args(self.asset_file, "   ", "model"))
+
     def test_registry_file_location(self):
         cmd_asset_put(_put_args(self.asset_file, "adapter", "checkpoint"))
         self.assertTrue(assets_path(self.root).exists())

--- a/tests/unit/test_asset_registry.py
+++ b/tests/unit/test_asset_registry.py
@@ -120,6 +120,17 @@ class TestPureRegistry(unittest.TestCase):
         registry_put(reg, self._entry("base-model", consumed_by=["exp_0009"]))
         self.assertEqual(asset_env_for_exp(reg, "exp_0002"), {})
 
+    def test_asset_env_for_exp_remote_injects_uri(self):
+        # Remote assets have no local path yet; expose the uri so the recipe
+        # can `evo asset get` it.
+        reg = empty_registry()
+        entry = self._entry("model", path=None, consumed_by=["exp_0002"])
+        entry["uri"] = "s3://b/model.bin"
+        entry["backend"] = "s3"
+        registry_put(reg, entry)
+        self.assertEqual(asset_env_for_exp(reg, "exp_0002"),
+                         {"EVO_ASSET_MODEL": "s3://b/model.bin"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_asset_registry.py
+++ b/tests/unit/test_asset_registry.py
@@ -1,0 +1,125 @@
+"""Tests for the workspace asset registry (#55, local-first).
+
+Split in two: the pure registry logic (no I/O) and the `evo asset` CLI
+round-trip against a temp workspace.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from evo.assets import (
+    asset_env_for_exp,
+    asset_env_var,
+    empty_registry,
+    parse_tag,
+    registry_filter,
+    registry_put,
+    registry_record_use,
+    registry_remove,
+)
+
+
+class TestPureRegistry(unittest.TestCase):
+    def _entry(self, name, **kw):
+        base = {
+            "name": name, "kind": kw.get("kind", "model"),
+            "path": kw.get("path", f"/data/{name}"), "tags": kw.get("tags", {}),
+            "produced_by": kw.get("produced_by"), "consumed_by": kw.get("consumed_by", []),
+            "copied": kw.get("copied", False), "created_at": "2026-08-27T00:00:00Z",
+        }
+        return base
+
+    def test_put_then_present(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model"))
+        self.assertIn("base-model", reg["assets"])
+
+    def test_put_rejects_empty_name(self):
+        with self.assertRaises(ValueError):
+            registry_put(empty_registry(), self._entry(""))
+
+    def test_put_rejects_empty_kind(self):
+        with self.assertRaises(ValueError):
+            registry_put(empty_registry(), self._entry("m", kind=""))
+
+    def test_filter_by_kind(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("m1", kind="model"))
+        registry_put(reg, self._entry("d1", kind="dataset"))
+        names = [e["name"] for e in registry_filter(reg, kind="dataset")]
+        self.assertEqual(names, ["d1"])
+
+    def test_filter_by_tags_is_and_match(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", tags={"verifier": "exact", "epoch": "2"}))
+        registry_put(reg, self._entry("b", tags={"verifier": "exact"}))
+        names = [e["name"] for e in registry_filter(reg, tags={"verifier": "exact", "epoch": "2"})]
+        self.assertEqual(names, ["a"])
+
+    def test_filter_by_produced_and_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", produced_by="exp_0001"))
+        registry_put(reg, self._entry("b", consumed_by=["exp_0002"]))
+        self.assertEqual([e["name"] for e in registry_filter(reg, produced_by="exp_0001")], ["a"])
+        self.assertEqual([e["name"] for e in registry_filter(reg, consumed_by="exp_0002")], ["b"])
+
+    def test_record_use_appends_once(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a"))
+        registry_record_use(reg, "a", "exp_0002")
+        registry_record_use(reg, "a", "exp_0002")  # idempotent
+        self.assertEqual(reg["assets"]["a"]["consumed_by"], ["exp_0002"])
+
+    def test_record_use_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            registry_record_use(empty_registry(), "nope", "exp_0002")
+
+    def test_remove_refuses_when_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", consumed_by=["exp_0002"]))
+        with self.assertRaises(RuntimeError):
+            registry_remove(reg, "a")
+
+    def test_remove_force_when_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("a", consumed_by=["exp_0002"]))
+        registry_remove(reg, "a", force=True)
+        self.assertNotIn("a", reg["assets"])
+
+    def test_remove_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            registry_remove(empty_registry(), "nope")
+
+    def test_asset_env_var(self):
+        self.assertEqual(asset_env_var("base-model"), "EVO_ASSET_BASE_MODEL")
+        self.assertEqual(asset_env_var("numina.cot 5k"), "EVO_ASSET_NUMINA_COT_5K")
+
+    def test_parse_tag(self):
+        self.assertEqual(parse_tag("epoch=2"), ("epoch", "2"))
+        self.assertEqual(parse_tag("uri=s3://a/b=c"), ("uri", "s3://a/b=c"))
+
+    def test_parse_tag_rejects_missing_eq(self):
+        with self.assertRaises(ValueError):
+            parse_tag("noequals")
+
+    def test_asset_env_for_exp_injects_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model", path="/m", consumed_by=["exp_0002"]))
+        registry_put(reg, self._entry("other", path="/o", consumed_by=["exp_0009"]))
+        env = asset_env_for_exp(reg, "exp_0002")
+        self.assertEqual(env, {"EVO_ASSET_BASE_MODEL": "/m"})
+
+    def test_asset_env_for_exp_empty_when_none_consumed(self):
+        reg = empty_registry()
+        registry_put(reg, self._entry("base-model", consumed_by=["exp_0009"]))
+        self.assertEqual(asset_env_for_exp(reg, "exp_0002"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> ⚠️ **Stacked on #109** (asset registry). This branch builds on `feat/issue-55-asset-registry`, so **this PR's diff currently includes #109's commits**. Opened as a **draft** — please review/merge #109 first; I'll then rebase onto `main` for a clean, focused diff and mark this ready. The incremental change here is just `asset_backends.py` + registry integration (~140 lines).

## What & why

Follow-up to #109. The local asset registry stores a local `path`; this adds **pluggable storage backends** so an asset can live in **S3** or the **HF Hub** and resolve to a local path on demand — the scope deferred in #109.

## Design

- **New `evo/asset_backends.py`** — a scheme-dispatched `StorageBackend` (`upload`/`download`/`exists`):
  - `LocalBackend` — dependency-free reference impl.
  - `S3Backend` (boto3) / `HFBackend` (huggingface_hub) — SDKs imported **lazily** (optional deps; a missing dep raises an actionable `pip install …` error) and each accepts an **injected client**, so their logic is unit-tested with a fake — **no network, no credentials**.
  - pure `parse_s3_uri` / `parse_hf_uri` helpers.
- **Registry integration** — entries gain `uri` + `backend`; local assets keep `path` (`backend: "local"`), no migration needed.
  - `evo asset put <path> --name … --backend s3://bucket/key` (or `hf://owner/name/path`) uploads and records the uri.
  - `evo asset get`/`use` download to a per-asset local cache (`workspace_path/assets/_cache/<name>/`) and return that path (reused if already cached).
  - Remote assets expose their **uri** via `EVO_ASSET_<NAME>` (the recipe resolves it with `evo asset get`), so the per-attempt env builder stays network-free.

## Testing

- 18 backend unit tests: uri parsing (valid + malformed), scheme dispatch, `LocalBackend` for real, `S3Backend`/`HFBackend` round-trips via **injected fake clients**, and missing-dependency → clear error.
- CLI round-trip: `put --backend` → `get` → cached local path (fake backend injected via the seam).
- Verified through the **real CLI**: the local flow is unchanged, `list --json` surfaces `backend`/`uri`, and `put --backend s3://` emits the clean `boto3 is required; pip install boto3` guard (boto3/hf are optional and not installed here).
- Full unit suite green (849 passed) minus the pre-existing Rust hook-binary failures unrelated to this change.

### Not covered locally

Real S3/HF **network** round-trips (need credentials) — a manual/CI concern, same caveat I flagged on #108's remote path.

## Out of scope

Credential management (relies on ambient AWS/HF auth), multipart/retry tuning, content-addressed dedup, cache eviction/gc.